### PR TITLE
[FE 18] feat: add ride cancel component

### DIFF
--- a/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.component.ts
+++ b/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PassengerCancelComponent } from './passenger-cancel/passenger-cancel.component';
+import { DriverCancelComponent } from './driver-cancel/driver-cancel.component';
+import { CancelRideResult, RideSummaryForCancel } from '../../models/cancel-ride.model';
+
+export type CancelUserRole = 'passenger' | 'driver';
+
+@Component({
+  selector: 'app-cancel-ride',
+  standalone: true,
+  imports: [CommonModule, PassengerCancelComponent, DriverCancelComponent],
+  template: `
+    @if (userRole === 'passenger') {
+      <app-passenger-cancel [ride]="ride" (cancel)="onCancel($event)" (keepRide)="onKeepRide()" />
+    } @else {
+      <app-driver-cancel [ride]="ride" (cancel)="onCancel($event)" (keepRide)="onKeepRide()" />
+    }
+  `,
+})
+export class CancelRideComponent {
+  @Input() ride!: RideSummaryForCancel;
+  @Input() userRole: CancelUserRole = 'passenger';
+
+  @Output() cancel = new EventEmitter<CancelRideResult>();
+  @Output() keepRide = new EventEmitter<void>();
+
+  onCancel(result: CancelRideResult): void {
+    this.cancel.emit(result);
+  }
+
+  onKeepRide(): void {
+    this.keepRide.emit();
+  }
+}

