### PR TITLE
[3 SP][FE 37] Admin ride history

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -30,7 +30,8 @@
                 "input": "public"
               }
             ],
-            "styles": ["src/styles.scss"]
+            "styles": ["src/styles.scss"],
+            "externalDependencies": ["@mapbox/mapbox-sdk"]
           },
           "configurations": {
             "production": {

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -95,6 +95,19 @@ export const routes: Routes = [
           },
         ],
       },
+
+      // Admin Routes
+      {
+        path: 'admin',
+        children: [
+          {
+            path: 'ride-history',
+            loadComponent: () =>
+              import('./features/ride-history/pages/admin-history-page/admin-history-page.component')
+                .then((m) => m.AdminHistoryPageComponent),
+          },
+        ],
+      },
     ],
   },
   // Catch-all

--- a/frontend/src/app/features/landing/services/estimate-ride.service.ts
+++ b/frontend/src/app/features/landing/services/estimate-ride.service.ts
@@ -8,16 +8,22 @@ import {
   LocationDTO,
   VehicleTypeName,
 } from '../models/estimate.model';
-import mbxGeocoding from '@mapbox/mapbox-sdk/services/geocoding';
 
 @Injectable({
   providedIn: 'root',
 })
 export class EstimateService {
   private apiUrl = `${environment.apiBaseUrl}/rides/estimate`;
-  private geocodingClient = mbxGeocoding({ accessToken: environment.mapboxToken });
+  private geocodingClient: any;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) {
+    this.initGeocoding();
+  }
+
+  private async initGeocoding() {
+    const mbxGeocoding = (await import('@mapbox/mapbox-sdk/services/geocoding')).default;
+    this.geocodingClient = mbxGeocoding({ accessToken: environment.mapboxToken });
+  }
 
   getEstimate(
     startAddress: string,

--- a/frontend/src/app/features/landing/services/estimate-ride.service.ts
+++ b/frontend/src/app/features/landing/services/estimate-ride.service.ts
@@ -15,12 +15,13 @@ import {
 export class EstimateService {
   private apiUrl = `${environment.apiBaseUrl}/rides/estimate`;
   private geocodingClient: any;
+  private geocodingInitPromise: Promise<void>;
 
   constructor(private http: HttpClient) {
-    this.initGeocoding();
+    this.geocodingInitPromise = this.initGeocoding();
   }
 
-  private async initGeocoding() {
+  private async initGeocoding(): Promise<void> {
     const mbxGeocoding = (await import('@mapbox/mapbox-sdk/services/geocoding')).default;
     this.geocodingClient = mbxGeocoding({ accessToken: environment.mapboxToken });
   }
@@ -54,7 +55,9 @@ export class EstimateService {
   }
 
   private geocodeAddress(address: string): Observable<LocationDTO> {
-    const promise = this.geocodingClient.forwardGeocode({ query: address, limit: 1 }).send();
+    const promise = this.geocodingInitPromise.then(() =>
+      this.geocodingClient.forwardGeocode({ query: address, limit: 1 }).send()
+    );
     return from(promise).pipe(
       map((response: any) => {
         const feature = response?.body?.features?.[0];

--- a/frontend/src/app/features/ride-history/config/admin-history.config.ts
+++ b/frontend/src/app/features/ride-history/config/admin-history.config.ts
@@ -1,0 +1,29 @@
+import { TableColumnConfig } from '../components/ride-history-table/ride-history-table.component';
+import { RideDetailsConfig } from '../components/ride-details/ride-details.component';
+
+/**
+ * Configuration for admin ride history view.
+ * Admins see all system rides with full information visibility.
+ */
+export const adminHistoryConfig = {
+  tableColumns: [
+    { key: 'dateTime', label: 'Date & Time', visible: true },
+    { key: 'driver', label: 'Driver', visible: true },
+    { key: 'passengers', label: 'Passengers', visible: true },
+    { key: 'route', label: 'Route', visible: true },
+    { key: 'status', label: 'Status', visible: true },
+  ] as TableColumnConfig[],
+
+  detailsConfig: {
+    showPassengers: true,
+    showDriverInfo: true, // Admins see driver info
+    showPanicAlert: true,
+    showCancellationInfo: true,
+    showEarnings: true,
+    showRatings: true,
+  } as RideDetailsConfig,
+
+  pageTitle: 'System Ride History',
+  pageSubtitle: 'View and monitor all rides in the system',
+  showEarningsInTable: true,
+};

--- a/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.html
+++ b/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.html
@@ -1,0 +1,35 @@
+<div class="page-container">
+  <!-- Main Content -->
+  <main class="main-content">
+    <div class="page-header">
+      <h1 class="page-title">{{ config.pageTitle }}</h1>
+      <p class="page-subtitle">{{ config.pageSubtitle }}</p>
+    </div>
+
+    <!-- Filters -->
+    <app-ride-history-filters
+      [startDate]="startDate()"
+      [endDate]="endDate()"
+      [resultsCount]="filteredRides().length"
+      (filterChanged)="onFilterChanged($event)"
+      (filterCleared)="onFilterCleared()"
+    />
+
+    <!-- Rides Table -->
+    <app-ride-history-table
+      [rides]="filteredRides()"
+      [columns]="config.tableColumns"
+      [showEarnings]="config.showEarningsInTable || false"
+      [showPassengers]="true"
+      (rideSelected)="onRideSelected($event)"
+      (sortChanged)="onSortChanged($event)"
+    />
+  </main>
+</div>
+
+<!-- Ride Details Side Panel -->
+<app-ride-details
+  [ride]="selectedRide()"
+  [config]="config.detailsConfig"
+  (close)="onRideDetailsClosed()"
+/>

--- a/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.scss
+++ b/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.scss
@@ -1,0 +1,40 @@
+:host {
+  display: block;
+  width: 100%;
+  min-height: 100vh;
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg-cream);
+  color: var(--text-dark);
+}
+
+.page-container {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.main-content {
+  padding: 32px;
+}
+
+.page-header {
+  margin-bottom: 32px;
+}
+
+.page-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 8px;
+}
+
+.page-subtitle {
+  font-size: 15px;
+  color: var(--text-light);
+}
+
+@media (max-width: 768px) {
+  .main-content {
+    padding: 24px 16px;
+  }
+}

--- a/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.ts
+++ b/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RideHistoryService } from '../../services/ride-history.service';
+import { Ride } from '../../models';
+import { adminHistoryConfig } from '../../config/admin-history.config';
+import { RideHistoryTableComponent, SortState } from '../../components/ride-history-table/ride-history-table.component';
+import { RideHistoryFiltersComponent } from '../../components/ride-history-filters/ride-history-filters.component';
+import { RideDetailsComponent } from '../../components/ride-details/ride-details.component';
+
+/**
+ * Smart page component for admin ride history.
+ * Handles data fetching and state management for admin role.
+ * Uses shared presentational components configured for admin view with full visibility.
+ */
+@Component({
+  selector: 'app-admin-history-page',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RideHistoryTableComponent,
+    RideHistoryFiltersComponent,
+    RideDetailsComponent,
+  ],
+  templateUrl: './admin-history-page.component.html',
+  styleUrl: './admin-history-page.component.scss',
+})
+export class AdminHistoryPageComponent implements OnInit {
+  allRides = signal<Ride[]>([]);
+  filteredRides = signal<Ride[]>([]);
+  startDate = signal<string>('');
+  endDate = signal<string>('');
+  selectedRide = signal<Ride | null>(null);
+  currentSort = signal<SortState>({ field: null, order: 'asc' });
+
+  config = adminHistoryConfig;
+
+  constructor(private rideHistoryService: RideHistoryService) {}
+
+  ngOnInit(): void {
+    this.loadRides();
+    this.setDefaultDateRange();
+  }
+
+  private loadRides(): void {
+    const rides = this.rideHistoryService.getAdminRideHistory();
+    this.allRides.set(rides);
+    this.filteredRides.set(rides);
+  }
+
+  private setDefaultDateRange(): void {
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - 90); // Admins see 90 days by default
+
+    this.endDate.set(endDate.toISOString().split('T')[0]);
+    this.startDate.set(startDate.toISOString().split('T')[0]);
+  }
+
+  onFilterChanged(filter: { startDate: string; endDate: string }): void {
+    const start = filter.startDate ? new Date(filter.startDate) : null;
+    const end = filter.endDate ? new Date(filter.endDate) : null;
+    let filtered = this.rideHistoryService.filterRidesByDateRange(
+      this.allRides(),
+      start,
+      end,
+    );
+    
+    // Apply current sort if active
+    if (this.currentSort().field) {
+      filtered = this.rideHistoryService.sortRides(filtered, this.currentSort().field, this.currentSort().order);
+    }
+    
+    this.filteredRides.set(filtered);
+  }
+
+  onFilterCleared(): void {
+    this.startDate.set('');
+    this.endDate.set('');
+    let rides = this.allRides();
+    
+    // Apply current sort if active
+    if (this.currentSort().field) {
+      rides = this.rideHistoryService.sortRides(rides, this.currentSort().field, this.currentSort().order);
+    }
+    
+    this.filteredRides.set(rides);
+  }
+
+  onSortChanged(sortState: SortState): void {
+    this.currentSort.set(sortState);
+    if (sortState.field) {
+      const sorted = this.rideHistoryService.sortRides(this.filteredRides(), sortState.field, sortState.order);
+      this.filteredRides.set(sorted);
+    }
+  }
+
+  onRideSelected(ride: Ride): void {
+    if (this.selectedRide() === ride) {
+      this.selectedRide.set(null);
+    } else {
+      this.selectedRide.set(ride);
+    }
+  }
+
+  onRideDetailsClosed(): void {
+    this.selectedRide.set(null);
+  }
+}

--- a/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.ts
+++ b/frontend/src/app/features/ride-history/pages/admin-history-page/admin-history-page.component.ts
@@ -50,7 +50,7 @@ export class AdminHistoryPageComponent implements OnInit {
   private setDefaultDateRange(): void {
     const endDate = new Date();
     const startDate = new Date();
-    startDate.setDate(startDate.getDate() - 90); // Admins see 90 days by default
+    startDate.setDate(startDate.getDate() - 90); //TODO: make admins see last 30 rides by default, paginate older rides
 
     this.endDate.set(endDate.toISOString().split('T')[0]);
     this.startDate.set(startDate.toISOString().split('T')[0]);


### PR DESCRIPTION
Closes #65 - FE 37

[3 SP][FE 37] Admin ride history

This pull request introduces a new admin ride history feature to the frontend, allowing administrators to view and manage all system rides with enhanced visibility and filtering. It also improves the way Mapbox dependencies are loaded, optimizing bundle size and performance.

**Admin Ride History Feature:**

* Added a new admin route (`/admin/ride-history`) to the Angular router, providing access to the admin ride history page.
* Implemented the `AdminHistoryPageComponent` with smart state management, including ride data loading, date filtering, sorting, and ride selection.
* Created a dedicated configuration (`adminHistoryConfig`) for the admin view, enabling full information visibility (e.g., earnings, driver info, passenger info) and customizing table columns and details display.
* Developed the admin ride history page template and styles for a clear, responsive UI, and integrated shared presentational components for filters, table, and ride details. [[1]](diffhunk://#diff-004eb7c419ab85219ac22fdb3ec307ebb283b05bba8494b7dc6e3d74d92e138bR1-R35) [[2]](diffhunk://#diff-3c425e190faaa3da0943712cbb7969526188f115fa9ac1a14fb31fe0d6a6cc52R1-R40)

**Dependency and Performance Improvements:**

* Updated Mapbox SDK usage to load the geocoding module dynamically at runtime, reducing initial bundle size and improving app performance. Also declared `@mapbox/mapbox-sdk` as an external dependency in the Angular build config. [[1]](diffhunk://#diff-933ab92d0165ba52af3f413693e90b6463412b3b105f0c1b3f9789ad37cc07fdL11-R26) [[2]](diffhunk://#diff-dc1db98b7a4eeaf4047e28ec08a91379d813e7fe58bb8be3a5d439a401f10922L33-R34)