### PR TITLE
[FE 42] feat: use API call on panic component

### DIFF
--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -42,6 +42,8 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild(MapComponent) mapComponent!: MapComponent;
   @ViewChild(InconsistencyReportComponent)
   inconsistencyReportComponent?: InconsistencyReportComponent;
+  @ViewChild(PanicComponent)
+  panicComponent?: PanicComponent;
 
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -414,9 +416,21 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onPanicActivated(): void {
-    console.log('PANIC ACTIVATED - Emergency services notified');
-    // In real app: Send emergency notification to backend
-    // This would trigger: emergency contacts, support team, location sharing
+    console.log('PANIC ACTIVATED - sending event to backend');
+    const rideId = Number(this.rideId());
+    if (!rideId) return;
+
+    this.rideApiService.createPanic(rideId).subscribe({
+      next: (response) => {
+        console.log('Panic event created:', response);
+        this.closePanicModal();
+        this.panicComponent?.resetPanic();
+      },
+      error: (error) => {
+        console.error('Failed to create panic event:', error);
+        //TODO: add error message
+      },
+    });
   }
 
   onContactSupport(): void {

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -418,7 +418,12 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
   onPanicActivated(): void {
     console.log('PANIC ACTIVATED - sending event to backend');
     const rideId = Number(this.rideId());
-    if (!rideId) return;
+    if (!rideId) {
+      console.error('Ride id is missing or invalid, cannot activate panic');
+      this.closePanicModal();
+      this.panicComponent?.resetPanic();
+      return;
+    }
 
     this.rideApiService.createPanic(rideId).subscribe({
       next: () => {

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -421,8 +421,8 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
     if (!rideId) return;
 
     this.rideApiService.createPanic(rideId).subscribe({
-      next: (response) => {
-        console.log('Panic event created:', response);
+      next: () => {
+        console.log('Panic event created for ride:', rideId);
         this.closePanicModal();
         this.panicComponent?.resetPanic();
       },

--- a/frontend/src/app/features/ride-tracking/services/ride-api.service.ts
+++ b/frontend/src/app/features/ride-tracking/services/ride-api.service.ts
@@ -19,10 +19,13 @@ export class RideApiService {
       .set('sort', 'scheduledFor,asc');
 
     return this.http
-      .get<PageResponse<RideResponseDto>>(
-        `${environment.apiBaseUrl}/drivers/${driverId}/rides/upcoming`,
-        { params },
-      )
+      .get<
+        PageResponse<RideResponseDto>
+      >(`${environment.apiBaseUrl}/drivers/${driverId}/rides/upcoming`, { params })
       .pipe(map((response) => response.content));
+  }
+
+  createPanic(rideId: number): Observable<void> {
+    return this.http.post<void>(`${environment.apiBaseUrl}/rides/${rideId}/panic`, {});
   }
 }


### PR DESCRIPTION
Closes #101 

This pull request adds backend integration for the panic feature in the ride tracking component. The changes ensure that when a panic event is triggered, it is now sent to the backend API, and the UI is updated accordingly.

**Panic feature integration:**

* Added a `@ViewChild` reference to `PanicComponent` in `RideTrackingComponent` to allow interaction with the panic modal.
* Updated the `onPanicActivated` method in `RideTrackingComponent` to call the new `createPanic` API method, handle the response, close the panic modal, and reset the panic state in the UI.

**API service enhancements:**

* Added a new `createPanic` method to `RideApiService` to send a POST request to the backend when a panic event is triggered.