--- a/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.styles.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.styles.scss
@@ -1,0 +1,540 @@
+// Custom scrollbar mixin
+@mixin custom-scrollbar {
+  // Firefox
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+
+  // Chrome/Safari/Edge
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
+    transition: background 0.2s;
+
+    &:hover {
+      background: var(--text-light);
+    }
+  }
+}
+
+// Overlay
+.cancel-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+  overflow-y: auto;
+  @include custom-scrollbar;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.cancel-dialog {
+  width: 100%;
+  max-width: 520px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp 0.3s ease-out;
+  @include custom-scrollbar;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Ride Summary Card
+.ride-summary {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.ride-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.ride-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--warning);
+  animation: pulse 2s infinite;
+
+  &.arriving {
+    background: var(--primary);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.status-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--warning);
+}
+
+.ride-id {
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+.ride-route {
+  display: flex;
+  align-items: stretch;
+  gap: 14px;
+}
+
+.route-markers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.marker {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &.start {
+    background: var(--primary);
+  }
+  &.end {
+    background: var(--accent);
+  }
+}
+
+.marker-line {
+  flex: 1;
+  width: 2px;
+  background: linear-gradient(180deg, var(--primary) 0%, var(--accent) 100%);
+  margin: 4px 0;
+}
+
+.route-details {
+  flex: 1;
+}
+
+.route-point {
+  padding: 8px 0;
+
+  &:first-child {
+    border-bottom: 1px dashed var(--border);
+  }
+}
+
+.route-label {
+  font-size: 12px;
+  color: var(--text-light);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.route-address {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-dark);
+}
+
+// Driver Info
+.driver-info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+.driver-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--white);
+  font-family: 'Outfit', sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+}
+
+.driver-details {
+  flex: 1;
+}
+
+.driver-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 2px;
+}
+
+.driver-car {
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+.driver-rating {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--bg-warm);
+  border-radius: 8px;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    color: var(--warning);
+    fill: var(--warning);
+  }
+
+  span {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-dark);
+  }
+}
+
+// Cancel Card
+.cancel-card {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  box-shadow: var(--shadow-md);
+}
+
+.cancel-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+
+  svg {
+    width: 28px;
+    height: 28px;
+  }
+}
+
+.cancel-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+}
+
+.cancel-description {
+  font-size: 15px;
+  color: var(--text-light);
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+// Time remaining indicator
+.time-remaining {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-warm);
+  border-radius: var(--radius-sm);
+  margin-bottom: 20px;
+
+  svg {
+    width: 18px;
+    height: 18px;
+    color: var(--primary);
+  }
+
+  span {
+    font-size: 14px;
+    color: var(--text-medium);
+  }
+
+  strong {
+    color: var(--primary);
+    font-weight: 600;
+  }
+}
+
+// Reason Selection
+.reason-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-medium);
+  margin-bottom: 12px;
+
+  .required {
+    color: var(--danger);
+  }
+}
+
+.reason-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.reason-option {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px;
+  background: var(--bg-cream);
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: var(--bg-warm);
+  }
+
+  &.selected {
+    border-color: var(--primary);
+    background: rgba(91, 76, 219, 0.04);
+
+    .reason-radio {
+      border-color: var(--primary);
+      background: var(--primary);
+    }
+
+    .reason-radio-inner {
+      opacity: 1;
+    }
+  }
+}
+
+.reason-radio {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.2s;
+}
+
+.reason-radio-inner {
+  width: 8px;
+  height: 8px;
+  background: var(--white);
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.reason-text {
+  font-size: 15px;
+  color: var(--text-dark);
+  flex: 1;
+}
+
+.requires-explanation {
+  font-size: 12px;
+  color: var(--text-light);
+  background: var(--bg-warm);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+// Explanation field
+.explanation-field {
+  margin-bottom: 24px;
+  animation: slideDown 0.2s ease-out;
+
+  textarea {
+    width: 100%;
+    padding: 16px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 15px;
+    color: var(--text-dark);
+    background: var(--bg-cream);
+    border: 2px solid var(--border);
+    border-radius: var(--radius-md);
+    resize: vertical;
+    min-height: 100px;
+    outline: none;
+    transition: all 0.2s;
+
+    &::placeholder {
+      color: var(--text-light);
+    }
+
+    &:focus {
+      border-color: var(--primary);
+      box-shadow: 0 0 0 4px rgba(91, 76, 219, 0.1);
+    }
+  }
+
+  .field-error {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--danger);
+  }
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Warning Notice
+.warning-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 24px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--text-medium);
+    line-height: 1.5;
+    margin: 0;
+  }
+}
+
+// Action Buttons
+.action-buttons {
+  display: flex;
+  gap: 12px;
+}
+
+.btn-secondary {
+  flex: 1;
+  padding: 16px 24px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-medium);
+  background: var(--bg-cream);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: var(--text-medium);
+  }
+}
+
+.btn-danger {
+  flex: 1;
+  padding: 16px 24px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--white);
+  background: var(--danger);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+
+  &:hover:not(:disabled) {
+    filter: brightness(0.9);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(239, 68, 68, 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+  }
+}
+
+// Responsive
+@media (max-width: 480px) {
+  .cancel-dialog {
+    max-width: 100%;
+  }
+
+  .cancel-card {
+    padding: 24px;
+  }
+
+  .action-buttons {
+    flex-direction: column;
+  }
+
+  .btn-secondary,
+  .btn-danger {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.styles.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/cancel-ride.styles.scss
@@ -1,10 +1,11 @@
+// Cancel Ride - Shared Base Styles
+// Only truly shared styles that both passenger and driver components use
+
 // Custom scrollbar mixin
 @mixin custom-scrollbar {
-  // Firefox
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 
-  // Chrome/Safari/Edge
   &::-webkit-scrollbar {
     width: 6px;
   }
@@ -17,7 +18,6 @@
   &::-webkit-scrollbar-thumb {
     background: var(--border);
     border-radius: 3px;
-    transition: background 0.2s;
 
     &:hover {
       background: var(--text-light);
@@ -25,7 +25,7 @@
   }
 }
 
-// Overlay
+// Overlay - shared by both
 .cancel-dialog-overlay {
   position: fixed;
   inset: 0;
@@ -50,15 +50,6 @@
   }
 }
 
-.cancel-dialog {
-  width: 100%;
-  max-width: 520px;
-  max-height: 90vh;
-  overflow-y: auto;
-  animation: slideUp 0.3s ease-out;
-  @include custom-scrollbar;
-}
-
 @keyframes slideUp {
   from {
     opacity: 0;
@@ -70,405 +61,7 @@
   }
 }
 
-// Ride Summary Card
-.ride-summary {
-  background: var(--white);
-  border-radius: var(--radius-lg);
-  padding: 24px;
-  margin-bottom: 20px;
-  box-shadow: var(--shadow-sm);
-}
-
-.ride-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 20px;
-}
-
-.ride-status {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--warning);
-  animation: pulse 2s infinite;
-
-  &.arriving {
-    background: var(--primary);
-  }
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-.status-text {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--warning);
-}
-
-.ride-id {
-  font-size: 13px;
-  color: var(--text-light);
-}
-
-.ride-route {
-  display: flex;
-  align-items: stretch;
-  gap: 14px;
-}
-
-.route-markers {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 4px 0;
-}
-
-.marker {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  flex-shrink: 0;
-
-  &.start {
-    background: var(--primary);
-  }
-  &.end {
-    background: var(--accent);
-  }
-}
-
-.marker-line {
-  flex: 1;
-  width: 2px;
-  background: linear-gradient(180deg, var(--primary) 0%, var(--accent) 100%);
-  margin: 4px 0;
-}
-
-.route-details {
-  flex: 1;
-}
-
-.route-point {
-  padding: 8px 0;
-
-  &:first-child {
-    border-bottom: 1px dashed var(--border);
-  }
-}
-
-.route-label {
-  font-size: 12px;
-  color: var(--text-light);
-  margin-bottom: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.route-address {
-  font-size: 15px;
-  font-weight: 500;
-  color: var(--text-dark);
-}
-
-// Driver Info
-.driver-info {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 1px solid var(--border);
-}
-
-.driver-avatar {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary) 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--white);
-  font-family: 'Outfit', sans-serif;
-  font-weight: 600;
-  font-size: 18px;
-}
-
-.driver-details {
-  flex: 1;
-}
-
-.driver-name {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-dark);
-  margin-bottom: 2px;
-}
-
-.driver-car {
-  font-size: 13px;
-  color: var(--text-light);
-}
-
-.driver-rating {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 10px;
-  background: var(--bg-warm);
-  border-radius: 8px;
-
-  svg {
-    width: 14px;
-    height: 14px;
-    color: var(--warning);
-    fill: var(--warning);
-  }
-
-  span {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-dark);
-  }
-}
-
-// Cancel Card
-.cancel-card {
-  background: var(--white);
-  border-radius: var(--radius-lg);
-  padding: 32px;
-  box-shadow: var(--shadow-md);
-}
-
-.cancel-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 24px;
-
-  svg {
-    width: 28px;
-    height: 28px;
-  }
-}
-
-.cancel-title {
-  font-family: 'Outfit', sans-serif;
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--text-dark);
-  margin-bottom: 8px;
-}
-
-.cancel-description {
-  font-size: 15px;
-  color: var(--text-light);
-  line-height: 1.6;
-  margin-bottom: 28px;
-}
-
-// Time remaining indicator
-.time-remaining {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px;
-  background: var(--bg-warm);
-  border-radius: var(--radius-sm);
-  margin-bottom: 20px;
-
-  svg {
-    width: 18px;
-    height: 18px;
-    color: var(--primary);
-  }
-
-  span {
-    font-size: 14px;
-    color: var(--text-medium);
-  }
-
-  strong {
-    color: var(--primary);
-    font-weight: 600;
-  }
-}
-
-// Reason Selection
-.reason-label {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-medium);
-  margin-bottom: 12px;
-
-  .required {
-    color: var(--danger);
-  }
-}
-
-.reason-options {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-bottom: 20px;
-}
-
-.reason-option {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 16px;
-  background: var(--bg-cream);
-  border: 2px solid transparent;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all 0.2s;
-
-  &:hover {
-    background: var(--bg-warm);
-  }
-
-  &.selected {
-    border-color: var(--primary);
-    background: rgba(91, 76, 219, 0.04);
-
-    .reason-radio {
-      border-color: var(--primary);
-      background: var(--primary);
-    }
-
-    .reason-radio-inner {
-      opacity: 1;
-    }
-  }
-}
-
-.reason-radio {
-  width: 22px;
-  height: 22px;
-  border: 2px solid var(--border);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: all 0.2s;
-}
-
-.reason-radio-inner {
-  width: 8px;
-  height: 8px;
-  background: var(--white);
-  border-radius: 50%;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-.reason-text {
-  font-size: 15px;
-  color: var(--text-dark);
-  flex: 1;
-}
-
-.requires-explanation {
-  font-size: 12px;
-  color: var(--text-light);
-  background: var(--bg-warm);
-  padding: 4px 8px;
-  border-radius: 4px;
-}
-
-// Explanation field
-.explanation-field {
-  margin-bottom: 24px;
-  animation: slideDown 0.2s ease-out;
-
-  textarea {
-    width: 100%;
-    padding: 16px;
-    font-family: 'DM Sans', sans-serif;
-    font-size: 15px;
-    color: var(--text-dark);
-    background: var(--bg-cream);
-    border: 2px solid var(--border);
-    border-radius: var(--radius-md);
-    resize: vertical;
-    min-height: 100px;
-    outline: none;
-    transition: all 0.2s;
-
-    &::placeholder {
-      color: var(--text-light);
-    }
-
-    &:focus {
-      border-color: var(--primary);
-      box-shadow: 0 0 0 4px rgba(91, 76, 219, 0.1);
-    }
-  }
-
-  .field-error {
-    margin-top: 8px;
-    font-size: 13px;
-    color: var(--danger);
-  }
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-// Warning Notice
-.warning-notice {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 16px;
-  border-radius: var(--radius-sm);
-  margin-bottom: 24px;
-
-  svg {
-    width: 20px;
-    height: 20px;
-    flex-shrink: 0;
-    margin-top: 1px;
-  }
-
-  p {
-    font-size: 14px;
-    color: var(--text-medium);
-    line-height: 1.5;
-    margin: 0;
-  }
-}
-
-// Action Buttons
+// Action Buttons - shared base
 .action-buttons {
   display: flex;
   gap: 12px;
@@ -476,7 +69,7 @@
 
 .btn-secondary {
   flex: 1;
-  padding: 16px 24px;
+  padding: 14px 20px;
   font-family: 'DM Sans', sans-serif;
   font-size: 15px;
   font-weight: 600;
@@ -494,7 +87,7 @@
 
 .btn-danger {
   flex: 1;
-  padding: 16px 24px;
+  padding: 14px 20px;
   font-family: 'DM Sans', sans-serif;
   font-size: 15px;
   font-weight: 600;
@@ -509,26 +102,16 @@
   &:hover:not(:disabled) {
     filter: brightness(0.9);
     transform: translateY(-1px);
-    box-shadow: 0 6px 16px rgba(239, 68, 68, 0.4);
   }
 
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
-    transform: none;
   }
 }
 
 // Responsive
 @media (max-width: 480px) {
-  .cancel-dialog {
-    max-width: 100%;
-  }
-
-  .cancel-card {
-    padding: 24px;
-  }
-
   .action-buttons {
     flex-direction: column;
   }

--- a/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.html
+++ b/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.html
@@ -4,7 +4,7 @@
     <div class="ride-summary">
       <div class="ride-header">
         <div class="ride-status">
-          <div class="status-dot"></div>
+          <div class="status-dot" [class.arriving]="ride.status === 'driver_arriving'"></div>
           <span class="status-text">
             @switch (ride.status) {
               @case ('pending') {

--- a/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.html
+++ b/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.html
@@ -1,0 +1,181 @@
+<div class="cancel-dialog-overlay">
+  <div class="cancel-dialog">
+    <!-- Ride Summary -->
+    <div class="ride-summary">
+      <div class="ride-header">
+        <div class="ride-status">
+          <div class="status-dot"></div>
+          <span class="status-text">
+            @switch (ride.status) {
+              @case ('pending') {
+                Ride assigned
+              }
+              @case ('driver_arriving') {
+                En route to pickup
+              }
+              @case ('in_progress') {
+                Ride in progress
+              }
+            }
+          </span>
+        </div>
+        <span class="ride-id">Ride #{{ ride.id }}</span>
+      </div>
+
+      <div class="ride-route">
+        <div class="route-markers">
+          <div class="marker start"></div>
+          <div class="marker-line"></div>
+          <div class="marker end"></div>
+        </div>
+        <div class="route-details">
+          <div class="route-point">
+            <div class="route-label">Pickup</div>
+            <div class="route-address">{{ ride.pickup }}</div>
+          </div>
+          <div class="route-point">
+            <div class="route-label">Drop-off</div>
+            <div class="route-address">{{ ride.dropoff }}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Passenger Info -->
+      @if (ride.passenger) {
+        <div class="passenger-info">
+          <div class="passenger-avatar">{{ ride.passenger.initials }}</div>
+          <div class="passenger-details">
+            <div class="passenger-name">{{ ride.passenger.name }}</div>
+            <div class="passenger-meta">Passenger</div>
+          </div>
+        </div>
+      }
+    </div>
+
+    <!-- Cancel Form -->
+    <div class="cancel-card">
+      <div class="cancel-icon">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="15" y1="9" x2="9" y2="15" />
+          <line x1="9" y1="9" x2="15" y2="15" />
+        </svg>
+      </div>
+
+      <h2 class="cancel-title">Cancel this ride?</h2>
+      <p class="cancel-description">
+        Please provide a reason for canceling this ride. This information will be shared with the
+        passenger and recorded in your history.
+      </p>
+
+      <!-- Driver status indicator -->
+      <div class="driver-status-notice">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+        <span>
+          @if (ride.status === 'driver_arriving') {
+            You can cancel before the passenger enters the vehicle
+          } @else if (ride.status === 'in_progress') {
+            Ride is in progress - contact support for assistance
+          } @else {
+            Cancellation reason will be recorded in your history
+          }
+        </span>
+      </div>
+
+      @if (canCancel) {
+        <form [formGroup]="form">
+          <div class="reason-label">Reason for cancellation <span class="required">*</span></div>
+
+          <div class="reason-options">
+            @for (reason of reasons; track reason.id) {
+              <div
+                class="reason-option"
+                [class.selected]="selectedReason?.id === reason.id"
+                (click)="selectReason(reason)"
+              >
+                <div class="reason-radio">
+                  <div class="reason-radio-inner"></div>
+                </div>
+                <span class="reason-text">{{ reason.label }}</span>
+                @if (reason.requiresExplanation) {
+                  <span class="requires-explanation">Requires explanation</span>
+                }
+              </div>
+            }
+          </div>
+
+          <!-- Explanation textarea -->
+          @if (selectedReason?.requiresExplanation) {
+            <div class="explanation-field">
+              <textarea
+                formControlName="explanation"
+                placeholder="Please describe your reason for canceling (minimum 10 characters)..."
+                rows="4"
+              ></textarea>
+              @if (form.get('explanation')?.touched && form.get('explanation')?.invalid) {
+                <div class="field-error">
+                  Please provide a detailed explanation (at least 10 characters)
+                </div>
+              }
+            </div>
+          }
+        </form>
+
+        <!-- Warning Notice -->
+        <div class="warning-notice">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path
+              d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+            />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+          <p>
+            Frequent ride cancellations may affect your driver rating and availability for future
+            rides. Please only cancel when absolutely necessary.
+          </p>
+        </div>
+
+        <!-- Action Buttons -->
+        <div class="action-buttons">
+          <button type="button" class="btn-secondary" (click)="onKeepRide()">Keep ride</button>
+          <button
+            type="button"
+            class="btn-danger"
+            [disabled]="!isFormValid"
+            (click)="onCancelRide()"
+          >
+            Cancel ride
+          </button>
+        </div>
+      } @else {
+        <!-- Cannot cancel - ride in progress -->
+        <div class="cannot-cancel-notice">
+          <p>
+            You cannot cancel a ride that is already in progress. Please contact support if you need
+            assistance.
+          </p>
+          <button type="button" class="btn-secondary full-width" (click)="onKeepRide()">
+            Go back
+          </button>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.scss
@@ -1,44 +1,144 @@
 @use '../cancel-ride.styles' as *;
 
-// Driver-specific styles
-.cancel-icon {
-  background: var(--warning-light);
+// Driver Cancel - Full dialog with form
 
-  svg {
-    color: var(--warning);
+// Dialog container
+.cancel-dialog {
+  width: 100%;
+  max-width: 520px;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: slideUp 0.3s ease-out;
+
+  // Custom scrollbar
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
   }
 }
 
-.driver-status-notice {
+// Ride Summary Card
+.ride-summary {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.ride-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 16px;
-  background: rgba(91, 76, 219, 0.08);
-  border-radius: var(--radius-sm);
+  justify-content: space-between;
   margin-bottom: 20px;
+}
 
-  svg {
-    width: 20px;
-    height: 20px;
-    color: var(--primary);
-    flex-shrink: 0;
+.ride-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--warning);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
   }
-
-  span {
-    font-size: 14px;
-    color: var(--text-medium);
+  50% {
+    opacity: 0.5;
   }
 }
 
-.warning-notice {
-  background: rgba(91, 76, 219, 0.08);
+.status-text {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--warning);
+}
 
-  svg {
-    color: var(--primary);
+.ride-id {
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+// Route display
+.ride-route {
+  display: flex;
+  align-items: stretch;
+  gap: 14px;
+}
+
+.route-markers {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.marker {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &.start {
+    background: var(--primary);
+  }
+  &.end {
+    background: var(--accent);
   }
 }
 
+.marker-line {
+  flex: 1;
+  width: 2px;
+  background: linear-gradient(180deg, var(--primary) 0%, var(--accent) 100%);
+  margin: 4px 0;
+}
+
+.route-details {
+  flex: 1;
+}
+
+.route-point {
+  padding: 8px 0;
+
+  &:first-child {
+    border-bottom: 1px dashed var(--border);
+  }
+}
+
+.route-label {
+  font-size: 12px;
+  color: var(--text-light);
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.route-address {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-dark);
+}
+
+// Passenger info (driver sees passenger)
 .passenger-info {
   display: flex;
   align-items: center;
@@ -78,6 +178,216 @@
   color: var(--text-light);
 }
 
+// Cancel Card
+.cancel-card {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  box-shadow: var(--shadow-md);
+}
+
+// Cancel icon - warning/orange theme for driver
+.cancel-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--warning-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 24px;
+
+  svg {
+    width: 28px;
+    height: 28px;
+    color: var(--warning);
+  }
+}
+
+.cancel-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+}
+
+.cancel-description {
+  font-size: 15px;
+  color: var(--text-light);
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+// Driver status notice
+.driver-status-notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: rgba(91, 76, 219, 0.08);
+  border-radius: var(--radius-sm);
+  margin-bottom: 20px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--primary);
+    flex-shrink: 0;
+  }
+
+  span {
+    font-size: 14px;
+    color: var(--text-medium);
+  }
+}
+
+// Reason Selection
+.reason-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-medium);
+  margin-bottom: 12px;
+
+  .required {
+    color: var(--danger);
+  }
+}
+
+.reason-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.reason-option {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px;
+  background: var(--bg-cream);
+  border: 2px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: var(--bg-warm);
+  }
+
+  &.selected {
+    border-color: var(--primary);
+    background: rgba(91, 76, 219, 0.04);
+
+    .reason-radio {
+      border-color: var(--primary);
+      background: var(--primary);
+    }
+
+    .reason-radio-inner {
+      opacity: 1;
+    }
+  }
+}
+
+.reason-radio {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.2s;
+}
+
+.reason-radio-inner {
+  width: 8px;
+  height: 8px;
+  background: var(--white);
+  border-radius: 50%;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.reason-text {
+  font-size: 15px;
+  color: var(--text-dark);
+  flex: 1;
+}
+
+.requires-explanation {
+  font-size: 12px;
+  color: var(--text-light);
+  background: var(--bg-warm);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+// Explanation field
+.explanation-field {
+  margin-bottom: 24px;
+
+  textarea {
+    width: 100%;
+    padding: 16px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 15px;
+    color: var(--text-dark);
+    background: var(--bg-cream);
+    border: 2px solid var(--border);
+    border-radius: var(--radius-md);
+    resize: vertical;
+    min-height: 100px;
+    outline: none;
+    transition: all 0.2s;
+
+    &::placeholder {
+      color: var(--text-light);
+    }
+
+    &:focus {
+      border-color: var(--primary);
+      box-shadow: 0 0 0 4px rgba(91, 76, 219, 0.1);
+    }
+  }
+
+  .field-error {
+    margin-top: 8px;
+    font-size: 13px;
+    color: var(--danger);
+  }
+}
+
+// Warning notice
+.warning-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(91, 76, 219, 0.08);
+  border-radius: var(--radius-sm);
+  margin-bottom: 24px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--primary);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--text-medium);
+    line-height: 1.5;
+    margin: 0;
+  }
+}
+
+// Cannot cancel state
 .cannot-cancel-notice {
   text-align: center;
   padding: 20px 0;
@@ -92,4 +402,15 @@
 
 .full-width {
   width: 100%;
+}
+
+// Responsive
+@media (max-width: 480px) {
+  .cancel-dialog {
+    max-width: 100%;
+  }
+
+  .cancel-card {
+    padding: 24px;
+  }
 }

--- a/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.scss
@@ -1,0 +1,95 @@
+@use '../cancel-ride.styles' as *;
+
+// Driver-specific styles
+.cancel-icon {
+  background: var(--warning-light);
+
+  svg {
+    color: var(--warning);
+  }
+}
+
+.driver-status-notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: rgba(91, 76, 219, 0.08);
+  border-radius: var(--radius-sm);
+  margin-bottom: 20px;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--primary);
+    flex-shrink: 0;
+  }
+
+  span {
+    font-size: 14px;
+    color: var(--text-medium);
+  }
+}
+
+.warning-notice {
+  background: rgba(91, 76, 219, 0.08);
+
+  svg {
+    color: var(--primary);
+  }
+}
+
+.passenger-info {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border);
+}
+
+.passenger-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-light) 0%, var(--accent) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--white);
+  font-family: 'Outfit', sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+}
+
+.passenger-details {
+  flex: 1;
+}
+
+.passenger-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 2px;
+}
+
+.passenger-meta {
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+.cannot-cancel-notice {
+  text-align: center;
+  padding: 20px 0;
+
+  p {
+    font-size: 15px;
+    color: var(--text-medium);
+    line-height: 1.6;
+    margin-bottom: 20px;
+  }
+}
+
+.full-width {
+  width: 100%;
+}

--- a/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.ts
+++ b/frontend/src/app/features/ride/components/cancel-ride/driver-cancel/driver-cancel.component.ts
@@ -1,0 +1,78 @@
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  CancelReason,
+  CancelRideResult,
+  RideSummaryForCancel,
+  DRIVER_CANCEL_REASONS,
+} from '../../../models/cancel-ride.model';
+
+@Component({
+  selector: 'app-driver-cancel',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './driver-cancel.component.html',
+  styleUrl: './driver-cancel.component.scss',
+})
+export class DriverCancelComponent {
+  private fb = inject(FormBuilder);
+
+  @Input() ride!: RideSummaryForCancel;
+
+  @Output() cancel = new EventEmitter<CancelRideResult>();
+  @Output() keepRide = new EventEmitter<void>();
+
+  form: FormGroup = this.fb.group({
+    reasonId: ['', Validators.required],
+    explanation: [''],
+  });
+
+  selectedReason: CancelReason | null = null;
+  reasons = DRIVER_CANCEL_REASONS;
+
+  get canCancel(): boolean {
+    // Driver can only cancel before passengers enter (not during in_progress)
+    return this.ride.status === 'pending' || this.ride.status === 'driver_arriving';
+  }
+
+  get isFormValid(): boolean {
+    if (!this.selectedReason) return false;
+    if (this.selectedReason.requiresExplanation) {
+      const explanation = this.form.get('explanation')?.value?.trim();
+      return !!explanation && explanation.length >= 10;
+    }
+    return true;
+  }
+
+  selectReason(reason: CancelReason): void {
+    this.selectedReason = reason;
+    this.form.patchValue({ reasonId: reason.id });
+
+    if (reason.requiresExplanation) {
+      this.form.get('explanation')?.setValidators([Validators.required, Validators.minLength(10)]);
+    } else {
+      this.form.get('explanation')?.clearValidators();
+    }
+    this.form.get('explanation')?.updateValueAndValidity();
+  }
+
+  onKeepRide(): void {
+    this.keepRide.emit();
+  }
+
+  onCancelRide(): void {
+    if (!this.isFormValid || !this.selectedReason) return;
+
+    const result: CancelRideResult = {
+      reasonId: this.selectedReason.id,
+      reasonLabel: this.selectedReason.label,
+    };
+
+    if (this.selectedReason.requiresExplanation) {
+      result.explanation = this.form.get('explanation')?.value?.trim();
+    }
+
+    this.cancel.emit(result);
+  }
+}

