### PR TITLE
[MOB 11] Active vehicles mobile

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/controller/VehicleController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/VehicleController.java
@@ -1,11 +1,9 @@
 package com.ftn.drumigo.controller;
 
-import com.ftn.drumigo.domain.Vehicle;
 import com.ftn.drumigo.dto.VehicleCreateRequest;
 import com.ftn.drumigo.dto.VehicleLocationUpdateRequest;
 import com.ftn.drumigo.dto.VehicleResponse;
 import com.ftn.drumigo.dto.VehicleUpdateRequest;
-import com.ftn.drumigo.mapper.VehicleMapper;
 import com.ftn.drumigo.service.VehicleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/vehicles")
@@ -26,11 +23,7 @@ public class VehicleController {
     
     @GetMapping("/active")
     public ResponseEntity<List<VehicleResponse>> getActiveVehicles() {
-        List<Vehicle> vehicles = vehicleService.getActiveVehicles();
-        List<VehicleResponse> responses = vehicles.stream()
-            .map(vehicleMapper::toResponse)
-            .collect(Collectors.toList());
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(vehicleService.getActiveVehicleResponses());
     }
     
     @GetMapping

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/users/Driver.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/users/Driver.java
@@ -19,6 +19,9 @@ public class Driver extends User {
     
     @Column(name = "active_driver", nullable = false)
     private Boolean activeDriver = false;
+
+    @Column(name = "busy", nullable = false)
+    private boolean busy = false;
     
     @Column(name = "last_state_change_at")
     private Instant lastStateChangeAt;

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/DriverResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/DriverResponse.java
@@ -12,6 +12,7 @@ public record DriverResponse(
     String profilePictureUrl,
     Boolean blocked,
     Boolean activeDriver,
+    Boolean isBusy,
     Instant lastStateChangeAt,
     Instant createdAt,
     Instant updatedAt

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/VehicleResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/VehicleResponse.java
@@ -13,6 +13,7 @@ public record VehicleResponse(
     Boolean babyFriendly,
     Boolean petFriendly,
     BigDecimal currentLat,
-    BigDecimal currentLng
+    BigDecimal currentLng,
+    Boolean available
 ) {}
 

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/profile/response/ProfileResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/profile/response/ProfileResponse.java
@@ -25,6 +25,7 @@ public class ProfileResponse {
     
     // Driver-specific fields
     private Boolean activeDriver;
+    private Boolean isBusy;
     private Instant lastStateChangeAt;
     private VehicleInfoResponse vehicle;
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/mapper/DriverMapper.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/mapper/DriverMapper.java
@@ -22,6 +22,7 @@ public class DriverMapper {
             driver.getProfilePictureUrl(),
             driver.getBlocked(),
             driver.getActiveDriver(),
+            driver.isBusy(),
             driver.getLastStateChangeAt(),
             driver.getCreatedAt(),
             driver.getUpdatedAt()

--- a/drumigo/src/main/java/com/ftn/drumigo/mapper/VehicleMapper.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/mapper/VehicleMapper.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Component;
 public class VehicleMapper {
     
     public VehicleResponse toResponse(Vehicle vehicle) {
+        return toResponseWithAvailability(vehicle, null);
+    }
+
+    public VehicleResponse toResponseWithAvailability(Vehicle vehicle, Boolean available) {
         if (vehicle == null) {
             return null;
         }
@@ -22,7 +26,8 @@ public class VehicleMapper {
             vehicle.getBabyFriendly(),
             vehicle.getPetFriendly(),
             vehicle.getCurrentLat(),
-            vehicle.getCurrentLng()
+            vehicle.getCurrentLng(),
+            available
         );
     }
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/VehicleRepository.java
@@ -1,7 +1,7 @@
 package com.ftn.drumigo.repository;
 
-import com.ftn.drumigo.domain.Driver;
 import com.ftn.drumigo.domain.Vehicle;
+import com.ftn.drumigo.domain.users.Driver;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
@@ -44,6 +44,7 @@ public class ProfileService {
         // Add driver-specific fields if user is a driver
         if (user instanceof Driver driver) {
             response.setActiveDriver(driver.getActiveDriver());
+            response.setIsBusy(driver.isBusy());
             response.setLastStateChangeAt(driver.getLastStateChangeAt());
             
             // Add vehicle info if driver has a vehicle

--- a/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
@@ -125,6 +125,7 @@ public class RideService {
         ride.setStatus(RideStatus.FINISHED);
         ride.setEndTime(Instant.now());
         ride.setPaidAt(Instant.now());
+        setDriverBusy(ride.getDriver(), false);
         
         ride = rideRepository.save(ride);
         eventPublisher.publishEvent(new RideFinishedEvent(ride.getId()));
@@ -336,6 +337,7 @@ public class RideService {
         
         ride.setStatus(RideStatus.ACTIVE);
         ride.setStartTime(Instant.now());
+        setDriverBusy(driver, true);
         
         // Update estimated arrival based on start time
         if (ride.getEstimatedDurationSec() != null) {
@@ -391,6 +393,9 @@ public class RideService {
         List<Driver> activeDrivers = driverRepository.findByActiveDriverTrue();
         
         for (Driver driver : activeDrivers) {
+            if (driver.isBusy()) {
+                continue;
+            }
             // Check if driver has worked less than 8 hours in last 24 hours
             if (hasExceededWorkingHours(driver)) {
                 continue;
@@ -411,6 +416,14 @@ public class RideService {
         }
         
         return null;
+    }
+
+    private void setDriverBusy(Driver driver, boolean busy) {
+        if (driver == null) {
+            return;
+        }
+        driver.setBusy(busy);
+        driverRepository.save(driver);
     }
     
     private boolean hasExceededWorkingHours(Driver driver) {
@@ -574,10 +587,8 @@ public class RideService {
         ride.setCancelReasonType(reasonType);
         ride.setCancelReason(reason);
         ride.setCanceledByUser(canceledBy);
+        setDriverBusy(ride.getDriver(), false);
 
-        if (ride.getVehicle() != null) {
-            Vehicle vehicle = ride.getVehicle();
-        }
         // TODO: create cancellation notifications
     }
     
@@ -653,6 +664,7 @@ public class RideService {
         ride.setStatus(RideStatus.FINISHED);
 
         // Vehicle availability removed - no longer tracking
+        setDriverBusy(ride.getDriver(), false);
         
         ride = rideRepository.save(ride);
         eventPublisher.publishEvent(new RideFinishedEvent(ride.getId()));

--- a/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
@@ -5,9 +5,10 @@ import com.ftn.drumigo.domain.Vehicle;
 import com.ftn.drumigo.domain.VehicleType;
 import com.ftn.drumigo.dto.VehicleCreateRequest;
 import com.ftn.drumigo.dto.VehicleLocationUpdateRequest;
+import com.ftn.drumigo.dto.VehicleResponse;
 import com.ftn.drumigo.dto.VehicleUpdateRequest;
-import com.ftn.drumigo.exception.ConflictException;
 import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.mapper.VehicleMapper;
 import com.ftn.drumigo.repository.DriverRepository;
 import com.ftn.drumigo.repository.VehicleRepository;
 import com.ftn.drumigo.repository.VehicleTypeRepository;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class VehicleService {
     private final VehicleRepository vehicleRepository;
     private final DriverRepository driverRepository;
     private final VehicleTypeRepository vehicleTypeRepository;
+    private final VehicleMapper vehicleMapper;
     
     /**
      * Get all vehicles from active drivers for display on the landing page map.
@@ -34,6 +37,16 @@ public class VehicleService {
     public List<Vehicle> getActiveVehicles() {
         return vehicleRepository.findByDriverActiveDriverTrue();
 
+    }
+
+    public List<VehicleResponse> getActiveVehicleResponses() {
+        List<Vehicle> vehicles = vehicleRepository.findByDriverActiveDriverTrue();
+        return vehicles.stream()
+            .map(vehicle -> vehicleMapper.toResponseWithAvailability(
+                vehicle,
+                vehicle.getDriver() == null || !vehicle.getDriver().isBusy()
+            ))
+            .collect(Collectors.toList());
     }
     
     public Vehicle getById(Long id) {

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -8,3 +8,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+secrets.properties

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -2,6 +2,18 @@ plugins {
     alias(libs.plugins.android.application)
 }
 
+import java.util.Properties
+
+val secretsPropertiesFile = rootProject.file("secrets.properties")
+val secretsProperties = Properties().apply {
+    if (secretsPropertiesFile.exists()) {
+        secretsPropertiesFile.inputStream().use { load(it) }
+    }
+}
+
+val mapboxAccessToken = secretsProperties.getProperty("MAPBOX_ACCESS_TOKEN") ?: "MAPBOX_API_KEY"
+val apiBaseUrl = secretsProperties.getProperty("API_BASE_URL") ?: "http://localhost:8080/api"
+
 android {
     namespace = "com.drumigo.mobile"
     compileSdk = 36
@@ -14,6 +26,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "MAPBOX_ACCESS_TOKEN", "\"${mapboxAccessToken}\"")
+        buildConfigField("String", "API_BASE_URL", "\"${apiBaseUrl}\"")
     }
 
     buildTypes {
@@ -33,6 +48,7 @@ android {
     
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 
@@ -46,6 +62,14 @@ dependencies {
     // Navigation Component
     implementation(libs.navigation.fragment)
     implementation(libs.navigation.ui)
+
+    // Maps (Mapbox)
+    implementation(libs.mapbox.maps)
+    implementation(libs.mapbox.annotation)
+
+    // Networking
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.converter.gson)
     
     // Testing
     testImplementation(libs.junit)

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Drumigo"
         tools:targetApi="31">
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -105,7 +105,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     private void updateSelectedNavItem(int destinationId) {
         int menuItemId;
-        if (destinationId == R.id.loginFragment) {
+        if (destinationId == R.id.activeVehiclesMapFragment) {
+            menuItemId = R.id.nav_active_vehicles;
+        } else if (destinationId == R.id.loginFragment) {
             menuItemId = R.id.nav_login;
         } else if (destinationId == R.id.registrationFragment) {
             menuItemId = R.id.nav_registration;
@@ -124,8 +126,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     @Override
     public boolean onNavigationItemSelected(@NonNull MenuItem item) {
         int itemId = item.getItemId();
-        
-        if (itemId == R.id.nav_login) {
+
+        if (itemId == R.id.nav_active_vehicles) {
+            navController.navigate(R.id.activeVehiclesMapFragment);
+        } else if (itemId == R.id.nav_login) {
             navController.navigate(R.id.loginFragment);
         } else if (itemId == R.id.nav_registration) {
             navController.navigate(R.id.registrationFragment);

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
@@ -1,0 +1,35 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.BuildConfig;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class ApiClient {
+
+    private static Retrofit retrofit;
+
+    private ApiClient() {
+    }
+
+    public static VehicleApiService getVehicleApiService() {
+        return getRetrofit().create(VehicleApiService.class);
+    }
+
+    private static Retrofit getRetrofit() {
+        if (retrofit == null) {
+            retrofit = new Retrofit.Builder()
+                .baseUrl(ensureTrailingSlash(BuildConfig.API_BASE_URL))
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+        }
+        return retrofit;
+    }
+
+    private static String ensureTrailingSlash(String baseUrl) {
+        if (baseUrl == null || baseUrl.trim().isEmpty()) {
+            return "http://localhost:8080/api/";
+        }
+        return baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/VehicleApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/VehicleApiService.java
@@ -1,0 +1,14 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.VehicleResponse;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface VehicleApiService {
+
+    @GET("vehicles/active")
+    Call<List<VehicleResponse>> getActiveVehicles();
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/VehicleResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/VehicleResponse.java
@@ -1,0 +1,18 @@
+package com.drumigo.mobile.data.model;
+
+public class VehicleResponse {
+    public Long id;
+    public Long driverId;
+    public String driverName;
+    public String driverSurname;
+    public Long vehicleTypeId;
+    public String vehicleTypeName;
+    public String model;
+    public String licensePlate;
+    public Integer numSeats;
+    public Boolean babyFriendly;
+    public Boolean petFriendly;
+    public Double currentLat;
+    public Double currentLng;
+    public Boolean available;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/map/ActiveVehiclesMapFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/map/ActiveVehiclesMapFragment.java
@@ -1,0 +1,311 @@
+package com.drumigo.mobile.ui.map;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.fragment.app.Fragment;
+
+import com.drumigo.mobile.BuildConfig;
+import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.api.ApiClient;
+import com.drumigo.mobile.data.api.VehicleApiService;
+import com.drumigo.mobile.data.model.VehicleResponse;
+import com.drumigo.mobile.databinding.FragmentActiveVehiclesMapBinding;
+import com.google.gson.JsonObject;
+import com.google.android.material.snackbar.Snackbar;
+import com.mapbox.common.MapboxOptions;
+import com.mapbox.geojson.Point;
+import com.mapbox.maps.CameraOptions;
+import com.mapbox.maps.MapView;
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor;
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class ActiveVehiclesMapFragment extends Fragment {
+
+    private static final double DEFAULT_LNG = 19.8200;
+    private static final double DEFAULT_LAT = 45.2500;
+    private static final double DEFAULT_ZOOM = 12.5;
+    private static final String MAPBOX_STYLE_URI = "mapbox://styles/mapbox/streets-v12";
+    private static final long VEHICLE_POLLING_INTERVAL_MS = 10_000L;
+
+    private FragmentActiveVehiclesMapBinding binding;
+    private MapView mapView;
+    private VehicleApiService vehicleApiService;
+    private List<VehicleResponse> activeVehicles = new ArrayList<>();
+    private boolean mapReady = false;
+    private PointAnnotationManager pointAnnotationManager;
+    private Bitmap availableIcon;
+    private Bitmap busyIcon;
+    private final Handler pollingHandler = new Handler(Looper.getMainLooper());
+    private final Runnable pollingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            fetchActiveVehicles();
+            pollingHandler.postDelayed(this, VEHICLE_POLLING_INTERVAL_MS);
+        }
+    };
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        MapboxOptions.setAccessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
+        vehicleApiService = ApiClient.getVehicleApiService();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(
+        @NonNull LayoutInflater inflater,
+        @Nullable ViewGroup container,
+        @Nullable Bundle savedInstanceState
+    ) {
+        binding = FragmentActiveVehiclesMapBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        mapView = binding.mapView;
+
+        if (isMapboxTokenMissing()) {
+            showMapError();
+            return;
+        }
+
+        mapView.getMapboxMap().setCamera(new CameraOptions.Builder()
+            .center(Point.fromLngLat(DEFAULT_LNG, DEFAULT_LAT))
+            .zoom(DEFAULT_ZOOM)
+            .build());
+        mapView.getMapboxMap().loadStyleUri(MAPBOX_STYLE_URI, style -> {
+            mapReady = true;
+            updateMarkers();
+        });
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (mapView != null) {
+            mapView.onStart();
+        }
+        startPolling();
+    }
+
+    @Override
+    public void onStop() {
+        stopPolling();
+        if (mapView != null) {
+            mapView.onStop();
+        }
+        super.onStop();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        if (mapView != null) {
+            mapView.onLowMemory();
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (mapView != null) {
+            mapView.onDestroy();
+        }
+        stopPolling();
+        mapView = null;
+        pointAnnotationManager = null;
+        availableIcon = null;
+        busyIcon = null;
+        binding = null;
+        super.onDestroyView();
+    }
+
+    private boolean isMapboxTokenMissing() {
+        String token = BuildConfig.MAPBOX_ACCESS_TOKEN;
+        return token == null || token.trim().isEmpty() || "MAPBOX_API_KEY".equals(token);
+    }
+
+    private void showMapError() {
+        if (binding == null) {
+            return;
+        }
+        binding.mapError.setVisibility(View.VISIBLE);
+        binding.mapError.setText(R.string.mapbox_token_missing);
+    }
+
+    private void startPolling() {
+        pollingHandler.removeCallbacks(pollingRunnable);
+        pollingHandler.post(pollingRunnable);
+    }
+
+    private void stopPolling() {
+        pollingHandler.removeCallbacks(pollingRunnable);
+    }
+
+    private void fetchActiveVehicles() {
+        if (vehicleApiService == null) {
+            return;
+        }
+        vehicleApiService.getActiveVehicles().enqueue(new Callback<List<VehicleResponse>>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<List<VehicleResponse>> call,
+                @NonNull Response<List<VehicleResponse>> response
+            ) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    showVehicleLoadError();
+                    return;
+                }
+                activeVehicles = response.body();
+                updateMarkers();
+            }
+
+            @Override
+            public void onFailure(
+                @NonNull Call<List<VehicleResponse>> call,
+                @NonNull Throwable t
+            ) {
+                showVehicleLoadError();
+            }
+        });
+    }
+
+    private void updateMarkers() {
+        if (!mapReady) {
+            return;
+        }
+        ensureAnnotationManager();
+        if (pointAnnotationManager == null) {
+            return;
+        }
+
+        pointAnnotationManager.deleteAll();
+
+        for (VehicleResponse vehicle : activeVehicles) {
+            if (vehicle == null || vehicle.currentLat == null || vehicle.currentLng == null) {
+                continue;
+            }
+            boolean isAvailable = vehicle.available == null || vehicle.available;
+            Bitmap icon = isAvailable ? getAvailableIcon() : getBusyIcon();
+            if (icon == null) {
+                continue;
+            }
+
+            String driverFullName = buildDriverName(vehicle.driverName, vehicle.driverSurname);
+            String statusLabel = isAvailable ? "Available" : "On a ride";
+
+            JsonObject data = new JsonObject();
+            data.addProperty("driverName", driverFullName);
+            data.addProperty("status", statusLabel);
+
+            PointAnnotationOptions options = new PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(vehicle.currentLng, vehicle.currentLat))
+                .withIconImage(icon)
+                .withIconAnchor(IconAnchor.BOTTOM)
+                .withData(data);
+            pointAnnotationManager.create(options);
+        }
+    }
+
+    private void showVehicleLoadError() {
+        if (binding == null) {
+            return;
+        }
+        Snackbar.make(
+            binding.getRoot(),
+            R.string.active_vehicles_load_failed,
+            Snackbar.LENGTH_SHORT
+        ).show();
+    }
+
+    private void ensureAnnotationManager() {
+        if (mapView == null || pointAnnotationManager != null) {
+            return;
+        }
+        AnnotationPlugin annotationPlugin = mapView.getAnnotations();
+        pointAnnotationManager = annotationPlugin.createPointAnnotationManager();
+        pointAnnotationManager.addClickListener(annotation -> {
+            if (binding == null) {
+                return false;
+            }
+            JsonObject data = annotation.getData() != null && annotation.getData().isJsonObject()
+                ? annotation.getData().getAsJsonObject()
+                : null;
+            if (data != null) {
+                String driverName = data.has("driverName") ? data.get("driverName").getAsString() : "";
+                String status = data.has("status") ? data.get("status").getAsString() : "";
+                String message = driverName.isEmpty() ? status : driverName + " • " + status;
+                Snackbar.make(binding.getRoot(), message, Snackbar.LENGTH_SHORT).show();
+            }
+            return true;
+        });
+    }
+
+    private Bitmap getAvailableIcon() {
+        if (availableIcon == null) {
+            availableIcon = createTintedMarker(R.color.success);
+        }
+        return availableIcon;
+    }
+
+    private Bitmap getBusyIcon() {
+        if (busyIcon == null) {
+            busyIcon = createTintedMarker(R.color.error);
+        }
+        return busyIcon;
+    }
+
+    private Bitmap createTintedMarker(int colorResId) {
+        if (getContext() == null) {
+            return null;
+        }
+        Drawable drawable = ContextCompat.getDrawable(requireContext(), R.drawable.ic_car);
+        if (drawable == null) {
+            return null;
+        }
+        Drawable wrapped = DrawableCompat.wrap(drawable.mutate());
+        DrawableCompat.setTint(wrapped, ContextCompat.getColor(requireContext(), colorResId));
+        int width = wrapped.getIntrinsicWidth() > 0 ? wrapped.getIntrinsicWidth() : 48;
+        int height = wrapped.getIntrinsicHeight() > 0 ? wrapped.getIntrinsicHeight() : 48;
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        wrapped.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        wrapped.draw(canvas);
+        return bitmap;
+    }
+
+    private String buildDriverName(String firstName, String lastName) {
+        String first = firstName == null ? "" : firstName.trim();
+        String last = lastName == null ? "" : lastName.trim();
+        if (first.isEmpty()) {
+            return last;
+        }
+        if (last.isEmpty()) {
+            return first;
+        }
+        return first + " " + last;
+    }
+}

--- a/mobile/app/src/main/res/layout/fragment_active_vehicles_map.xml
+++ b/mobile/app/src/main/res/layout/fragment_active_vehicles_map.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/mapError"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:background="@color/white"
+        android:padding="16dp"
+        android:textColor="@color/error"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/mobile/app/src/main/res/menu/drawer_menu.xml
+++ b/mobile/app/src/main/res/menu/drawer_menu.xml
@@ -3,6 +3,11 @@
 
     <group android:checkableBehavior="single">
         <item
+            android:id="@+id/nav_active_vehicles"
+            android:title="@string/nav_active_vehicles"
+            android:icon="@drawable/ic_car" />
+
+        <item
             android:id="@+id/nav_login"
             android:title="@string/nav_login" />
 

--- a/mobile/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,13 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/loginFragment">
+    app:startDestination="@id/activeVehiclesMapFragment">
+
+    <fragment
+        android:id="@+id/activeVehiclesMapFragment"
+        android:name="com.drumigo.mobile.ui.map.ActiveVehiclesMapFragment"
+        android:label="@string/nav_active_vehicles"
+        tools:layout="@layout/fragment_active_vehicles_map" />
 
     <fragment
         android:id="@+id/loginFragment"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -99,6 +99,9 @@
     <string name="nav_drawer_close">Close navigation drawer</string>
     <string name="open_navigation">Open navigation</string>
     <string name="nav_ride_history">Ride History</string>
+    <string name="nav_active_vehicles">Active Vehicles</string>
+    <string name="mapbox_token_missing">Mapbox token missing. Add it to mobile/secrets.properties.</string>
+    <string name="active_vehicles_load_failed">Unable to load active vehicles</string>
 
     <!-- Validation Messages -->
     <string name="error_email_required">Email is required</string>

--- a/mobile/gradle/libs.versions.toml
+++ b/mobile/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ appcompat = "1.6.1"
 material = "1.10.0"
 navigationFragment = "2.9.6"
 navigationUi = "2.9.6"
+mapboxMaps = "11.18.1"
+retrofit = "3.0.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -16,6 +18,10 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigationFragment" }
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
+mapbox-maps = { group = "com.mapbox.maps", name = "android", version.ref = "mapboxMaps" }
+mapbox-annotation = { group = "com.mapbox.maps", name = "plugin-annotation", version.ref = "mapboxMaps" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request introduces a "busy" status for drivers and improves how vehicle availability is tracked and exposed in both the backend and mobile app. It also adds foundational networking and mapping support to the Android client. The most significant changes are grouped below.

**Backend: Driver "Busy" Status & Vehicle Availability**

* Added a `busy` field to the `Driver` entity and updated the `DriverResponse` and related mappers to expose this status. The `ProfileResponse` DTO and `ProfileService` were also updated to include this field. (`[[1]](diffhunk://#diff-9760c3625fd86301c2012a12d9425ff3c710533f686aab64007ce27acb9c6b4fR23-R25)`, `[[2]](diffhunk://#diff-9330c746d38f5e5a97f35dc2f6e4b05b644f82787f9ecb8b29aa9555eb7591daR15)`, `[[3]](diffhunk://#diff-9acfc647fef4d7c697ba1325985eb07b55b0552d7f080af264a8df72449fc256R28)`, `[[4]](diffhunk://#diff-835de31652d538a3bd87522ad37b59efd60b989a317a2bebfe702618e7b65cb6R25)`, `[[5]](diffhunk://#diff-705d99b10a15427bcc3e9e2383f8e90a781584dc27767ee4bb651a0316f1b322R47)`)
* Updated ride lifecycle in `RideService` to set the driver's `busy` status to `true` when a ride starts and `false` when a ride ends or is canceled. Drivers marked as busy are excluded from assignment to new rides. (`[[1]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R340)`, `[[2]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R128)`, `[[3]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R590-L580)`, `[[4]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R667)`, `[[5]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R396-R398)`, `[[6]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R421-R428)`)
* Vehicle availability is now determined based on the driver's busy status. The `VehicleResponse` DTO, `VehicleMapper`, and `VehicleService` were updated to include and calculate an `available` field. The `/api/vehicles/active` endpoint now returns this field. (`[[1]](diffhunk://#diff-c9f5aa25a3184537cd1a24aee624303a2759ae0ec8ed5dd38d511c027055b3cfL16-R17)`, `[[2]](diffhunk://#diff-6524f9af04a31c264b73755e55d29f455030ab206d8e0509a91879af15604a6aR11-R14)`, `[[3]](diffhunk://#diff-6524f9af04a31c264b73755e55d29f455030ab206d8e0509a91879af15604a6aL25-R30)`, `[[4]](diffhunk://#diff-114b014dbe668f249ef057d63a3544d571faedd3a5955ed36611a69e996ae560R30)`, `[[5]](diffhunk://#diff-114b014dbe668f249ef057d63a3544d571faedd3a5955ed36611a69e996ae560R42-R51)`, `[[6]](diffhunk://#diff-58e28fc90af4bebf61f5429ecf905742fdbb563d4082cde33c26c18565ec9717L29-R26)`)

**Mobile App: Networking & Mapping Foundations**

* Added dependencies and configuration for Mapbox maps and Retrofit networking in the Android project. Secrets (such as API keys) are now loaded from a `secrets.properties` file. (`[[1]](diffhunk://#diff-88ee5eac977700af450da72480d952c654086c7b635a3e3a07f0fb2485c5cf2bR5-R16)`, `[[2]](diffhunk://#diff-88ee5eac977700af450da72480d952c654086c7b635a3e3a07f0fb2485c5cf2bR29-R31)`, `[[3]](diffhunk://#diff-88ee5eac977700af450da72480d952c654086c7b635a3e3a07f0fb2485c5cf2bR51)`, `[[4]](diffhunk://#diff-88ee5eac977700af450da72480d952c654086c7b635a3e3a07f0fb2485c5cf2bR66-R73)`)
* Introduced `ApiClient` and `VehicleApiService` classes to fetch active vehicles from the backend, and a `VehicleResponse` data model to represent the API response. (`[[1]](diffhunk://#diff-d7594e5356769eb882475183c3c3e4a0cbf45319fa74e290728bfd6d1064d7f2R1-R35)`, `[[2]](diffhunk://#diff-25ae26752797eb47b57cc814ddaf7ac83a21abc35129b7b79022d56cd3e68093R1-R14)`, `[[3]](diffhunk://#diff-4c8c658461cf72007ae5351054758bf95da448c2087272d92806e2096c95b933R1-R18)`)
* Updated navigation logic in `MainActivity` to support a new map fragment for viewing active vehicles. (`[[1]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L108-R110)`, `[[2]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L128-R132)`)

**Miscellaneous**

* Allowed cleartext traffic in the AndroidManifest for development purposes. (`[mobile/app/src/main/AndroidManifest.xmlR24](diffhunk://#diff-bce0c3202d674f0041e23230c200feb777301569b8d8d0ed586dff00021b3c84R24)`)
* Minor cleanup of unused imports in backend controller and repository files. (`[[1]](diffhunk://#diff-58e28fc90af4bebf61f5429ecf905742fdbb563d4082cde33c26c18565ec9717L3-L8)`, `[[2]](diffhunk://#diff-58e28fc90af4bebf61f5429ecf905742fdbb563d4082cde33c26c18565ec9717L17)`, `[[3]](diffhunk://#diff-5a9ca9dfc604737ad31a60ec554ee575f43df5f0ede6c72a27c0160a61364186L3-R4)`)

These changes collectively improve the accuracy of driver and vehicle status tracking, and lay the groundwork for showing live vehicle availability on the mobile client.