### PR TITLE
[FE 19] feat: add landing page navbar and ride estimation panel

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,14 +10,14 @@ export const routes: Routes = [
     path: 'forgot-password',
     loadComponent: () =>
       import('./features/auth/forgot-password/forgot-password.component').then(
-        (m) => m.ForgotPasswordComponent
+        (m) => m.ForgotPasswordComponent,
       ),
   },
   {
     path: 'reset-password/:token',
     loadComponent: () =>
       import('./features/auth/reset-password/reset-password.component').then(
-        (m) => m.ResetPasswordComponent
+        (m) => m.ResetPasswordComponent,
       ),
   },
   {
@@ -30,24 +30,31 @@ export const routes: Routes = [
     path: 'profile',
     loadComponent: () =>
       import('./features/profile/profile-page/profile-page.component').then(
-        (m) => m.ProfilePageComponent
+        (m) => m.ProfilePageComponent,
       ),
   },
   {
     path: 'driver-history',
     loadComponent: () =>
       import('./features/driver-history/driver-history.component').then(
-        (m) => m.DriverHistoryComponent
+        (m) => m.DriverHistoryComponent,
+      ),
+  },
+  {
+    path: 'landing',
+    loadComponent: () =>
+      import('./features/landing/landing-page/landing-page.component').then(
+        (m) => m.LandingPageComponent,
       ),
   },
 
   {
     path: '',
-    redirectTo: 'login',
+    redirectTo: 'landing',
     pathMatch: 'full',
   },
   {
     path: '**',
-    redirectTo: 'login',
+    redirectTo: 'landing',
   },
 ];

--- a/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.html
+++ b/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.html
@@ -1,0 +1,167 @@
+<div class="side-panel" [class.open]="isOpen">
+  <!-- Retract tab button -->
+  <button class="btn-retract" (click)="closePanel()" title="Close panel">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="9 18 15 12 9 6" />
+    </svg>
+  </button>
+
+  <div class="panel-header">
+    <div class="panel-header-content">
+      <h2>Estimate your ride</h2>
+      <p>Enter locations to see price & time</p>
+    </div>
+    <button class="btn-close-panel" (click)="closePanel()">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+      </svg>
+    </button>
+  </div>
+
+  <div class="panel-content">
+    <!-- Location Inputs -->
+    <div class="location-inputs">
+      <div class="connector-line"></div>
+
+      <div class="location-input-group">
+        <div class="location-marker-icon start">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <circle cx="12" cy="12" r="8" />
+          </svg>
+        </div>
+        <div class="location-input-wrapper">
+          <label class="location-label">Pickup location</label>
+          <input
+            type="text"
+            class="location-input"
+            placeholder="Enter pickup address..."
+            [value]="pickupLocation()"
+            (input)="updatePickup($any($event.target).value)"
+          />
+        </div>
+      </div>
+
+      <div class="location-input-group">
+        <div class="location-marker-icon end">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+            <circle cx="12" cy="10" r="3" />
+          </svg>
+        </div>
+        <div class="location-input-wrapper">
+          <label class="location-label">Destination</label>
+          <input
+            type="text"
+            class="location-input"
+            placeholder="Enter destination address..."
+            [value]="destinationLocation()"
+            (input)="updateDestination($any($event.target).value)"
+          />
+        </div>
+      </div>
+
+      <button class="btn-calculate" (click)="calculateEstimate()">Calculate estimate</button>
+    </div>
+
+    <!-- Estimate Results -->
+    <div class="estimate-results" [class.show]="showResults()">
+      <div class="estimate-header">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        <span>Route calculated</span>
+      </div>
+      <div class="estimate-grid">
+        <div class="estimate-item">
+          <div class="estimate-value">~{{ estimate.time }} <span>min</span></div>
+          <div class="estimate-label">Est. Time</div>
+        </div>
+        <div class="estimate-item">
+          <div class="estimate-value">~{{ estimate.price }} <span>RSD</span></div>
+          <div class="estimate-label">Est. Price</div>
+        </div>
+        <div class="estimate-distance">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="18" x2="18" y2="18" />
+          </svg>
+          <span>Distance: {{ estimate.distance }} km</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- CTA Section -->
+    <div class="cta-section">
+      <h3 class="cta-title">Ready to book this ride?</h3>
+      <p class="cta-description">
+        Create a free account to book rides, track your driver in real-time, and enjoy seamless
+        travel.
+      </p>
+      <a routerLink="/register" class="btn-cta">Sign up to book</a>
+    </div>
+
+    <div class="guest-note">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="16" x2="12" y2="12" />
+        <line x1="12" y1="8" x2="12.01" y2="8" />
+      </svg>
+      <p>
+        This is an estimate only. Actual price may vary based on traffic, route changes, and
+        selected vehicle type.
+      </p>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.html
+++ b/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.html
@@ -90,7 +90,13 @@
         </div>
       </div>
 