--- a/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.html
+++ b/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.html
@@ -1,5 +1,5 @@
 <div class="cancel-dialog-overlay" (click)="onOverlayClick($event)">
-  <div class="cancel-dialog-unified">
+  <div class="cancel-dialog-unified" (click)="$event.stopPropagation()">
     <!-- Cancel Icon -->
     <div class="cancel-icon">
       <svg

--- a/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.html
+++ b/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.html
@@ -1,0 +1,67 @@
+<div class="cancel-dialog-overlay" (click)="onOverlayClick($event)">
+  <div class="cancel-dialog-unified">
+    <!-- Cancel Icon -->
+    <div class="cancel-icon">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="15" y1="9" x2="9" y2="15" />
+        <line x1="9" y1="9" x2="15" y2="15" />
+      </svg>
+    </div>
+
+    <h2 class="cancel-title">Cancel your ride?</h2>
+
+    <!-- Ride Info Summary -->
+    <div class="ride-info-compact">
+      <div class="route-summary">
+        <div class="route-point">
+          <span class="dot start"></span>
+          <span class="address">{{ ride.pickup }}</span>
+        </div>
+        <div class="route-point">
+          <span class="dot end"></span>
+          <span class="address">{{ ride.dropoff }}</span>
+        </div>
+      </div>
+
+      @if (ride.driver) {
+        <div class="driver-summary">
+          <span class="driver-avatar">{{ ride.driver.initials }}</span>
+          <span class="driver-name">{{ ride.driver.name }}</span>
+          <span class="driver-car">{{ ride.driver.car }}</span>
+        </div>
+      }
+    </div>
+
+    <!-- Cancellation Policy Notice -->
+    <div class="policy-notice">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+      <p>
+        You can cancel for free up to <strong>10 minutes</strong> before your scheduled ride.
+      </p>
+    </div>
+
+    <!-- Action Buttons -->
+    <div class="action-buttons">
+      <button type="button" class="btn-secondary" (click)="onKeepRide()">Keep ride</button>
+      <button type="button" class="btn-danger" (click)="onCancelRide()">Cancel ride</button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.scss
@@ -1,0 +1,201 @@
+@use '../cancel-ride.styles' as *;
+
+// Passenger-specific styles for unified dialog
+.cancel-dialog-unified {
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.cancel-icon {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--danger-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 20px;
+
+  svg {
+    width: 28px;
+    height: 28px;
+    color: var(--danger);
+  }
+}
+
+.cancel-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 20px;
+}
+
+// Compact ride info
+.ride-info-compact {
+  background: var(--bg-cream);
+  border-radius: var(--radius-md);
+  padding: 16px;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.route-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.route-point {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+
+    &.start {
+      background: var(--primary);
+    }
+    &.end {
+      background: var(--accent);
+    }
+  }
+
+  .address {
+    font-size: 14px;
+    color: var(--text-dark);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.driver-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--border);
+
+  .driver-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--primary-light) 0%, var(--primary) 100%);
+    color: var(--white);
+    font-size: 12px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .driver-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-dark);
+  }
+
+  .driver-car {
+    font-size: 13px;
+    color: var(--text-light);
+    margin-left: auto;
+  }
+}
+
+// Policy notice
+.policy-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--bg-warm);
+  border-radius: var(--radius-sm);
+  margin-bottom: 24px;
+  text-align: left;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    color: var(--primary);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--text-medium);
+    line-height: 1.5;
+    margin: 0;
+
+    strong {
+      color: var(--primary);
+    }
+  }
+
+  &.warning {
+    background: var(--warning-light);
+
+    svg {
+      color: var(--warning);
+    }
+
+    p strong {
+      color: var(--danger);
+    }
+  }
+}
+
+// Action buttons
+.action-buttons {
+  display: flex;
+  gap: 12px;
+}
+
+.btn-secondary {
+  flex: 1;
+  padding: 14px 20px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-medium);
+  background: var(--bg-cream);
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: var(--text-medium);
+  }
+}
+
+.btn-danger {
+  flex: 1;
+  padding: 14px 20px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--white);
+  background: var(--danger);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+
+  &:hover {
+    filter: brightness(0.9);
+    transform: translateY(-1px);
+  }
+}

