### PR TITLE
[3 SP][FE 12] Favorite routes selection during ride ordering

### DIFF
--- a/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
+++ b/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
@@ -2,6 +2,9 @@
   <table class="rides-table">
     <thead>
       <tr>
+        @if (showFavoriteButton()) {
+          <th class="favorite-col"></th>
+        }
         <th
           (click)="onHeaderClick('dateTime')"
           [class.sortable]="isSortable('dateTime')"
@@ -79,6 +82,45 @@
     <tbody>
       @for (ride of rides(); track ride.id) {
         <tr (click)="selectRide(ride)" style="cursor: pointer">
+          @if (showFavoriteButton()) {
+            <td class="favorite-cell" (click)="$event.stopPropagation()">
+              <button
+                type="button"
+                class="favorite-btn"
+                [class.is-favorite]="ride.isFavorite"
+                (click)="favoriteToggled.emit(ride)"
+                [title]="ride.isFavorite ? 'Remove from favorites' : 'Add to favorites'"
+                aria-label="Toggle favorite"
+              >
+                <svg
+                  *ngIf="!ride.isFavorite"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polygon
+                    points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                  />
+                </svg>
+                <svg
+                  *ngIf="ride.isFavorite"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polygon
+                    points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                  />
+                </svg>
+              </button>
+            </td>
+          }
           <td>
             <div class="date-cell">
               <span class="date-value">{{ formatDate(ride.startTime) }}</span>

--- a/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
+++ b/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
@@ -2,9 +2,7 @@
   <table class="rides-table">
     <thead>
       <tr>
-        @if (showFavoriteButton()) {
-          <th class="favorite-col"></th>
-        }
+        <th *ngIf="showFavoriteButton()" class="favorite-col"></th>
         <th
           (click)="onHeaderClick('dateTime')"
           [class.sortable]="isSortable('dateTime')"
@@ -12,36 +10,32 @@
           class="sortable-header"
         >
           Date & Time
-          @if (isSortable('dateTime')) {
-            <span class="sort-icon">{{ getSortIcon('dateTime') }}</span>
-          }
+          <span *ngIf="isSortable('dateTime')" class="sort-icon">{{
+            getSortIcon('dateTime')
+          }}</span>
         </th>
-        @if (isColumnVisible('driver')) {
-          <th
-            (click)="onHeaderClick('driver')"
-            [class.sortable]="isSortable('driver')"
-            [class.active]="sortState.field === 'driver'"
-            class="sortable-header"
-          >
-            Driver
-            @if (isSortable('driver')) {
-              <span class="sort-icon">{{ getSortIcon('driver') }}</span>
-            }
-          </th>
-        }
-        @if (isColumnVisible('passengers')) {
-          <th
-            (click)="onHeaderClick('passengers')"
-            [class.sortable]="isSortable('passengers')"
-            [class.active]="sortState.field === 'passengers'"
-            class="sortable-header"
-          >
-            Passengers
-            @if (isSortable('passengers')) {
-              <span class="sort-icon">{{ getSortIcon('passengers') }}</span>
-            }
-          </th>
-        }
+        <th
+          *ngIf="isColumnVisible('driver')"
+          (click)="onHeaderClick('driver')"
+          [class.sortable]="isSortable('driver')"
+          [class.active]="sortState.field === 'driver'"
+          class="sortable-header"
+        >
+          Driver
+          <span *ngIf="isSortable('driver')" class="sort-icon">{{ getSortIcon('driver') }}</span>
+        </th>
+        <th
+          *ngIf="isColumnVisible('passengers')"
+          (click)="onHeaderClick('passengers')"
+          [class.sortable]="isSortable('passengers')"
+          [class.active]="sortState.field === 'passengers'"
+          class="sortable-header"
+        >
+          Passengers
+          <span *ngIf="isSortable('passengers')" class="sort-icon">{{
+            getSortIcon('passengers')
+          }}</span>
+        </th>
         <th
           (click)="onHeaderClick('route')"
           [class.sortable]="isSortable('route')"
@@ -49,9 +43,7 @@
           class="sortable-header"
         >
           Route
-          @if (isSortable('route')) {
-            <span class="sort-icon">{{ getSortIcon('route') }}</span>
-          }
+          <span *ngIf="isSortable('route')" class="sort-icon">{{ getSortIcon('route') }}</span>
         </th>
         <th
           (click)="onHeaderClick('status')"
@@ -60,186 +52,164 @@
           class="sortable-header"
         >
           Status
-          @if (isSortable('status')) {
-            <span class="sort-icon">{{ getSortIcon('status') }}</span>
-          }
+          <span *ngIf="isSortable('status')" class="sort-icon">{{ getSortIcon('status') }}</span>
         </th>
-        @if (showEarnings()) {
-          <th
-            (click)="onHeaderClick('earnings')"
-            [class.sortable]="isSortable('earnings')"
-            [class.active]="sortState.field === 'earnings'"
-            class="sortable-header"
-          >
-            Earnings
-            @if (isSortable('earnings')) {
-              <span class="sort-icon">{{ getSortIcon('earnings') }}</span>
-            }
-          </th>
-        }
+        <th
+          *ngIf="showEarnings()"
+          (click)="onHeaderClick('earnings')"
+          [class.sortable]="isSortable('earnings')"
+          [class.active]="sortState.field === 'earnings'"
+          class="sortable-header"
+        >
+          Earnings
+          <span *ngIf="isSortable('earnings')" class="sort-icon">{{
+            getSortIcon('earnings')
+          }}</span>
+        </th>
       </tr>
     </thead>
     <tbody>
-      @for (ride of rides(); track ride.id) {
-        <tr (click)="selectRide(ride)" style="cursor: pointer">
-          @if (showFavoriteButton()) {
-            <td class="favorite-cell" (click)="$event.stopPropagation()">
-              <button
-                type="button"
-                class="favorite-btn"
-                [class.is-favorite]="ride.isFavorite"
-                (click)="favoriteToggled.emit(ride)"
-                [title]="ride.isFavorite ? 'Remove from favorites' : 'Add to favorites'"
-                aria-label="Toggle favorite"
+      <tr *ngFor="let ride of rides()" (click)="selectRide(ride)" style="cursor: pointer">
+        <td *ngIf="showFavoriteButton()" class="favorite-cell" (click)="$event.stopPropagation()">
+          <button
+            type="button"
+            class="favorite-btn"
+            [class.is-favorite]="ride.isFavorite"
+            (click)="favoriteToggled.emit(ride)"
+            [title]="ride.isFavorite ? 'Remove from favorites' : 'Add to favorites'"
+            aria-label="Toggle favorite"
+          >
+            <ng-container *ngIf="!ride.isFavorite; else favoriteFilled">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                @if (!ride.isFavorite) {
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <polygon
-                      points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
-                    />
-                  </svg>
-                } @else {
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <polygon
-                      points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
-                    />
-                  </svg>
-                }
-              </button>
-            </td>
-          }
-          <td>
-            <div class="date-cell">
-              <span class="date-value">{{ formatDate(ride.startTime) }}</span>
-              <span class="time-value">{{
-                formatDateTimeRange(ride.startTime, ride.endTime)
-              }}</span>
+                <polygon
+                  points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                />
+              </svg>
+            </ng-container>
+            <ng-template #favoriteFilled>
+              <svg
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polygon
+                  points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                />
+              </svg>
+            </ng-template>
+          </button>
+        </td>
+        <td>
+          <div class="date-cell">
+            <span class="date-value">{{ formatDate(ride.startTime) }}</span>
+            <span class="time-value">{{ formatDateTimeRange(ride.startTime, ride.endTime) }}</span>
+          </div>
+        </td>
+        <td *ngIf="isColumnVisible('driver')">
+          <div class="driver-cell">
+            <div class="driver-avatar">
+              {{ getDriverInitials(ride.driver) }}
             </div>
-          </td>
-          @if (isColumnVisible('driver')) {
-            <td>
-              <div class="driver-cell">
-                <div class="driver-avatar">
-                  {{ getDriverInitials(ride.driver) }}
-                </div>
-                <span class="driver-name">{{ getDriverName(ride.driver) }}</span>
+            <span class="driver-name">{{ getDriverName(ride.driver) }}</span>
+          </div>
+        </td>
+        <td *ngIf="isColumnVisible('passengers')">
+          <div class="passengers-cell">
+            <div class="passenger-avatars">
+              <div class="passenger-avatar" *ngFor="let passenger of ride.passengers.slice(0, 3)">
+                {{ getPassengerInitials(passenger) }}
               </div>
-            </td>
-          }
-          @if (isColumnVisible('passengers')) {
-            <td>
-              <div class="passengers-cell">
-                <div class="passenger-avatars">
-                  @for (passenger of ride.passengers.slice(0, 3); track passenger.email) {
-                    <div class="passenger-avatar">
-                      {{ getPassengerInitials(passenger) }}
-                    </div>
-                  }
-                  @if (ride.passengers.length > 3) {
-                    <div class="passenger-avatar">+{{ ride.passengers.length - 3 }}</div>
-                  }
-                </div>
-                <span class="passenger-count">{{
-                  getPassengerDisplayCount(ride.passengers.length)
-                }}</span>
-              </div>
-            </td>
-          }
-          <td>
-            <div class="route-cell">
-              <div class="route-markers">
-                <div class="route-dot start"></div>
-                <div class="route-line-small"></div>
-                <div class="route-dot end"></div>
-              </div>
-              <div class="route-addresses">
-                <span class="route-from">{{ ride.origin }}</span>
-                <span class="route-to">{{ ride.destination }}</span>
+              <div class="passenger-avatar" *ngIf="ride.passengers.length > 3">
+                +{{ ride.passengers.length - 3 }}
               </div>
             </div>
-          </td>
-          <td>
-            <span
-              class="status-badge"
-              [class.completed]="!ride.isCancelled && !ride.panicActivated"
-              [class.cancelled]="ride.isCancelled"
-              [class.panic]="!ride.isCancelled && ride.panicActivated"
-            >
-              @if (!ride.isCancelled && !ride.panicActivated) {
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <polyline points="20 6 9 17 4 12" />
-                </svg>
-              }
-              @if (!ride.isCancelled && ride.panicActivated) {
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <path d="M12 2 2 22h20L12 2Z" />
-                  <line x1="12" y1="9" x2="12" y2="13" />
-                  <line x1="12" y1="17" x2="12" y2="17" />
-                </svg>
-              }
-              @if (ride.isCancelled) {
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <circle cx="12" cy="12" r="10" />
-                  <line x1="15" y1="9" x2="9" y2="15" />
-                  <line x1="9" y1="9" x2="15" y2="15" />
-                </svg>
-              }
-              {{ ride.isCancelled ? 'Cancelled' : ride.panicActivated ? 'Panic' : 'Completed' }}
-            </span>
-          </td>
-          @if (showEarnings()) {
-            <td class="price-cell">
-              @if (!ride.isCancelled) {
-                <span>{{ formatCurrency(ride.cost) }}</span>
-              }
-              @if (ride.isCancelled) {
-                <span>—</span>
-              }
-            </td>
-          }
-        </tr>
-      }
+            <span class="passenger-count">{{
+              getPassengerDisplayCount(ride.passengers.length)
+            }}</span>
+          </div>
+        </td>
+        <td>
+          <div class="route-cell">
+            <div class="route-markers">
+              <div class="route-dot start"></div>
+              <div class="route-line-small"></div>
+              <div class="route-dot end"></div>
+            </div>
+            <div class="route-addresses">
+              <span class="route-from">{{ ride.origin }}</span>
+              <span class="route-to">{{ ride.destination }}</span>
+            </div>
+          </div>
+        </td>
+        <td>
+          <span
+            class="status-badge"
+            [class.completed]="!ride.isCancelled && !ride.panicActivated"
+            [class.cancelled]="ride.isCancelled"
+            [class.panic]="!ride.isCancelled && ride.panicActivated"
+          >
+            <ng-container *ngIf="!ride.isCancelled && !ride.panicActivated">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </ng-container>
+            <ng-container *ngIf="!ride.isCancelled && ride.panicActivated">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 2 2 22h20L12 2Z" />
+                <line x1="12" y1="9" x2="12" y2="13" />
+                <line x1="12" y1="17" x2="12" y2="17" />
+              </svg>
+            </ng-container>
+            <ng-container *ngIf="ride.isCancelled">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="15" y1="9" x2="9" y2="15" />
+                <line x1="9" y1="9" x2="15" y2="15" />
+              </svg>
+            </ng-container>
+            {{ ride.isCancelled ? 'Cancelled' : ride.panicActivated ? 'Panic' : 'Completed' }}
+          </span>
+        </td>
+        <td *ngIf="showEarnings()" class="price-cell">
+          <span *ngIf="!ride.isCancelled">{{ formatCurrency(ride.cost) }}</span>
+          <span *ngIf="ride.isCancelled">—</span>
+        </td>
+      </tr>
     </tbody>
   </table>
 
-  @if (rides().length === 0) {
-    <div class="empty-state">
-      <p>{{ emptyMessage() }}</p>
-    </div>
-  }
+  <div *ngIf="rides().length === 0" class="empty-state">
+    <p>{{ emptyMessage() }}</p>
+  </div>
 </div>

--- a/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
+++ b/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.html
@@ -92,32 +92,33 @@
                 [title]="ride.isFavorite ? 'Remove from favorites' : 'Add to favorites'"
                 aria-label="Toggle favorite"
               >
-                <svg
-                  *ngIf="!ride.isFavorite"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <polygon
-                    points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
-                  />
-                </svg>
-                <svg
-                  *ngIf="ride.isFavorite"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                >
-                  <polygon
-                    points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
-                  />
-                </svg>
+                @if (!ride.isFavorite) {
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polygon
+                      points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                    />
+                  </svg>
+                } @else {
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polygon
+                      points="12 2 15.09 10.26 24 10.5 18 16.6 20.29 25.5 12 20.92 3.71 25.5 6 16.6 0 10.5 8.91 10.26 12 2"
+                    />
+                  </svg>
+                }
               </button>
             </td>
           }