-      <button class="btn-calculate" (click)="calculateEstimate()">Calculate estimate</button>
+      <button
+        class="btn-calculate"
+        (click)="calculateEstimate()"
+        [disabled]="!pickupLocation() || !destinationLocation()"
+      >
+        Calculate estimate
+      </button>
     </div>
 
     <!-- Estimate Results -->

--- a/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.scss
+++ b/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.scss
@@ -1,0 +1,376 @@
+.side-panel {
+  width: 440px;
+  background: var(--white);
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  position: absolute;
+  top: 73px;
+  right: 0;
+  height: calc(100% - 73px);
+  z-index: 900;
+  transform: translateX(100%);
+  transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.1);
+
+  &.open {
+    transform: translateX(0);
+  }
+}
+
+.btn-retract {
+  position: absolute;
+  left: -44px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 80px;
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-right: none;
+  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: -4px 0 12px rgba(0, 0, 0, 0.08);
+  transition: all 0.2s;
+  opacity: 0;
+  pointer-events: none;
+
+  .open & {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  &:hover {
+    background: var(--bg-cream);
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--text-medium);
+  }
+}
+
+.panel-header {
+  padding: 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.panel-header-content {
+  h2 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--text-dark);
+    margin-bottom: 4px;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--text-light);
+  }
+}
+
+.btn-close-panel {
+  width: 40px;
+  height: 40px;
+  background: var(--bg-cream);
+  border: none;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: var(--border);
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--text-medium);
+  }
+}
+
+.panel-content {
+  flex: 1;
+  padding: 24px;
+  overflow-y: auto;
+}
+
+// Location Inputs
+.location-inputs {
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.location-input-group {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+
+.location-marker-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &.start {
+    background: rgba(91, 76, 219, 0.1);
+
+    svg {
+      color: var(--primary);
+    }
+  }
+
+  &.end {
+    background: rgba(255, 127, 92, 0.1);
+
+    svg {
+      color: var(--accent);
+    }
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.location-input-wrapper {
+  flex: 1;
+}
+
+.location-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.location-input {
+  width: 100%;
+  padding: 14px 16px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  color: var(--text-dark);
+  background: var(--bg-cream);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: all 0.2s;
+
+  &::placeholder {
+    color: var(--text-light);
+  }
+
+  &:focus {
+    border-color: var(--primary);
+    background: var(--white);
+    box-shadow: 0 0 0 4px rgba(91, 76, 219, 0.1);
+  }
+}
+
+.connector-line {
+  position: absolute;
+  left: 19px;
+  top: 48px;
+  height: 54px;
+  width: 2px;
+  background: linear-gradient(180deg, var(--primary) 0%, var(--accent) 100%);
+}
+
+.btn-calculate {
+  width: 100%;
+  padding: 16px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: var(--shadow-md);
+  margin-top: 8px;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-lg);
+  }
+}
+
+// Estimate Results
+.estimate-results {
+  background: var(--bg-warm);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  margin-top: 24px;
+  display: none;
+
+  &.show {
+    display: block;
+  }
+}
+
+.estimate-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--success);
+  }
+
+  span {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--success);
+  }
+}
+
+.estimate-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.estimate-item {
+  text-align: center;
+  padding: 16px;
+  background: var(--white);
+  border-radius: var(--radius-sm);
+}
+
+.estimate-value {
+  font-family: 'Outfit', sans-serif;
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text-dark);
+  margin-bottom: 4px;
+
+  span {
+    font-size: 14px;
+    font-weight: 500;
+  }
+}
+
+.estimate-label {
+  font-size: 12px;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.estimate-distance {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  background: var(--white);
+  border-radius: var(--radius-sm);
+
+  svg {
+    width: 18px;
+    height: 18px;
+    color: var(--primary);
+  }
+
+  span {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-medium);
+  }
+}
+
+// CTA Section
+.cta-section {
+  background: linear-gradient(135deg, rgba(91, 76, 219, 0.08) 0%, rgba(255, 127, 92, 0.08) 100%);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  text-align: center;
+  margin-top: 24px;
+}
+
+.cta-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+}
+
+.cta-description {
+  font-size: 14px;
+  color: var(--text-light);
+  margin-bottom: 20px;
+  line-height: 1.5;
+}
+
+.btn-cta {
+  display: inline-block;
+  padding: 14px 28px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--accent) 0%, #e5694a 100%);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.3s;
+  box-shadow: 0 4px 16px rgba(255, 127, 92, 0.3);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 127, 92, 0.4);
+  }
+}
+
+.guest-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 20px;
+  padding: 14px;
+  background: var(--bg-cream);
+  border-radius: var(--radius-sm);
+  text-align: left;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    color: var(--text-light);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  p {
+    font-size: 13px;
+    color: var(--text-light);
+    line-height: 1.5;
+  }
+}