--- a/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.scss
+++ b/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.scss
@@ -1,6 +1,7 @@
 @use '../cancel-ride.styles' as *;
 
-// Passenger-specific styles for unified dialog
+// Passenger Cancel - Unified simple dialog
+
 .cancel-dialog-unified {
   background: var(--white);
   border-radius: var(--radius-lg);
@@ -9,8 +10,10 @@
   max-width: 420px;
   box-shadow: var(--shadow-lg);
   text-align: center;
+  animation: slideUp 0.3s ease-out;
 }
 
+// Cancel icon - danger/red theme
 .cancel-icon {
   width: 64px;
   height: 64px;
@@ -36,7 +39,7 @@
   margin-bottom: 20px;
 }
 
-// Compact ride info
+// Compact ride info card
 .ride-info-compact {
   background: var(--bg-cream);
   border-radius: var(--radius-md);
@@ -113,7 +116,7 @@
   }
 }
 
-// Policy notice
+// Policy notice - info style
 .policy-notice {
   display: flex;
   align-items: flex-start;
@@ -141,61 +144,5 @@
     strong {
       color: var(--primary);
     }
-  }
-
-  &.warning {
-    background: var(--warning-light);
-
-    svg {
-      color: var(--warning);
-    }
-
-    p strong {
-      color: var(--danger);
-    }
-  }
-}
-
-// Action buttons
-.action-buttons {
-  display: flex;
-  gap: 12px;
-}
-
-.btn-secondary {
-  flex: 1;
-  padding: 14px 20px;
-  font-family: 'DM Sans', sans-serif;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--text-medium);
-  background: var(--bg-cream);
-  border: 2px solid var(--border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all 0.2s;
-
-  &:hover {
-    border-color: var(--text-medium);
-  }
-}
-
-.btn-danger {
-  flex: 1;
-  padding: 14px 20px;
-  font-family: 'DM Sans', sans-serif;
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--white);
-  background: var(--danger);
-  border: none;
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all 0.2s;
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-
-  &:hover {
-    filter: brightness(0.9);
-    transform: translateY(-1px);
   }
 }

