### PR TITLE
[FE 43] feat: call API for stop ride component

### DIFF
--- a/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.html
+++ b/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.html
@@ -124,7 +124,14 @@
             </div>
             <div class="location-content">
               <div class="location-label">New drop-off location</div>
-              <div class="location-value">{{ stopInfo.currentLocation }}</div>
+              <div class="location-value">
+                <input
+                  class="stop-address-input"
+                  type="text"
+                  [value]="stopAddress()"
+                  (input)="stopAddress.set($any($event.target).value)"
+                />
+              </div>
             </div>
           </div>
 
@@ -158,22 +165,28 @@
           <button
             class="btn-secondary"
             (click)="onContinueRide()"
-            [disabled]="isStopping()"
+            [disabled]="submitting || isStopping()"
             type="button"
           >
             Continue ride
           </button>
-          <button class="btn-stop" (click)="onStopRide()" [disabled]="isStopping()" type="button">
-            @if (!isStopping()) {
+          <button
+            class="btn-stop"
+            (click)="onStopRide()"
+            [disabled]="submitting || isStopping()"
+            type="button"
+          >
+            <ng-container *ngIf="!submitting && !isStopping()">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
                 <rect x="6" y="4" width="4" height="16" />
                 <rect x="14" y="4" width="4" height="16" />
               </svg>
               <span>Confirm Stop</span>
-            } @else {
+            </ng-container>
+            <ng-container *ngIf="submitting || isStopping()">
               <div class="btn-spinner"></div>
               <span>Stopping...</span>
-            }
+            </ng-container>
           </button>
         </div>
       </div>

--- a/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.scss
+++ b/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.scss
@@ -146,7 +146,13 @@
   top: 28px;
   bottom: 28px;
   width: 2px;