--- a/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.ts
+++ b/frontend/src/app/features/landing/components/ride-estimate-panel/ride-estimate-panel.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input, Output, EventEmitter, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+
+export interface RideEstimate {
+  time: number; // minutes
+  price: number; // RSD
+  distance: number; // km
+}
+
+@Component({
+  selector: 'app-ride-estimate-panel',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './ride-estimate-panel.component.html',
+  styleUrl: './ride-estimate-panel.component.scss',
+})
+export class RideEstimatePanelComponent {
+  @Input() isOpen = false;
+  @Output() panelClosed = new EventEmitter<void>();
+
+  pickupLocation = signal('');
+  destinationLocation = signal('');
+  showResults = signal(false);
+
+  estimate: RideEstimate = {
+    time: 12,
+    price: 450,
+    distance: 3.2,
+  };
+
+  closePanel(): void {
+    this.panelClosed.emit();
+  }
+
+  calculateEstimate(): void {
+    // Mock calculation - in real app this would call a service
+    if (this.pickupLocation() && this.destinationLocation()) {
+      // Simulate random estimate
+      this.estimate = {
+        time: Math.floor(Math.random() * 20) + 5,
+        price: Math.floor(Math.random() * 500) + 200,
+        distance: Math.round((Math.random() * 10 + 1) * 10) / 10,
+      };
+      this.showResults.set(true);
+    }
+  }
+
+  updatePickup(value: string): void {
+    this.pickupLocation.set(value);
+  }
+
+  updateDestination(value: string): void {
+    this.destinationLocation.set(value);
+  }
+}

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.html
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.html
@@ -1,10 +1,10 @@
 <div class="app-container">
   <!-- Header -->
   <header class="header">
-    <a routerLink="/" class="logo">
+    <div class="logo">
       <img src="images/logo/logo-blue-v2.svg" alt="Drumigo Logo" class="logo-img" />
       <span class="logo-text">Drumigo</span>
-    </a>
+    </div>
     <div class="header-actions">
       <a routerLink="/login" class="btn-header btn-header-secondary">Sign in</a>
       <a routerLink="/register" class="btn-header btn-header-primary">Sign up</a>

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.html
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.html
@@ -13,7 +13,10 @@
 
   <!-- Map Section (Placeholder) -->
   <div class="map-section">