--- a/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.ts
+++ b/frontend/src/app/features/ride/components/cancel-ride/passenger-cancel/passenger-cancel.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CancelRideResult, RideSummaryForCancel } from '../../../models/cancel-ride.model';
+
+@Component({
+  selector: 'app-passenger-cancel',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './passenger-cancel.component.html',
+  styleUrl: './passenger-cancel.component.scss',
+})
+export class PassengerCancelComponent {
+  @Input() ride!: RideSummaryForCancel;
+
+  @Output() cancel = new EventEmitter<CancelRideResult>();
+  @Output() keepRide = new EventEmitter<void>();
+
+  onOverlayClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('cancel-dialog-overlay')) {
+      this.keepRide.emit();
+    }
+  }
+
+  onKeepRide(): void {
+    this.keepRide.emit();
+  }
+
+  onCancelRide(): void {
+    const result: CancelRideResult = {
+      reasonId: 'passenger_cancel',
+      reasonLabel: 'Passenger cancelled ride',
+    };
+    this.cancel.emit(result);
+  }
+}

--- a/frontend/src/app/features/ride/models/cancel-ride.model.ts
+++ b/frontend/src/app/features/ride/models/cancel-ride.model.ts
@@ -1,0 +1,51 @@
+export interface CancelReason {
+  id: string;
+  label: string;
+  requiresExplanation: boolean;
+}
+
+export interface CancelRideResult {
+  reasonId: string;
+  reasonLabel: string;
+  explanation?: string;
+}
+
+export interface RideSummaryForCancel {
+  id: string;
+  pickup: string;
+  dropoff: string;
+  status: 'pending' | 'driver_arriving' | 'in_progress';
+  scheduledTime?: Date;
+  driver?: {
+    name: string;
+    initials: string;
+    car: string;
+    plate: string;
+    rating?: number;
+  };
+  passenger?: {
+    name: string;
+    initials: string;
+  };
+}
+
+export const PASSENGER_CANCEL_REASONS: CancelReason[] = [
+  { id: 'driver_late', label: 'Driver is taking too long', requiresExplanation: false },
+  { id: 'changed_plans', label: 'I changed my plans', requiresExplanation: false },
+  { id: 'driver_asked', label: 'Driver asked me to cancel', requiresExplanation: false },
+  { id: 'wrong_location', label: 'Wrong pickup location', requiresExplanation: false },
+  { id: 'other', label: 'Other reason', requiresExplanation: true },
+];
+
+export const DRIVER_CANCEL_REASONS: CancelReason[] = [
+  {
+    id: 'passenger_not_found',
+    label: 'Passenger not at pickup location',
+    requiresExplanation: false,
+  },
+  { id: 'health_issue', label: 'Health issue - need to end shift', requiresExplanation: true },
+  { id: 'vehicle_problem', label: 'Vehicle breakdown or issue', requiresExplanation: true },
+  { id: 'safety_concern', label: 'Safety concern', requiresExplanation: true },
+  { id: 'wrong_address', label: 'Cannot reach pickup address', requiresExplanation: false },
+  { id: 'other', label: 'Other reason', requiresExplanation: true },
+];

