### PR TITLE
[FE 41] feat: implement functional activate account page

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -36,6 +36,13 @@ export const routes: Routes = [
         (m) => m.ResetPasswordComponent,
       ),
   },
+  {
+    path: 'activate/:token',
+    loadComponent: () =>
+      import('./features/auth/activate-account/activate-account.component').then(
+        (m) => m.ActivateAccountComponent,
+      ),
+  },
 
   // Non-auth routes under layout
   {

--- a/frontend/src/app/features/auth/activate-account/activate-account.component.html
+++ b/frontend/src/app/features/auth/activate-account/activate-account.component.html
@@ -1,0 +1,77 @@
+<div class="card">
+  <a routerLink="/login" class="back-link">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M19 12H5" />
+      <path d="M12 19l-7-7 7-7" />
+    </svg>
+    Back to login
+  </a>
+
+  <div class="icon-wrapper">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  </div>
+
+  <h1 class="card-title">Activate your account</h1>
+  <p class="card-description">
+    Click the button below to activate your account and get started with Drumigo.
+  </p>
+  <div *ngIf="error" class="alert alert-error">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+    <span>{{ error }}</span>
+  </div>
+
+  <div *ngIf="success" class="alert alert-success">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+    <span>Account activated successfully! Redirecting to login...</span>
+  </div>
+
+  <div *ngIf="!success">
+    <form (ngSubmit)="onSubmit()">
+      <button type="submit" class="btn-primary" [disabled]="!token || isSubmitting">
+        <ng-container *ngIf="isSubmitting; else notSubmitting">
+          <span class="loading-spinner"></span>
+          Activating...
+        </ng-container>
+        <ng-template #notSubmitting>Activate Account</ng-template>
+      </button>
+    </form>
+  </div>
+
+  <p class="help-text">Already activated? <a routerLink="/login">Sign in here</a></p>
+</div>

--- a/frontend/src/app/features/auth/activate-account/activate-account.component.scss
+++ b/frontend/src/app/features/auth/activate-account/activate-account.component.scss
@@ -1,0 +1,176 @@
+:host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg-cream);
+  color: var(--text-dark);
+  padding: 40px 20px;
+}
+
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  padding: 48px;
+  box-shadow: var(--shadow-md);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-medium);
+  text-decoration: none;
+  margin-bottom: 32px;
+  transition: color 0.2s;
+
+  &:hover {
+    color: var(--primary);
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+.icon-wrapper {
+  width: 72px;
+  height: 72px;
+  background: linear-gradient(135deg, rgba(91, 76, 219, 0.1) 0%, rgba(91, 76, 219, 0.05) 100%);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 28px;
+
+  svg {
+    width: 32px;
+    height: 32px;
+    color: var(--primary);
+  }
+}
+
+.card-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--text-dark);
+  margin-bottom: 12px;
+  letter-spacing: -0.5px;
+}
+
+.card-description {
+  font-size: 15px;
+  color: var(--text-light);
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+
+.alert {
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 28px;
+  font-size: 14px;
+  line-height: 1.5;
+
+  svg {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  &.alert-error {
+    background: rgba(220, 53, 69, 0.1);
+    border: 1px solid rgba(220, 53, 69, 0.3);
+    color: #dc3545;
+
+    svg {
+      color: #dc3545;
+    }
+  }
+
+  &.alert-success {
+    background: rgba(40, 167, 69, 0.1);
+    border: 1px solid rgba(40, 167, 69, 0.3);
+    color: #28a745;
+
+    svg {
+      color: #28a745;
+    }
+  }
+}
+
+.btn-primary {
+  width: 100%;
+  padding: 18px 32px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.3s;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.loading-spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: var(--white);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.help-text {
+  text-align: center;
+  margin-top: 24px;
+  font-size: 14px;
+  color: var(--text-light);
+
+  a {
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 500;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/frontend/src/app/features/auth/activate-account/activate-account.component.ts
+++ b/frontend/src/app/features/auth/activate-account/activate-account.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivateAccountService } from '../services/activate-account.service';
+
+@Component({
+  selector: 'app-activate-account',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './activate-account.component.html',
+  styleUrls: ['./activate-account.component.scss'],
+})
+export class ActivateAccountComponent implements OnInit {
+  token: string | null = null;
+  loading = false;
+  isSubmitting = false;
+  error: string | null = null;
+  success = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private activateService: ActivateAccountService,
+  ) {}
+
+  ngOnInit(): void {
+    this.token = this.route.snapshot.paramMap.get('token');
+    console.log('Token from URL:', this.token);
+    if (!this.token) {
+      this.error = 'Invalid activation link.';
+    }
+  }
+
+  onSubmit(): void {
+    console.log('onSubmit called, token:', this.token);
+    if (!this.token) {
+      this.error = 'Invalid activation link.';
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.error = null;
+
+    this.activateService.activate(this.token).subscribe({
+      next: () => {
+        console.log('Activation successful');
+        this.success = true;
+        this.isSubmitting = false;
+        setTimeout(() => {
+          this.router.navigate(['/login']);
+        }, 2000);
+      },
+      error: (err) => {
+        console.error('Activation error:', err);
+        this.error = 'Account activation failed. Please try again or contact support.';
+        this.isSubmitting = false;
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/auth/activate-account/activate-account.component.ts
+++ b/frontend/src/app/features/auth/activate-account/activate-account.component.ts
@@ -26,14 +26,12 @@ export class ActivateAccountComponent implements OnInit {
 
   ngOnInit(): void {
     this.token = this.route.snapshot.paramMap.get('token');
-    console.log('Token from URL:', this.token);
     if (!this.token) {
       this.error = 'Invalid activation link.';
     }
   }
 
   onSubmit(): void {
-    console.log('onSubmit called, token:', this.token);
     if (!this.token) {
       this.error = 'Invalid activation link.';
       return;
@@ -44,7 +42,6 @@ export class ActivateAccountComponent implements OnInit {
 
     this.activateService.activate(this.token).subscribe({
       next: () => {
-        console.log('Activation successful');
         this.success = true;
         this.isSubmitting = false;
         setTimeout(() => {
@@ -52,7 +49,6 @@ export class ActivateAccountComponent implements OnInit {
         }, 2000);
       },
       error: (err) => {
-        console.error('Activation error:', err);
         this.error = 'Account activation failed. Please try again or contact support.';
         this.isSubmitting = false;
       },

--- a/frontend/src/app/features/auth/services/activate-account.service.ts
+++ b/frontend/src/app/features/auth/services/activate-account.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ActivateAccountService {
+  constructor(private http: HttpClient) {}
+
+  activate(token: string): Observable<any> {
+    return this.http.get(`${environment.apiBaseUrl}/passengers/activate/${token}`);
+  }
+}

--- a/frontend/src/app/features/auth/services/activate-account.service.ts
+++ b/frontend/src/app/features/auth/services/activate-account.service.ts
@@ -9,7 +9,7 @@ import { environment } from '../../../../environments/environment';
 export class ActivateAccountService {
   constructor(private http: HttpClient) {}
 
-  activate(token: string): Observable<any> {
-    return this.http.get(`${environment.apiBaseUrl}/passengers/activate/${token}`);
+  activate(token: string): Observable<void> {
+    return this.http.get<void>(`${environment.apiBaseUrl}/passengers/activate/${token}`);
   }
 }


### PR DESCRIPTION
Closes #83 

This pull request introduces a complete account activation flow to the frontend application, allowing users to activate their accounts via a tokenized link. The implementation includes a new route, a standalone Angular component for activation, supporting service logic, and associated UI/UX styling.

### Account Activation Feature

* Added a new route `/activate/:token` to handle account activation links, loading the new `ActivateAccountComponent` when accessed.
* Implemented `ActivateAccountComponent` with logic to read the activation token from the URL, display activation status, handle form submission, and redirect to login on success.
* Created `ActivateAccountService` to interact with the backend activation endpoint using the provided token.

### UI/UX Enhancements

* Developed a user-friendly activation page in `activate-account.component.html`, including error/success alerts, loading states, and navigation links.
* Added custom styles in `activate-account.component.scss` for a polished and responsive activation experience, including card layout, button styling, and alert visuals.