-    <div class="map-placeholder">
+    <div
+      class="map-placeholder"
+      style="min-height: 280px; display: flex; align-items: center; justify-content: center; background-color: #f3f4f6; border-radius: 12px; border: 1px dashed #cbd5f5; color: #6b7280; text-align: center;"
+    >
       <p>Map WIP</p>
     </div>
 

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.html
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.html
@@ -1,0 +1,44 @@
+<div class="app-container" [class.panel-open]="isPanelOpen()">
+  <!-- Header -->
+  <header class="header">
+    <a routerLink="/" class="logo">
+      <img src="images/logo/logo-blue-v2.svg" alt="Drumigo Logo" class="logo-img" />
+      <span class="logo-text">Drumigo</span>
+    </a>
+    <div class="header-actions">
+      <a routerLink="/login" class="btn-header btn-header-secondary">Sign in</a>
+      <a routerLink="/register" class="btn-header btn-header-primary">Sign up</a>
+    </div>
+  </header>
+
+  <!-- Map Section (Placeholder) -->
+  <div class="map-section">
+    <div class="map-placeholder">
+      <p>Map WIP</p>
+    </div>
+
+    <!-- Floating Estimate Button -->
+    <div class="estimate-cta">
+      <button class="btn-estimate" (click)="openPanel()">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 10" />
+        </svg>
+        Estimate your ride
+      </button>
+    </div>
+  </div>
+
+  <!-- Side Panel -->
+  <app-ride-estimate-panel
+    [isOpen]="isPanelOpen()"
+    (panelClosed)="closePanel()"
+  ></app-ride-estimate-panel>
+</div>

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.html
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.html
@@ -1,4 +1,4 @@
-<div class="app-container" [class.panel-open]="isPanelOpen()">
+<div class="app-container">
   <!-- Header -->
   <header class="header">
     <a routerLink="/" class="logo">

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.scss
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.scss
@@ -1,0 +1,128 @@
+:host {
+  display: block;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.app-container {
+  display: flex;
+  height: 100vh;
+  position: relative;
+}
+
+// Header
+.header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  background: var(--white);
+  border-bottom: 1px solid var(--border);
+  z-index: 1000;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.logo-img {
+  height: 40px;
+  width: auto;
+}
+
+.logo-text {
+  font-family: 'Outfit', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--primary);
+  letter-spacing: -0.5px;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn-header {
+  padding: 12px 24px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.2s;
+
+  &-secondary {
+    color: var(--text-medium);
+    background: var(--white);
+    border: 2px solid var(--border);
+
+    &:hover {
+      border-color: var(--primary);
+      color: var(--primary);
+    }
+  }
+
+  &-primary {
+    color: var(--white);
+    background: var(--primary);
+    border: 2px solid var(--primary);
+
+    &:hover {
+      background: var(--primary-dark);
+      border-color: var(--primary-dark);
+    }
+  }
+}
+
+// Map Section
+.map-section {
+  flex: 1;
+  position: relative;
+  padding-top: 73px; // Header height
+}
+
+// Floating Estimate Button
+.estimate-cta {
+  position: absolute;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 500;
+}
+
+.btn-estimate {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 36px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  border: none;
+  border-radius: 60px;
+  cursor: pointer;
+  box-shadow: 0 8px 32px rgba(91, 76, 219, 0.35);
+  transition: all 0.3s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 40px rgba(91, 76, 219, 0.45);
+  }
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+}

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.ts
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.ts
@@ -1,0 +1,22 @@
+import { Component, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { RideEstimatePanelComponent } from '../components/ride-estimate-panel/ride-estimate-panel.component';
+
+@Component({
+  selector: 'app-landing-page',
+  standalone: true,
+  imports: [RouterLink, RideEstimatePanelComponent],
+  templateUrl: './landing-page.component.html',
+  styleUrl: './landing-page.component.scss',
+})
+export class LandingPageComponent {
+  isPanelOpen = signal(false);
+
+  openPanel(): void {
+    this.isPanelOpen.set(true);
+  }
+
+  closePanel(): void {
+    this.isPanelOpen.set(false);
+  }
+}


### PR DESCRIPTION
Closes FE 19

This pull request introduces a new "Landing" page to the frontend, featuring a ride estimate side panel and updates to routing and navigation. The changes include new UI components, styles, and logic for estimating rides, as well as updates to the app's default route and navigation flow.

**Landing Page Feature:**

* Added a new `LandingPageComponent` with a header, placeholder map section, floating "Estimate your ride" button, and integration of the ride estimate side panel. [[1]](diffhunk://#diff-b71b6edb0743593fec17a6a9c3057a8a547bd89b04a98b0ccd41f0e376648028R1-R44) [[2]](diffhunk://#diff-3797a728e6f6bfe8e8cc0d0c1a53482bd7a78cc665e4ca3296583853840fd868R1-R22)
* Implemented a ride estimate side panel (`RideEstimatePanelComponent`) that allows users to input pickup and destination locations, view a mock estimate, and see a call-to-action for registration. [[1]](diffhunk://#diff-6c244c3cb97dd734e973f7642ad35389035f27f7427620949e82f917364eb73fR1-R57) [[2]](diffhunk://#diff-1d00c1f925ee890872f1494d5c2db673d66ac741b10bdb710b5186cf67053e7bR1-R167)
* Created comprehensive SCSS styles for both the landing page and the ride estimate panel to deliver a modern, responsive UI. [[1]](diffhunk://#diff-d95cece0741fdc99a05dd48e10e36d02bebe2f8e88db6d9dfa55f3ee3b065c76R1-R128) [[2]](diffhunk://#diff-2bbdfd8ac36d95fe45034d1e494a60548d9c50005fc9bbbda9d2dce6cc807dbdR1-R376)

**Routing Updates:**

* Added a route for the new landing page and changed the default and fallback routes to redirect to `landing` instead of `login`, making the landing page the new entry point for the app.

These changes collectively provide a welcoming landing experience for users and encourage registration by showcasing the ride estimation feature upfront.