--- a/frontend/src/app/features/ride/models/ride.model.ts
+++ b/frontend/src/app/features/ride/models/ride.model.ts
@@ -1,0 +1,59 @@
+export interface Ride {
+  id: string;
+  pickup: string;
+  dropoff: string;
+  stops?: string[];
+  status: RideStatus;
+  price?: number;
+  distance?: number;
+  duration?: number;
+  scheduledTime?: Date;
+  createdAt: Date;
+  startedAt?: Date;
+  completedAt?: Date;
+  canceledAt?: Date;
+  cancelReason?: string;
+  canceledBy?: 'passenger' | 'driver' | 'system';
+  driver?: RideDriver;
+  passenger?: RidePassenger;
+  linkedPassengers?: RidePassenger[];
+  vehicleType: VehicleType;
+  options: RideOptions;
+}
+
+export interface RideDriver {
+  id: string;
+  name: string;
+  initials: string;
+  phone?: string;
+  rating?: number;
+  vehicle: {
+    model: string;
+    plate: string;
+    type: VehicleType;
+  };
+}
+
+export interface RidePassenger {
+  id: string;
+  name: string;
+  initials: string;
+  email: string;
+  phone?: string;
+}
+
+export interface RideOptions {
+  babySeats: boolean;
+  petFriendly: boolean;
+}
+
+export type RideStatus =
+  | 'pending'
+  | 'searching_driver'
+  | 'driver_assigned'
+  | 'driver_arriving'
+  | 'in_progress'
+  | 'completed'
+  | 'canceled';
+
+export type VehicleType = 'standard' | 'luxury' | 'van';


