### PR TITLE
refactor: Remove unused driver lookup from VehicleRepository and clea…

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
@@ -14,7 +14,6 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
 
     List<Vehicle> findByAvailableTrue();
     boolean existsByLicensePlate(String licensePlate);
-    java.util.Optional<Vehicle> findByDriver(com.ftn.drumigo.domain.Driver driver);
     
     /**
      * Find all vehicles belonging to active drivers (drivers currently working).

--- a/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
@@ -33,7 +33,6 @@ public class VehicleService {
      */
     public List<Vehicle> getActiveVehicles() {
         return vehicleRepository.findByDriverActiveDriverTrue();
-
     }
     
     public Vehicle getById(Long id) {

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -13,7 +13,6 @@ import { AuthService } from '../shared/services/auth.service';
   styleUrls: ['./layout.component.scss'],
 })
 export class LayoutComponent implements OnInit {
-
   private profileService = inject(ProfileApiService);
   private readonly authService = inject(AuthService);
 
@@ -29,43 +28,6 @@ export class LayoutComponent implements OnInit {
   }
 
   private loadUserFromToken(): void {
-
-    const token = sessionStorage.getItem('token');
-    if (token) {
-      try {
-        const payload = this.decodeJwtPayload(token);
-        const userId = payload.userId || payload.sub;
-        const role = payload.role;
-
-        // Fetch full profile including avatar
-        if (userId) {
-          this.profileService.getProfile(userId).subscribe({
-            next: (profile) => {
-              this.user = {
-                name: `${profile.firstName} ${profile.lastName}`,
-                initials: this.getInitials(`${profile.firstName} ${profile.lastName}`),
-                role: role === 'PASSENGER' ? 'Passenger' : role === 'DRIVER' ? 'Driver' : 'Admin',
-                type: role === 'PASSENGER' ? 'passenger' : role === 'DRIVER' ? 'driver' : 'admin',
-                avatarUrl: profile.avatarUrl,
-              };
-            },
-            error: (err) => {
-              console.error('Failed to load profile:', err);
-              // Fallback to basic info from token
-              this.user = {
-                name: payload.sub || 'User',
-                initials: this.getInitials(payload.sub || 'User'),
-                role: role === 'PASSENGER' ? 'Passenger' : role === 'DRIVER' ? 'Driver' : 'Admin',
-                type: role === 'PASSENGER' ? 'passenger' : role === 'DRIVER' ? 'driver' : 'admin',
-              };
-            },
-          });
-        }
-      } catch (error) {
-        console.error('Error decoding token:', error);
-      }
-    }
-  }
     const email = this.authService.getEmail();
     const role = this.authService.getRole();
     if (email && role) {


### PR DESCRIPTION
This pull request primarily simplifies and refactors how user information is loaded in the `LayoutComponent` on the frontend, and makes minor cleanup changes in the backend vehicle repository and service. The most significant update is the removal of direct JWT token parsing in favor of using the `AuthService` for retrieving user details.

Frontend user loading refactor:

* Simplified the `loadUserFromToken` method in `LayoutComponent` to use `AuthService` for retrieving the user's email and role, removing the previous logic that manually decoded the JWT token and fetched the user profile from the API.
* Removed an unnecessary blank line in the `LayoutComponent` class for minor code cleanup.

Backend code cleanup:

* Removed an unused method (`findByDriver`) from the `VehicleRepository` interface, improving code maintainability.
* Removed an unnecessary blank line in the `getActiveVehicles` method in `VehicleService` for code cleanliness.