--- a/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.scss
+++ b/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.scss
@@ -280,6 +280,48 @@
   }
 }
 
+/* Favorite Column */
+.favorite-col {
+  width: 50px;
+}
+
+.favorite-cell {
+  padding: 18px 12px !important;
+}
+
+.favorite-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-light);
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  &:hover {
+    background: var(--bg-light);
+    color: var(--primary);
+  }
+
+  &.is-favorite {
+    color: #fbbf24;
+
+    &:hover {
+      background: rgba(251, 191, 36, 0.1);
+    }
+  }
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .rides-table-container {

--- a/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.ts
+++ b/frontend/src/app/features/ride-history/components/ride-history-table/ride-history-table.component.ts
@@ -34,10 +34,12 @@ export class RideHistoryTableComponent {
   columns = input<TableColumnConfig[]>([]);
   showEarnings = input(false);
   showPassengers = input(true);
+  showFavoriteButton = input(false);
   emptyMessage = input('No rides found.');
 
   rideSelected = output<Ride>();
   sortChanged = output<SortState>();
+  favoriteToggled = output<Ride>();
 
   sortState: SortState = { field: null, order: 'asc' };
 

--- a/frontend/src/app/features/ride-history/models/ride.model.ts
+++ b/frontend/src/app/features/ride-history/models/ride.model.ts
@@ -25,4 +25,8 @@ export interface Ride {
   vehicleType: 'STANDARD' | 'LUXURY' | 'VAN';
   driverRating?: number;
   passengerRating?: number;
+  // TODO: Backend Integration - Link to RidePassenger.isFavorite
+  // This should be: isFavorite: boolean; (per user per ride)
+  // Currently local state only - Backend needs RidePassenger entity update
+  isFavorite?: boolean;
 }

--- a/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.html
+++ b/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.html
@@ -21,8 +21,10 @@
       [columns]="config.tableColumns"
       [showEarnings]="config.showEarningsInTable || false"
       [showPassengers]="false"
+      [showFavoriteButton]="true"
       (rideSelected)="onRideSelected($event)"
       (sortChanged)="onSortChanged($event)"
+      (favoriteToggled)="onFavoriteToggled($event)"
     />
   </main>
 </div>

--- a/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.ts
+++ b/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.ts
@@ -95,4 +95,37 @@ export class PassengerHistoryPageComponent implements OnInit {
   onRideDetailsClosed(): void {
     this.selectedRide.set(null);
   }
+
+  onFavoriteToggled(ride: Ride): void {
+    // TODO: Backend Integration - Implement API call to mark ride as favorite
+    // 1. Create or update RidePassenger.isFavorite in the database
+    // 2. Call backend endpoint: PATCH /api/rides/{rideId}/favorite with { isFavorite: boolean }
+    // 3. Handle optimistic UI update vs. pessimistic (wait for response)
+    // 4. Add error handling and user feedback (toast notification)
+    // 5. Consider adding isFavorite to the Ride DTO in backend
+    
+    // For now: local toggle only
+    const updatedRide = { ...ride, isFavorite: !ride.isFavorite };
+    
+    // Update in allRides
+    const allRidesIndex = this.allRides().findIndex(r => r.id === ride.id);
+    if (allRidesIndex !== -1) {
+      const updated = [...this.allRides()];
+      updated[allRidesIndex] = updatedRide;
+      this.allRides.set(updated);
+    }
+    
+    // Update in filteredRides
+    const filteredIndex = this.filteredRides().findIndex(r => r.id === ride.id);
+    if (filteredIndex !== -1) {
+      const updated = [...this.filteredRides()];
+      updated[filteredIndex] = updatedRide;
+      this.filteredRides.set(updated);
+    }
+    
+    // Update selectedRide if it's the same ride
+    if (this.selectedRide()?.id === ride.id) {
+      this.selectedRide.set(updatedRide);
+    }
+  }
 }


### PR DESCRIPTION
close #61 

[3 SP][FE 12] Favorite routes selection during ride ordering

This pull request introduces a new "favorite ride" feature to the ride history table, allowing users to mark rides as favorites directly from the UI. The implementation is currently local-only, with clear TODOs for backend integration. The most important changes are grouped below:

**UI Enhancements:**

* Added a favorite/star button to each ride row in the `RideHistoryTableComponent`, including visual cues for favorite status and improved accessibility. [[1]](diffhunk://#diff-f3e0c9ee884cb71e7a185601f3624d21720c46a68dd10c2aedfd558b95bc5f8cR5-R7) [[2]](diffhunk://#diff-f3e0c9ee884cb71e7a185601f3624d21720c46a68dd10c2aedfd558b95bc5f8cR85-R123)
* Updated table styles in `ride-history-table.component.scss` to support the favorite column and button, including hover and active states.

**Component and Data Model Updates:**

* Introduced the `showFavoriteButton` input and `favoriteToggled` output to `RideHistoryTableComponent` to control and emit favorite toggling events.
* Extended the `Ride` model with an optional `isFavorite` property, with comments indicating the need for backend support.

**Integration and State Management:**

* Enabled the favorite button in the passenger history page and wired up the `favoriteToggled` event to a new handler.
* Implemented local optimistic toggling of the favorite status in `PassengerHistoryPageComponent`, with detailed TODOs for future backend/API integration.