### PR DESCRIPTION
Closes #35 - FE 18

This pull request introduces a modular and role-specific ride cancellation dialog for both drivers and passengers in the ride feature. It adds new Angular components, supporting models, and tailored UI/UX for each user type, including validation and reason selection for drivers and a streamlined process for passengers. The changes also include detailed styling for both dialogs and new model definitions to support cancellation logic.

**Feature: Modular Ride Cancellation Dialog**
* Added new `CancelRideComponent` to unify the cancellation flow for both drivers and passengers, dynamically rendering the appropriate dialog based on user role.

**Driver Cancellation Dialog**
* Implemented `DriverCancelComponent` with reason selection, explanation field validation, and cancellation restrictions based on ride status.
* Created a comprehensive driver cancellation dialog UI (`driver-cancel.component.html`) with ride summary, passenger info, reason selection, and warning notices.
* Added driver-specific SCSS styles for the cancellation dialog, including status and warning notices, passenger info, and action buttons.

**Passenger Cancellation Dialog**
* Implemented `PassengerCancelComponent` for simplified passenger cancellation, including overlay click-to-dismiss and basic cancellation logic.
* Designed a compact passenger cancellation dialog UI (`passenger-cancel.component.html`) with ride and driver summary, cancellation policy, and action buttons.
* Added passenger-specific SCSS styles for the unified dialog, route summary, driver info, policy notice, and action buttons.

**Models and Data Structures**
* Introduced new models (`cancel-ride.model.ts`) for cancellation reasons, results, and ride summary, supporting both driver and passenger flows.
* Added a comprehensive `Ride` model (`ride.model.ts`) to support ride details and cancellation tracking.