### PR TITLE
[BE 16] feat: vehicle location back integration

### DIFF
--- a/drumigo/h2_scripts/active_vehicles_display/active_vehicles_display.sql
+++ b/drumigo/h2_scripts/active_vehicles_display/active_vehicles_display.sql
@@ -1,0 +1,252 @@
+-- Test data for active vehicles display feature (spec 2.1.1).
+-- Creates 10 drivers with vehicles in various states:
+-- - 8 active drivers (activeDriver=true) - should appear on map
+--   - 4 available vehicles (free - green markers)
+--   - 4 busy vehicles (on ride - red markers)
+-- - 2 inactive drivers (activeDriver=false) - should NOT appear on map
+
+-- IDs used: 8001-8012 for users, 8001-8010 for vehicles
+
+-- ============================================
+-- CLEANUP: Remove previous active vehicles test data
+-- ============================================
+DELETE FROM vehicles WHERE id BETWEEN 8001 AND 8010;
+DELETE FROM drivers WHERE user_id BETWEEN 8001 AND 8012;
+DELETE FROM users WHERE id BETWEEN 8001 AND 8012;
+
+-- ============================================
+-- SETUP: Ensure vehicle types exist
+-- ============================================
+MERGE INTO vehicle_types (name, start_price, price_per_km)
+KEY (name)
+VALUES ('STANDARD', 200.00, 50.00);
+
+MERGE INTO vehicle_types (name, start_price, price_per_km)
+KEY (name)
+VALUES ('LUXURY', 400.00, 80.00);
+
+MERGE INTO vehicle_types (name, start_price, price_per_km)
+KEY (name)
+VALUES ('VAN', 300.00, 60.00);
+
+-- ============================================
+-- ACTIVE DRIVERS WITH AVAILABLE VEHICLES (Free - Green markers)
+-- These should appear on the map with green markers
+-- ============================================
+
+-- Driver 1: Active, Available (City Center)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8001, 'Marko', 'Petrovic', 'marko.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Bulevar Oslobodjenja 50', '+381 64 800 0001', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8001, 'LIC-8001', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8001, 8001, (SELECT id FROM vehicle_types WHERE name = 'STANDARD'),
+    'Toyota Corolla', 'NS-800-AA', 4, FALSE, TRUE, 45.2671, 19.8335, TRUE
+);
+
+-- Driver 2: Active, Available (Liman area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8002, 'Ana', 'Jovanovic', 'ana.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Liman 4', '+381 64 800 0002', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8002, 'LIC-8002', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8002, 8002, (SELECT id FROM vehicle_types WHERE name = 'LUXURY'),
+    'Mercedes-Benz E-Class', 'NS-800-BB', 4, TRUE, TRUE, 45.2556, 19.8447, TRUE
+);
+
+-- Driver 3: Active, Available (Detelinara area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8003, 'Milica', 'Stojanovic', 'milica.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Detelinara 15', '+381 64 800 0003', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8003, 'LIC-8003', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8003, 8003, (SELECT id FROM vehicle_types WHERE name = 'VAN'),
+    'Ford Transit', 'NS-800-CC', 8, TRUE, TRUE, 45.2805, 19.8203, TRUE
+);
+
+-- Driver 4: Active, Available (Telep area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8004, 'Luka', 'Djordjevic', 'luka.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Telep 22', '+381 64 800 0004', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8004, 'LIC-8004', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8004, 8004, (SELECT id FROM vehicle_types WHERE name = 'STANDARD'),
+    'Renault Clio', 'NS-800-DD', 4, FALSE, FALSE, 45.2598, 19.8124, TRUE
+);
+
+-- ============================================
+-- ACTIVE DRIVERS WITH BUSY VEHICLES (On ride - Red markers)
+-- These should appear on the map with red markers
+-- ============================================
+
+-- Driver 5: Active, Busy (Petrovaradin)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8005, 'Stefan', 'Nikolic', 'stefan.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Petrovaradin', '+381 64 800 0005', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8005, 'LIC-8005', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8005, 8005, (SELECT id FROM vehicle_types WHERE name = 'STANDARD'),
+    'Volkswagen Golf', 'NS-800-EE', 4, FALSE, FALSE, 45.2517, 19.8369, FALSE
+);
+
+-- Driver 6: Active, Busy (Grbavica area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8006, 'Sara', 'Popovic', 'sara.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Grbavica', '+381 64 800 0006', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8006, 'LIC-8006', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8006, 8006, (SELECT id FROM vehicle_types WHERE name = 'LUXURY'),
+    'BMW 5 Series', 'NS-800-FF', 4, TRUE, FALSE, 45.2734, 19.8578, FALSE
+);
+
+-- Driver 7: Active, Busy (Near Danube)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8007, 'Nikola', 'Radovic', 'nikola.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Kej, Novi Sad', '+381 64 800 0007', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8007, 'LIC-8007', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8007, 8007, (SELECT id FROM vehicle_types WHERE name = 'STANDARD'),
+    'Opel Astra', 'NS-800-GG', 4, FALSE, TRUE, 45.2487, 19.8291, FALSE
+);
+
+-- Driver 8: Active, Busy (Rotkvarija area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8008, 'Jovana', 'Ilic', 'jovana.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Rotkvarija', '+381 64 800 0008', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8008, 'LIC-8008', TRUE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8008, 8008, (SELECT id FROM vehicle_types WHERE name = 'VAN'),
+    'Mercedes Sprinter', 'NS-800-HH', 8, TRUE, TRUE, 45.2645, 19.8489, FALSE
+);
+
+-- ============================================
+-- INACTIVE DRIVERS (activeDriver=false)
+-- These should NOT appear on the map
+-- ============================================
+
+-- Driver 9: INACTIVE, Available vehicle (Sremska Kamenica)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8009, 'Jovan', 'Markovic', 'jovan.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Sremska Kamenica', '+381 64 800 0009', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8009, 'LIC-8009', FALSE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8009, 8009, (SELECT id FROM vehicle_types WHERE name = 'STANDARD'),
+    'Peugeot 308', 'NS-800-II', 4, FALSE, TRUE, 45.2432, 19.8015, TRUE
+);
+
+-- Driver 10: INACTIVE, Available vehicle (City center area)
+MERGE INTO users (
+    id, name, surname, email, password_hash, address, phone,
+    profile_picture_url, blocked, role, active, created_at, updated_at, dtype
+) KEY (id) VALUES (
+    8010, 'Marija', 'Tomic', 'marija.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    'Centar', '+381 64 800 0010', NULL, FALSE, 'DRIVER', TRUE,
+    CURRENT_TIMESTAMP(), CURRENT_TIMESTAMP(), 'Driver'
+);
+MERGE INTO drivers (user_id, license_number, active_driver, last_state_change_at)
+KEY (user_id) VALUES (8010, 'LIC-8010', FALSE, CURRENT_TIMESTAMP());
+MERGE INTO vehicles (
+    id, driver_id, vehicle_type_id, model, license_plate, num_seats,
+    baby_friendly, pet_friendly, current_lat, current_lng, available
+) KEY (id) VALUES (
+    8010, 8010, (SELECT id FROM vehicle_types WHERE name = 'LUXURY'),
+    'Audi A6', 'NS-800-JJ', 4, TRUE, TRUE, 45.2712, 19.8415, TRUE
+);
+
+-- ============================================
+-- VERIFICATION QUERIES
+-- ============================================
+-- Run these to verify the data is correct:
+
+-- Should return 8 vehicles (from active drivers)
+-- SELECT v.id, v.model, v.license_plate, v.available, d.active_driver 
+-- FROM vehicles v 
+-- JOIN drivers d ON v.driver_id = d.user_id 
+-- WHERE d.active_driver = TRUE AND v.id BETWEEN 8001 AND 8010;
+
+-- Should return 0 vehicles (from inactive drivers - these shouldn't appear on map)
+-- SELECT v.id, v.model, v.license_plate, v.available, d.active_driver 
+-- FROM vehicles v 
+-- JOIN drivers d ON v.driver_id = d.user_id 
+-- WHERE d.active_driver = FALSE AND v.id BETWEEN 8001 AND 8010;

--- a/drumigo/h2_scripts/active_vehicles_display/active_vehicles_display_instructions.txt
+++ b/drumigo/h2_scripts/active_vehicles_display/active_vehicles_display_instructions.txt
@@ -1,0 +1,120 @@
+ACTIVE VEHICLES DISPLAY TEST DATA - Usage Instructions
+======================================================
+
+This script creates test data for the active vehicles display feature (spec 2.1.1).
+It includes various vehicle/driver scenarios to test the landing page map display.
+
+HOW TO USE
+----------
+1. Start the Spring Boot backend application
+2. Open H2 Console at: http://localhost:8080/h2-console
+3. Connect with the settings from application-dev.properties
+4. Paste and run the entire active_vehicles_display.sql script
+5. Open the frontend landing page at: http://localhost:4200
+
+TEST SCENARIOS CREATED
+----------------------
+| Driver ID | Vehicle ID | Active Driver | Available | Expected Marker Color |
+|-----------|------------|---------------|-----------|----------------------|
+| 8001      | 8001       | TRUE          | TRUE      | GREEN (Available)    |
+| 8002      | 8002       | TRUE          | TRUE      | GREEN (Available)    |
+| 8003      | 8003       | TRUE          | TRUE      | GREEN (Available)    |
+| 8004      | 8004       | TRUE          | TRUE      | GREEN (Available)    |
+| 8005      | 8005       | TRUE          | FALSE     | RED (On a ride)      |
+| 8006      | 8006       | TRUE          | FALSE     | RED (On a ride)      |
+| 8007      | 8007       | TRUE          | FALSE     | RED (On a ride)      |
+| 8008      | 8008       | TRUE          | FALSE     | RED (On a ride)      |
+| 8009      | 8009       | FALSE         | TRUE      | NOT SHOWN            |
+| 8010      | 8010       | FALSE         | TRUE      | NOT SHOWN            |
+
+VEHICLE LOCATIONS (Novi Sad area)
+---------------------------------
+- 8001: City Center (45.2671, 19.8335) - Toyota Corolla, STANDARD
+- 8002: Liman area (45.2556, 19.8447) - Mercedes E-Class, LUXURY
+- 8003: Detelinara (45.2805, 19.8203) - Ford Transit, VAN
+- 8004: Telep (45.2598, 19.8124) - Renault Clio, STANDARD
+- 8005: Petrovaradin (45.2517, 19.8369) - VW Golf, STANDARD
+- 8006: Grbavica (45.2734, 19.8578) - BMW 5 Series, LUXURY
+- 8007: Near Danube (45.2487, 19.8291) - Opel Astra, STANDARD
+- 8008: Rotkvarija (45.2645, 19.8489) - Mercedes Sprinter, VAN
+- 8009: Sremska Kamenica (NOT SHOWN) - Peugeot 308, STANDARD
+- 8010: City center area (NOT SHOWN) - Audi A6, LUXURY
+
+TESTING THE ACTIVE VEHICLES DISPLAY FEATURE
+-------------------------------------------
+1. Open the landing page: http://localhost:4200
+2. Verify the map shows exactly 8 vehicle markers:
+   - 4 green markers (available vehicles from active drivers)
+   - 4 red markers (busy vehicles from active drivers)
+3. Verify that vehicles from inactive drivers (8009, 8010) do NOT appear
+
+TESTING MARKER POPUPS
+---------------------
+1. Click on any green marker:
+   - Should show driver name (e.g., "Marko Petrovic")
+   - Should show "Available" status
+2. Click on any red marker:
+   - Should show driver name
+   - Should show "On a ride" status
+
+TESTING VEHICLE TYPES
+---------------------
+The test data includes various vehicle types for visual verification:
+- STANDARD: Toyota Corolla, VW Golf, Renault Clio, Opel Astra, Peugeot 308
+- LUXURY: Mercedes E-Class, BMW 5 Series, Audi A6
+- VAN: Ford Transit, Mercedes Sprinter
+
+TESTING POLLING (REAL-TIME UPDATES)
+-----------------------------------
+1. Keep the landing page open
+2. In H2 Console, toggle a vehicle's availability:
+   UPDATE vehicles SET available = FALSE WHERE id = 8001;
+3. Wait up to 10 seconds for the next poll
+4. The marker for vehicle 8001 should change from green to red
+5. To revert: UPDATE vehicles SET available = TRUE WHERE id = 8001;
+
+TESTING DRIVER ACTIVATION/DEACTIVATION
+--------------------------------------
+1. In H2 Console, deactivate a driver:
+   UPDATE drivers SET active_driver = FALSE WHERE user_id = 8001;
+2. Wait up to 10 seconds for the next poll
+3. The marker for vehicle 8001 should disappear from the map
+4. To revert: UPDATE drivers SET active_driver = TRUE WHERE user_id = 8001;
+
+API ENDPOINT USED
+-----------------
+GET /api/vehicles/active - Returns all vehicles from active drivers (public endpoint)
+
+EXAMPLE API RESPONSE
+--------------------
+[
+  {
+    "id": 8001,
+    "driverId": 8001,
+    "driverName": "Marko",
+    "driverSurname": "Petrovic",
+    "vehicleTypeId": 1,
+    "vehicleTypeName": "STANDARD",
+    "model": "Toyota Corolla",
+    "licensePlate": "NS-800-AA",
+    "numSeats": 4,
+    "babyFriendly": false,
+    "petFriendly": true,
+    "currentLat": 45.2671,
+    "currentLng": 19.8335,
+    "available": true
+  },
+  ...
+]
+
+CLEANUP
+-------
+To remove test data, run the DELETE statements at the top of the SQL script,
+or simply rerun the entire script (it cleans up before inserting).
+
+NOTES
+-----
+- All drivers use password "Test1234" (SHA-256 hashed)
+- Polling interval is 10 seconds
+- Vehicle positions are spread across different areas of Novi Sad
+- The endpoint /api/vehicles/active is public (no authentication required)

--- a/drumigo/src/main/java/com/ftn/drumigo/config/SecurityConfig.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/auth/**",
                     "/api/rides/estimate",
+                    "/api/vehicles/active",
                     "/api/drivers/*/rides/upcoming",
                     "/api/users/*/notifications",
                     "/h2-console/**",

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
@@ -2,6 +2,7 @@ package com.ftn.drumigo.repository;
 
 import com.ftn.drumigo.domain.Vehicle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,5 +12,12 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     List<Vehicle> findByAvailableTrue();
     boolean existsByLicensePlate(String licensePlate);
     java.util.Optional<Vehicle> findByDriver(com.ftn.drumigo.domain.Driver driver);
+    
+    /**
+     * Find all vehicles belonging to active drivers (drivers currently working).
+     * Returns both available and busy vehicles for display on the landing page map.
+     */
+    @Query("SELECT v FROM Vehicle v WHERE v.driver.activeDriver = true")
+    List<Vehicle> findByDriverActiveDriverTrue();
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
@@ -26,8 +26,13 @@ public class VehicleService {
     private final DriverRepository driverRepository;
     private final VehicleTypeRepository vehicleTypeRepository;
     
+    /**
+     * Get all vehicles from active drivers for display on the landing page map.
+     * Returns both available (free) and busy (on ride) vehicles.
+     * Only vehicles from drivers with activeDriver=true are included.
+     */
     public List<Vehicle> getActiveVehicles() {
-        return vehicleRepository.findByAvailableTrue();
+        return vehicleRepository.findByDriverActiveDriverTrue();
     }
     
     public Vehicle getById(Long id) {

--- a/frontend/src/app/features/landing/landing-page/landing-page.component.ts
+++ b/frontend/src/app/features/landing/landing-page/landing-page.component.ts
@@ -1,10 +1,16 @@
 import { Component, signal, OnInit, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
+import { interval, switchMap, startWith, catchError, of } from 'rxjs';
 import { RideEstimatePanelComponent } from '../components/ride-estimate-panel/ride-estimate-panel.component';
 import { MapComponent, MapConfig } from '../../map/map.component';
 import { VehicleMockService } from '../../map/services/vehicle-mock.service';
-import { MapMarker, vehicleToMapMarker } from '../../map/models/vehicle.model';
+import { VehicleApiService } from '../../map/services/vehicle-api.service';
+import { MapMarker, vehicleToMapMarker, VehicleResponse } from '../../map/models/vehicle.model';
+import { environment } from '../../../../environments/environment';
+
+/** Polling interval for vehicle updates in milliseconds */
+const VEHICLE_POLLING_INTERVAL_MS = 10_000;
 
 @Component({
   selector: 'app-landing-page',
@@ -22,25 +28,54 @@ export class LandingPageComponent implements OnInit {
   };
 
   private destroyRef = inject(DestroyRef);
-  private vehicleService = inject(VehicleMockService);
+  private vehicleApiService = inject(VehicleApiService);
+  private vehicleMockService = inject(VehicleMockService);
 
   ngOnInit(): void {
-    this.loadVehicles();
+    this.startVehiclePolling();
   }
 
-  private loadVehicles(): void {
-    this.vehicleService
-      .getActiveVehicles()
-      .pipe(takeUntilDestroyed(this.destroyRef))
+  /**
+   * Starts polling for vehicle updates every VEHICLE_POLLING_INTERVAL_MS.
+   * Uses real API or mock service based on environment configuration.
+   * On error, keeps showing last known data and logs the error.
+   */
+  private startVehiclePolling(): void {
+    interval(VEHICLE_POLLING_INTERVAL_MS)
+      .pipe(
+        startWith(0), // Emit immediately on subscribe
+        switchMap(() => this.fetchVehicles()),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe({
         next: (vehicles) => {
-          const markers = vehicles.map((v) => vehicleToMapMarker(v));
-          this.vehicleMarkers.set(markers);
+          if (vehicles.length > 0 || this.vehicleMarkers().length === 0) {
+            const markers = vehicles.map((v) => vehicleToMapMarker(v));
+            this.vehicleMarkers.set(markers);
+          }
+          // If API returns empty but we have markers, keep showing them
         },
         error: (error) => {
-          console.error('Error loading active vehicles:', error);
+          console.error('Error in vehicle polling:', error);
         },
       });
+  }
+
+  /**
+   * Fetches vehicles from API or mock service based on environment config.
+   * Catches errors and returns empty array to prevent breaking the polling stream.
+   */
+  private fetchVehicles() {
+    const source$ = environment.useMockVehicles
+      ? this.vehicleMockService.getActiveVehicles()
+      : this.vehicleApiService.getActiveVehicles();
+
+    return source$.pipe(
+      catchError((error) => {
+        console.error('Error fetching active vehicles:', error);
+        return of([] as VehicleResponse[]);
+      })
+    );
   }
 
   openPanel(): void {

--- a/frontend/src/app/features/map/services/vehicle-api.service.ts
+++ b/frontend/src/app/features/map/services/vehicle-api.service.ts
@@ -1,0 +1,25 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { VehicleResponse } from '../models/vehicle.model';
+
+/**
+ * Service for fetching vehicle data from the backend API.
+ * Used for displaying active vehicles on the landing page map.
+ */
+@Injectable({ providedIn: 'root' })
+export class VehicleApiService {
+  private readonly http = inject(HttpClient);
+
+  /**
+   * Fetches all active vehicles (vehicles from drivers with activeDriver=true).
+   * Returns both available (free) and busy (on ride) vehicles.
+   * This endpoint is public and doesn't require authentication.
+   */
+  getActiveVehicles(): Observable<VehicleResponse[]> {
+    return this.http.get<VehicleResponse[]>(
+      `${environment.apiBaseUrl}/vehicles/active`
+    );
+  }
+}

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -2,4 +2,5 @@ export const environment = {
   production: false,
   mapboxToken: 'MAPBOX_API_KEY', // Placeholder - create environment.dev.ts with your real API key
   apiBaseUrl: 'http://localhost:8080/api', // Your backend domain
+  useMockVehicles: false, // Set to true to use mock data instead of real API
 };


### PR DESCRIPTION
This pull request adds comprehensive test data and usage instructions for key backend features in the Drumigo project, focusing on the active vehicles display, driver ride history, and ride completion flows. The changes introduce SQL scripts to set up realistic test scenarios and detailed instruction files to guide developers and testers through the process of using and verifying these features.

**Test Data and Instructions for Feature Verification:**

*Active Vehicles Display:*
- Added `active_vehicles_display.sql` to create 10 drivers with various vehicle states, ensuring 8 active drivers (with 4 available and 4 busy vehicles) and 2 inactive drivers for realistic map display testing. Includes cleanup and verification queries.
- Added `active_vehicles_display_instructions.txt` with step-by-step instructions, scenario tables, marker color expectations, location details, and API usage for thorough manual and automated testing.

*Driver Ride History:*
- Added `driver_ride_history_instructions.txt` providing detailed steps for setting up and testing the driver ride history feature, including test credentials, ride scenarios, pagination, date filtering, and API endpoint examples.

*Ride Completion:*
- Added `ride_completion.sql` to set up reusable test data for ride completion, including driver, passenger, vehicle, locations, and an active ride, along with cleanup logic.
- Added `ride_completion_instuctions.txt` with concise instructions for running the test scenario, logging in, and verifying the ride completion flow, along with notes on endpoint security and backend reset behavior.