### PR TITLE
[BE 26] feat: backend panic event flow

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/controller/PanicController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/PanicController.java
@@ -1,11 +1,9 @@
 package com.ftn.drumigo.controller;
 
 import com.ftn.drumigo.domain.PanicEvent;
-import com.ftn.drumigo.dto.PanicCreateRequest;
 import com.ftn.drumigo.dto.PanicEventResponse;
 import com.ftn.drumigo.mapper.PanicEventMapper;
 import com.ftn.drumigo.service.PanicService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api")
@@ -23,12 +23,12 @@ public class PanicController {
     private final PanicEventMapper panicEventMapper;
     
     @PostMapping("/rides/{rideId}/panic")
-    public ResponseEntity<PanicEventResponse> createPanic(
+    public ResponseEntity<Void> createPanic(
             @PathVariable Long rideId,
-            @RequestParam Long userId,
-            @Valid @RequestBody PanicCreateRequest request) {
-        PanicEvent panicEvent = panicService.create(rideId, userId, request);
-        return ResponseEntity.status(201).body(panicEventMapper.toResponse(panicEvent));
+            Principal principal
+            ) {
+        panicService.create(rideId, principal.getName());
+        return ResponseEntity.status(201).build();
     }
     
     @GetMapping("/panic-events")
@@ -49,4 +49,3 @@ public class PanicController {
         return ResponseEntity.ok(responses);
     }
 }
-

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/PanicEvent.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/PanicEvent.java
@@ -30,5 +30,8 @@ public class PanicEvent {
     
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
+
+    @Column(name = "reason")
+    private String reason;
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/PanicEvent.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/PanicEvent.java
@@ -28,9 +28,6 @@ public class PanicEvent {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
     
-    @Column(length = 500)
-    private String reason;
-    
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/PanicCreateRequest.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/PanicCreateRequest.java
@@ -1,6 +1,0 @@
-package com.ftn.drumigo.dto;
-
-public record PanicCreateRequest(
-    String reason
-) {}
-

--- a/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
@@ -44,7 +44,7 @@ public class PanicService {
         }
         
         User user = userRepository.findByEmail(email)
-            .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + email));
+            .orElseThrow(() -> new ResourceNotFoundException("User not found with email: " + email));
         
         // Create panic event
         PanicEvent panicEvent = new PanicEvent();

--- a/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
@@ -7,7 +7,6 @@ import com.ftn.drumigo.domain.Ride;
 import com.ftn.drumigo.domain.User;
 import com.ftn.drumigo.domain.enums.NotificationType;
 import com.ftn.drumigo.domain.enums.RideStatus;
-import com.ftn.drumigo.dto.PanicCreateRequest;
 import com.ftn.drumigo.exception.BadRequestException;
 import com.ftn.drumigo.exception.ResourceNotFoundException;
 import com.ftn.drumigo.repository.AdminRepository;
@@ -35,7 +34,7 @@ public class PanicService {
     private final AdminRepository adminRepository;
     private final NotificationRepository notificationRepository;
     
-    public PanicEvent create(Long rideId, Long userId, PanicCreateRequest request) {
+    public void create(Long rideId, String email) {
         Ride ride = rideRepository.findById(rideId)
             .orElseThrow(() -> new ResourceNotFoundException("Ride not found with id: " + rideId));
         
@@ -44,30 +43,18 @@ public class PanicService {
             throw new BadRequestException("Panic can only be triggered for ACTIVE rides. Current status: " + ride.getStatus());
         }
         
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+        User user = userRepository.findByEmail(email)
+            .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + email));
         
         // Create panic event
         PanicEvent panicEvent = new PanicEvent();
         panicEvent.setRide(ride);
         panicEvent.setUser(user);
-        panicEvent.setReason(request.reason());
         panicEvent.setCreatedAt(Instant.now());
         
         panicEvent = panicEventRepository.save(panicEvent);
         
-        // Create notification for all admins (spec 2.6.3)
-        List<Admin> admins = adminRepository.findAll();
-        for (Admin admin : admins) {
-            Notification notification = new Notification();
-            notification.setUser(admin);
-            notification.setRide(ride);
-            notification.setType(NotificationType.PANIC_ALERT);
-            notification.setMessage("Panic alert: Ride #" + ride.getId() + " - " + request.reason());
-            notificationRepository.save(notification);
-        }
-        
-        return panicEvent;
+        //TODO: Send admin notifications
     }
     
     public Page<PanicEvent> getAll(Pageable pageable) {


### PR DESCRIPTION
Closes #96

This pull request refactors the panic event creation flow to simplify the API and data model by removing the "reason" field from panic events, streamlining the controller and service logic, and switching user identification to use the authenticated principal's email instead of a user ID parameter.

**API and Controller Changes:**
- The `createPanic` endpoint now uses the authenticated user's email (via `Principal`) rather than requiring a `userId` and request body, and it no longer returns a response body.
- The `PanicCreateRequest` DTO and all related validation/imports have been removed. [[1]](diffhunk://#diff-cc2ab5989e7aed518b527a1ba9dc3a41cd7eab0dd69bcf28b33ab582932c746eL1-L6) [[2]](diffhunk://#diff-cf8e0e19fd20ba732a89c892c47a68d1ac4cd042dd973a26c787149d0859d1a1L4-L8) [[3]](diffhunk://#diff-1fbc2f4475676cac21e11d00b9fa5dcb5b0e7543b0b0a1cd5a995d6543cdfabfL10)

**Domain and Data Model Changes:**
- The `reason` field has been removed from the `PanicEvent` entity, so panic events no longer store a textual reason.

**Service Layer Changes:**
- The `PanicService.create` method now accepts a ride ID and user email (from the principal), instead of a user ID and a request object, and no longer sets or uses a reason. [[1]](diffhunk://#diff-1fbc2f4475676cac21e11d00b9fa5dcb5b0e7543b0b0a1cd5a995d6543cdfabfL38-R37) [[2]](diffhunk://#diff-1fbc2f4475676cac21e11d00b9fa5dcb5b0e7543b0b0a1cd5a995d6543cdfabfL47-R57)
- The logic for sending notifications to admins has been removed and replaced with a TODO comment, pending future implementation.