### PR TITLE
[FE 39] feat: use backend API call on frontend for passenger registration

### DIFF
--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, inject } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import {
   ReactiveFormsModule,
   FormBuilder,
@@ -11,16 +11,25 @@ import {
 import { CommonModule } from '@angular/common';
 import { PersonalInfoFormComponent } from '../../../shared/components/personal-info-form/personal-info-form.component';
 import { ProfilePhotoUploadComponent } from '../../../shared/components/profile-photo-upload/profile-photo-upload.component';
+import { RegisterService, PassengerRegisterRequest } from '../services/register.service';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [RouterLink, ReactiveFormsModule, CommonModule, PersonalInfoFormComponent, ProfilePhotoUploadComponent],
+  imports: [
+    RouterLink,
+    ReactiveFormsModule,
+    CommonModule,
+    PersonalInfoFormComponent,
+    ProfilePhotoUploadComponent,
+  ],
   templateUrl: './register.component.html',
   styleUrl: './register.component.scss',
 })
 export class RegisterComponent implements OnInit {
   private fb = inject(FormBuilder);
+  private registerService = inject(RegisterService);
+  private router = inject(Router);
 
   registerForm!: FormGroup;
   submitted = false;
@@ -48,7 +57,7 @@ export class RegisterComponent implements OnInit {
         confirmPassword: ['', [Validators.required]],
         agreeToTerms: [false, [Validators.requiredTrue]],
       },
-      { validators: this.passwordMatchValidator }
+      { validators: this.passwordMatchValidator },
     );
   }
 
@@ -88,22 +97,28 @@ export class RegisterComponent implements OnInit {
       return;
     }
 
-    // TODO: Implement registration logic in KT2
     const formValue = this.registerForm.value;
-    console.log('Registration submitted:', {
+    const payload: PassengerRegisterRequest = {
       firstName: formValue.firstName,
       lastName: formValue.lastName,
       email: formValue.email,
-      phone: formValue.countryCode + formValue.phone,
+      phoneNumber: formValue.countryCode + formValue.phone,
       address: formValue.address,
-      profilePhoto: this.selectedPhotoFile ? this.selectedPhotoFile.name : null,
+      password: formValue.password,
+      confirmPassword: formValue.confirmPassword,
+      profilePicture: this.selectedPhotoFile ? this.selectedPhotoFile.name : undefined, // Placeholder; replace with actual URL after upload
+    };
+
+    this.registerService.register(payload).subscribe({
+      next: (response) => {
+        console.log('Registration successful:', response);
+        // TODO: Show success message
+        this.router.navigate(['/login']); // Navigate to login after successful registration
+      },
+      error: (error) => {
+        console.error('Registration failed:', error);
+        // TODO: Show error message
+      },
     });
-    
-    // TODO: Upload photo file to backend storage
-    // if (this.selectedPhotoFile) {
-    //   this.uploadService.uploadProfilePhoto(this.selectedPhotoFile).subscribe(
-    //     url => { formData.profilePictureUrl = url; }
-    //   );
-    // }
   }
 }

--- a/frontend/src/app/features/auth/services/register.service.ts
+++ b/frontend/src/app/features/auth/services/register.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+export interface PassengerRegisterRequest {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  firstName: string;
+  lastName: string;
+  address: string;
+  phoneNumber: string;
+  profilePicture?: string;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RegisterService {
+  private apiUrl = `${environment.apiBaseUrl}/passengers`;
+
+  constructor(private http: HttpClient) {}
+
+  register(passenger: PassengerRegisterRequest): Observable<any> {
+    return this.http.post(this.apiUrl, passenger);
+  }
+}


### PR DESCRIPTION
Closes #77 

This pull request implements the registration logic for new passengers in the Angular frontend. It introduces a new `RegisterService` for handling registration API calls, updates the registration form submission to use this service, and prepares the payload for backend integration.

**Registration feature implementation:**

* Added a new `RegisterService` (`register.service.ts`) with a `register` method to send registration data to the backend API and defined the `PassengerRegisterRequest` interface for type safety.
* Updated `RegisterComponent` to inject and use `RegisterService` and `Router` for handling registration and navigation after successful signup. [[1]](diffhunk://#diff-7122abae4436681fef7b6057a0a5557dee229ab4f80162c27130ffe5494123b2L2-R2) [[2]](diffhunk://#diff-7122abae4436681fef7b6057a0a5557dee229ab4f80162c27130ffe5494123b2R14-R32)
* Replaced placeholder registration logic in `RegisterComponent` with a call to `registerService.register(payload)` using the constructed `PassengerRegisterRequest` object, and added navigation to the login page on success.

**Code and form improvements:**

* Cleaned up form initialization and payload construction, ensuring all required fields are included and naming is consistent with backend expectations. [[1]](diffhunk://#diff-7122abae4436681fef7b6057a0a5557dee229ab4f80162c27130ffe5494123b2L51-R60) [[2]](diffhunk://#diff-7122abae4436681fef7b6057a0a5557dee229ab4f80162c27130ffe5494123b2L91-R122)