### PR TITLE
[1 SP][FE 29] Migrate frontend readme from npm to bun

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,12 +2,14 @@
 
 This project was generated using [Angular CLI](https://github.com/angular/angular-cli) version 21.1.0.
 
+This project uses [Bun](https://bun.sh/) as the package manager and runtime.
+
 ## Development server
 
 To start a local development server, run:
 
 ```bash
-ng serve
+bun start
 ```
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
@@ -17,13 +19,13 @@ Once the server is running, open your browser and navigate to `http://localhost:
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:
 
 ```bash
-ng generate component component-name
+bun run ng generate component component-name
 ```
 
 For a complete list of available schematics (such as `components`, `directives`, or `pipes`), run:
 
 ```bash
-ng generate --help
+bun run ng generate --help
 ```
 
 ## Building
@@ -31,7 +33,7 @@ ng generate --help
 To build the project run:
 
 ```bash
-ng build
+bun run build
 ```
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
@@ -41,7 +43,7 @@ This will compile your project and store the build artifacts in the `dist/` dire
 To execute unit tests with the [Vitest](https://vitest.dev/) test runner, use the following command:
 
 ```bash
-ng test
+bun test
 ```
 
 ## Running end-to-end tests


### PR DESCRIPTION
Closes #36 

This pull request updates the `frontend/README.md` to reflect the migration from Angular CLI commands to using Bun as the package manager and runtime. The documentation now provides instructions for running, building, and testing the project with Bun, ensuring consistency with the new toolchain.

Migration to Bun for development workflow:

* Added a note that the project uses [Bun](https://bun.sh/) as the package manager and runtime.
* Updated commands for starting the development server, generating components, listing schematics, and building the project to use `bun run` instead of Angular CLI directly. [[1]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543R5-R12) [[2]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L20-R36)
* Changed the unit test command to `bun test` to align with the Vitest test runner and Bun integration.