-  background: repeating-linear-gradient(to bottom, var(--border) 0, var(--border) 4px, transparent 4px, transparent 8px);
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--border) 0,
+    var(--border) 4px,
+    transparent 4px,
+    transparent 8px
+  );
 }
 
 .route-label {
@@ -304,6 +310,30 @@
   font-size: 14px;
   font-weight: 600;
   color: var(--text-dark);
+}
+
+.stop-address-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-dark);
+  background: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: all 0.2s;
+  font-family: inherit;
+
+  &:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(91, 76, 219, 0.1);
+  }
+
+  &::placeholder {
+    color: var(--text-light);
+    font-weight: 500;
+  }
 }
 
 .fare-adjustment {

--- a/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.ts
+++ b/frontend/src/app/features/ride-tracking/components/driver/stop-ride/stop-ride.component.ts
@@ -24,18 +24,38 @@ export interface StopRideInfo {
   styleUrl: './stop-ride.component.scss',
 })
 export class StopRideComponent {
-  @Input() stopInfo: StopRideInfo | null = null;
-  @Output() stopRide = new EventEmitter<void>();
+  private _stopInfo: StopRideInfo | null = null;
+  @Input()
+  set stopInfo(v: StopRideInfo | null) {
+    this._stopInfo = v;
+    if (v) {
+      this.stopAddress.set(v.currentLocation ?? '');
+    }
+  }
+  get stopInfo(): StopRideInfo | null {
+    return this._stopInfo;
+  }
+
+  /** Emitted when driver confirms a stop. Payload: stop address string. */
+  @Output() confirmStop = new EventEmitter<string>();
   @Output() continueRide = new EventEmitter<void>();
+
+  /** Parent can bind to this to reflect submission state */
+  @Input() submitting = false;
 
   isStopping = signal(false);
 
+  stopAddress = signal('');
+
   onStopRide(): void {
+    // Use the editable address and emit to parent to perform the API call
+    const address = (this.stopAddress() || '').trim();
+    if (!address) {
+      // Basic guard; in real UI show validation error
+      return;
+    }
     this.isStopping.set(true);
-    // Simulate processing
-    setTimeout(() => {
-      this.stopRide.emit();
-    }, 500);
+    this.confirmStop.emit(address);
   }
 
   onContinueRide(): void {

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.html
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.html
@@ -141,7 +141,9 @@
                 </div>
                 <div class="summary-row">
                   <span class="label">Scheduled</span>
-                  <span class="value">{{ formatScheduledTime(nextRideSummary()!.scheduledFor) }}</span>
+                  <span class="value">{{
+                    formatScheduledTime(nextRideSummary()!.scheduledFor)
+                  }}</span>
                 </div>
               </div>
               <div class="post-ride-actions">
@@ -154,9 +156,7 @@
               </div>
             }
             @if (!nextRideSummary()) {
-              <p class="post-ride-text">
-                No upcoming scheduled rides were found.
-              </p>
+              <p class="post-ride-text">No upcoming scheduled rides were found.</p>
               <button class="btn-primary" type="button" (click)="navigateToUpcomingRides()">
                 View upcoming rides
               </button>
@@ -212,13 +212,13 @@
         <div class="stop-modal-body">
           <app-stop-ride
             [stopInfo]="stopRideInfo()"
-            (stopRide)="onStopRide()"
+            (confirmStop)="onConfirmStop($event)"
             (continueRide)="onContinueRide()"
+            [submitting]="stopLoading()"
           >
           </app-stop-ride>
         </div>
       </div>
     </div>
   }
-
 </div>

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -68,6 +68,8 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
   rideCompleted = signal<boolean>(false);
   endRideLoading = signal<boolean>(false);
   endRideError = signal<string | null>(null);
+  stopLoading = signal<boolean>(false);
+  stopError = signal<string | null>(null);
   upcomingRides = signal<RideResponseDto[]>([]);
 
   nextScheduledRide = computed(() => this.upcomingRides()[0] ?? null);
@@ -486,6 +488,51 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
         error: (error) => {
           console.error('Failed to end ride', error);
           this.endRideError.set('Failed to end ride. Please try again.');
+        },
+      });
+  }
+
+  onConfirmStop(stopAddress: string): void {
+    const rideId = Number(this.rideId());
+    if (!rideId) {
+      console.error('Ride id is missing or invalid, cannot stop ride');
+      return;
+    }
+
+    const loc = this.currentLocation();
+    if (!loc) {
+      console.error('Current location missing, cannot send stop coordinates');
+      this.stopError.set('Current location unknown');
+      return;
+    }
+
+    this.stopLoading.set(true);
+    this.stopError.set(null);
+
+    const request = {
+      stopAddress,
+      stopLat: loc.lat,
+      stopLng: loc.lng,
+    };
+
+    this.rideApiService
+      .stopRide(rideId, request)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.stopLoading.set(false)),
+      )
+      .subscribe({
+        next: (response) => {
+          console.log('Ride stopped successfully', response);
+          this.closeStopModal();
+          const driverId = this.activeRide()?.driver.id;
+          if (driverId) {
+            this.loadUpcomingRides(driverId);
+          }
+        },
+        error: (error) => {
+          console.error('Failed to stop ride', error);
+          this.stopError.set('Failed to stop ride. Please try again.');
         },
       });
   }

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -524,11 +524,17 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
       .subscribe({
         next: (response) => {
           console.log('Ride stopped successfully', response);
+          // Update active ride state with backend response and show post-ride UI
+          this.activeRide.set(response as unknown as ActiveRide);
+          this.rideCompleted.set(true);
           this.closeStopModal();
           const driverId = this.activeRide()?.driver.id;
           if (driverId) {
             this.loadUpcomingRides(driverId);
           }
+          // Refresh markers/view to reflect final location
+          this.updateMarkers();
+          this.updateMapView();
         },
         error: (error) => {
           console.error('Failed to stop ride', error);

--- a/frontend/src/app/features/ride-tracking/services/ride-api.service.ts
+++ b/frontend/src/app/features/ride-tracking/services/ride-api.service.ts
@@ -20,6 +20,13 @@ export interface RideInconsistencyCreateRequest {
   note: string;
 }
 
+/** Request body for stopping a ride (driver stops ride early) */
+export interface RideStopRequest {
+  stopAddress: string;
+  stopLat: number;
+  stopLng: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class RideApiService {
   private readonly http = inject(HttpClient);
@@ -43,6 +50,13 @@ export class RideApiService {
 
   createPanic(rideId: number): Observable<void> {
     return this.http.post<void>(`${environment.apiBaseUrl}/rides/${rideId}/panic`, {});
+  }
+
+  stopRide(rideId: number, request: RideStopRequest): Observable<RideResponseDto> {
+    return this.http.put<RideResponseDto>(
+      `${environment.apiBaseUrl}/rides/${rideId}/stop`,
+      request,
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #105 

This pull request introduces a significant improvement to the stop ride flow for drivers, allowing them to edit the stop address before confirming, and refactors the interaction between the stop ride modal and its parent component. It also adds new API integration for stopping a ride and improves button state handling and styling.

**Stop Ride Flow Improvements:**

* The stop ride modal now displays an editable input field for the stop address, allowing drivers to adjust the drop-off location before confirming the stop. The input is pre-filled with the current location and updates the internal state as the user types. (`stop-ride.component.html`, `stop-ride.component.ts`, `stop-ride.component.scss`) [[1]](diffhunk://#diff-a0bd08325fd7c935e65d9061051c477dfa2367e1f498009472c7aad3046a8a0dL127-R134) [[2]](diffhunk://#diff-75da854e12b9ae8801f912c4a7eb5e7016d4dcfaa1913aab3cf1f37846604473L27-R58) [[3]](diffhunk://#diff-02d80f14b9513a1ad543787293488dc1fd5f5603a0a04d4ed14c2d9b991674beR315-R338)
* The confirm stop action now emits the edited stop address to the parent, which then performs the API call to stop the ride, passing both the address and current coordinates. (`stop-ride.component.ts`, `ride-tracking.component.html`, `ride-tracking.component.ts`) [[1]](diffhunk://#diff-75da854e12b9ae8801f912c4a7eb5e7016d4dcfaa1913aab3cf1f37846604473L27-R58) [[2]](diffhunk://#diff-3799c8893a032a068f1db5dfbe97f64a80955777957eb84fee195f194e01c9edL215-L223) [[3]](diffhunk://#diff-d76d61db4d5e4a6501cfc16b5d16853de701214535d9badda771215515c8fe85R495-R539)
* Introduces a new `submitting` input and improved button state logic to prevent duplicate submissions and provide user feedback during the stop process. (`stop-ride.component.html`, `stop-ride.component.ts`, `ride-tracking.component.html`, `ride-tracking.component.ts`) [[1]](diffhunk://#diff-a0bd08325fd7c935e65d9061051c477dfa2367e1f498009472c7aad3046a8a0dL161-R189) [[2]](diffhunk://#diff-75da854e12b9ae8801f912c4a7eb5e7016d4dcfaa1913aab3cf1f37846604473L27-R58) [[3]](diffhunk://#diff-3799c8893a032a068f1db5dfbe97f64a80955777957eb84fee195f194e01c9edL215-L223) [[4]](diffhunk://#diff-d76d61db4d5e4a6501cfc16b5d16853de701214535d9badda771215515c8fe85R71-R72)

**API Integration:**

* Adds a new `RideStopRequest` interface and a `stopRide` method in `RideApiService` to call the backend endpoint for stopping a ride, sending the stop address and coordinates. (`ride-api.service.ts`) [[1]](diffhunk://#diff-7bfabe7cde297ede19b4605770681af56bed20c04ffbd0d2f2229e9634c1c3c1R23-R29) [[2]](diffhunk://#diff-7bfabe7cde297ede19b4605770681af56bed20c04ffbd0d2f2229e9634c1c3c1R55-R61)

**Styling and Minor Cleanups:**

* Adds new styles for the stop address input and improves code formatting for readability in the ride tracking components. (`stop-ride.component.scss`, `ride-tracking.component.html`) [[1]](diffhunk://#diff-02d80f14b9513a1ad543787293488dc1fd5f5603a0a04d4ed14c2d9b991674beR315-R338) [[2]](diffhunk://#diff-3799c8893a032a068f1db5dfbe97f64a80955777957eb84fee195f194e01c9edL144-R146) [[3]](diffhunk://#diff-3799c8893a032a068f1db5dfbe97f64a80955777957eb84fee195f194e01c9edL157-R159)
* Refactors and cleans up modal and button logic for consistency and user experience. (`stop-ride.component.html`, `ride-tracking.component.html`) [[1]](diffhunk://#diff-a0bd08325fd7c935e65d9061051c477dfa2367e1f498009472c7aad3046a8a0dL161-R189) [[2]](diffhunk://#diff-3799c8893a032a068f1db5dfbe97f64a80955777957eb84fee195f194e01c9edL215-L223)

These changes make the stop ride process more flexible and user-friendly for drivers, while ensuring robust API integration and improved UI feedback.