### PR TITLE
[MOB 12] Live ride tracking

### DIFF
--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -2,6 +2,8 @@ package com.drumigo.mobile;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
@@ -15,18 +17,37 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.navigation.NavController;
+import androidx.navigation.NavDestination;
 import androidx.navigation.fragment.NavHostFragment;
 
 import com.drumigo.mobile.databinding.ActivityMainBinding;
+import com.drumigo.mobile.data.api.ApiClient;
+import com.drumigo.mobile.data.api.RideApiService;
+import com.drumigo.mobile.data.model.ride.RideResponse;
+import com.drumigo.mobile.ui.ride.RideTrackingConfig;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.navigation.NavigationView;
 
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 public class MainActivity extends AppCompatActivity implements NavigationView.OnNavigationItemSelectedListener {
 
     private ActivityMainBinding binding;
     private NavController navController;
     private DrawerLayout drawerLayout;
     private MaterialToolbar toolbar;
+    private RideApiService rideApiService;
+    private final Handler ridePollingHandler = new Handler(Looper.getMainLooper());
+    private final Runnable ridePollingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            checkActiveRides();
+            ridePollingHandler.postDelayed(this, 10_000L);
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,6 +65,20 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         setupDrawer();
 
         setupBackPressedHandler();
+
+        rideApiService = ApiClient.getRideApiService();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        startRideAutoTracking();
+    }
+
+    @Override
+    protected void onStop() {
+        stopRideAutoTracking();
+        super.onStop();
     }
 
     private void setupEdgeToEdge() {
@@ -117,6 +152,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             menuItemId = R.id.nav_reset_password;
         } else if (destinationId == R.id.profileFragment) {
             menuItemId = R.id.nav_profile;
+        } else if (destinationId == R.id.rideTrackingFragment) {
+            return;
         } else {
             return;
         }
@@ -192,6 +229,63 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 }
             }
         });
+    }
+
+    private void startRideAutoTracking() {
+        ridePollingHandler.removeCallbacks(ridePollingRunnable);
+        ridePollingHandler.post(ridePollingRunnable);
+    }
+
+    private void stopRideAutoTracking() {
+        ridePollingHandler.removeCallbacks(ridePollingRunnable);
+    }
+
+    private void checkActiveRides() {
+        if (navController == null) {
+            return;
+        }
+        NavDestination current = navController.getCurrentDestination();
+        if (current != null && current.getId() == R.id.rideTrackingFragment) {
+            return;
+        }
+
+        if (RideTrackingConfig.USE_MOCK_UPDATES) {
+            navigateToRide(RideTrackingConfig.MOCK_RIDE_ID);
+            return;
+        }
+
+        if (rideApiService == null) {
+            return;
+        }
+        rideApiService.getActiveRides().enqueue(new Callback<List<RideResponse>>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<List<RideResponse>> call,
+                @NonNull Response<List<RideResponse>> response
+            ) {
+                if (!response.isSuccessful() || response.body() == null || response.body().isEmpty()) {
+                    return;
+                }
+                RideResponse firstRide = response.body().get(0);
+                if (firstRide == null || firstRide.id == null) {
+                    return;
+                }
+                navigateToRide(firstRide.id);
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<RideResponse>> call, @NonNull Throwable t) {
+            }
+        });
+    }
+
+    private void navigateToRide(long rideId) {
+        if (navController == null) {
+            return;
+        }
+        Bundle args = new Bundle();
+        args.putLong("rideId", rideId);
+        navController.navigate(R.id.rideTrackingFragment, args);
     }
 
     @Override

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
@@ -16,6 +16,10 @@ public class ApiClient {
         return getRetrofit().create(VehicleApiService.class);
     }
 
+    public static RideApiService getRideApiService() {
+        return getRetrofit().create(RideApiService.class);
+    }
+
     private static Retrofit getRetrofit() {
         if (retrofit == null) {
             retrofit = new Retrofit.Builder()

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxApiClient.java
@@ -1,0 +1,27 @@
+package com.drumigo.mobile.data.api;
+
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class MapboxApiClient {
+
+    private static final String MAPBOX_BASE_URL = "https://api.mapbox.com/";
+    private static Retrofit retrofit;
+
+    private MapboxApiClient() {
+    }
+
+    public static MapboxDirectionsService getDirectionsService() {
+        return getRetrofit().create(MapboxDirectionsService.class);
+    }
+
+    private static Retrofit getRetrofit() {
+        if (retrofit == null) {
+            retrofit = new Retrofit.Builder()
+                .baseUrl(MAPBOX_BASE_URL)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build();
+        }
+        return retrofit;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxDirectionsService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxDirectionsService.java
@@ -1,0 +1,20 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.mapbox.MapboxDirectionsResponse;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface MapboxDirectionsService {
+
+    @GET("directions/v5/mapbox/{profile}/{coordinates}")
+    Call<MapboxDirectionsResponse> getDirections(
+        @Path("profile") String profile,
+        @Path(value = "coordinates", encoded = true) String coordinates,
+        @Query("geometries") String geometries,
+        @Query("overview") String overview,
+        @Query("access_token") String accessToken
+    );
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
@@ -1,0 +1,19 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.ride.RideResponse;
+import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+public interface RideApiService {
+
+    @GET("rides/{id}")
+    Call<RideTrackingResponse> getRideTracking(@Path("id") long rideId);
+
+    @GET("rides/active")
+    Call<List<RideResponse>> getActiveRides();
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/mock/RideTrackingMockProvider.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/mock/RideTrackingMockProvider.java
@@ -1,0 +1,186 @@
+package com.drumigo.mobile.data.mock;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import com.drumigo.mobile.data.model.ride.ActiveRide;
+import com.drumigo.mobile.data.model.ride.LocationUpdate;
+import com.drumigo.mobile.data.model.ride.RoutePoint;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RideTrackingMockProvider {
+
+    private static final long UPDATE_INTERVAL_MS = 2500L;
+
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private Runnable updateRunnable;
+    private ActiveRide mockRide;
+    private int currentStep = 0;
+    private double progress = 0.0;
+    private RoutePoint previousLocation;
+
+    public RideTrackingMockProvider() {
+        mockRide = buildMockRide();
+    }
+
+    public ActiveRide getActiveRide(long rideId) {
+        ActiveRide ride = buildMockRide();
+        ride.id = rideId;
+        ride.estimatedArrivalTimeSec = calculateETA(ride.currentLocation, ride.destinationLocation);
+        return ride;
+    }
+
+    public void startLocationUpdates(long rideId, LocationUpdateListener listener) {
+        stopLocationUpdates();
+        ActiveRide ride = getActiveRide(rideId);
+        currentStep = 0;
+        progress = 0.0;
+        previousLocation = null;
+
+        updateRunnable = () -> {
+            LocationUpdate update = nextUpdate(ride);
+            if (listener != null && update != null) {
+                listener.onLocationUpdate(update);
+            }
+            handler.postDelayed(updateRunnable, UPDATE_INTERVAL_MS);
+        };
+        handler.post(updateRunnable);
+    }
+
+    public void stopLocationUpdates() {
+        if (updateRunnable != null) {
+            handler.removeCallbacks(updateRunnable);
+        }
+    }
+
+    private LocationUpdate nextUpdate(ActiveRide ride) {
+        List<RoutePoint> route = ride.route == null ? new ArrayList<>() : ride.route;
+        if (route.size() < 2) {
+            return null;
+        }
+
+        int totalSteps = route.size() - 1;
+        if (currentStep >= totalSteps) {
+            RoutePoint destination = ride.destinationLocation;
+            float bearing = previousLocation == null
+                ? 0f
+                : (float) calculateBearing(previousLocation, destination);
+            return new LocationUpdate(
+                destination.lat,
+                destination.lng,
+                System.currentTimeMillis(),
+                0,
+                bearing
+            );
+        }
+
+        RoutePoint currentWaypoint = route.get(currentStep);
+        RoutePoint nextWaypoint = route.get(currentStep + 1);
+        double stepProgress = progress % 1.0;
+        double lat = currentWaypoint.lat + (nextWaypoint.lat - currentWaypoint.lat) * stepProgress;
+        double lng = currentWaypoint.lng + (nextWaypoint.lng - currentWaypoint.lng) * stepProgress;
+
+        progress += 0.15;
+        if (progress >= 1.0) {
+            currentStep++;
+            progress = 0.0;
+        }
+
+        RoutePoint currentLocation = new RoutePoint(lat, lng, currentStep);
+        int eta = calculateETA(currentLocation, ride.destinationLocation);
+
+        float bearing;
+        if (previousLocation != null) {
+            bearing = (float) calculateBearing(previousLocation, currentLocation);
+        } else {
+            RoutePoint lookAhead = route.get(Math.min(currentStep + 1, totalSteps));
+            bearing = (float) calculateBearing(currentLocation, lookAhead);
+        }
+
+        previousLocation = currentLocation;
+
+        return new LocationUpdate(
+            lat,
+            lng,
+            System.currentTimeMillis(),
+            eta,
+            bearing
+        );
+    }
+
+    private ActiveRide buildMockRide() {
+        ActiveRide ride = new ActiveRide();
+        ride.id = 1L;
+        ride.status = "ACTIVE";
+        ride.driverName = "Marko";
+        ride.driverSurname = "Petrovic";
+        ride.vehicleModel = "Toyota Corolla";
+        ride.vehicleLicensePlate = "NS-123-AB";
+        ride.startAddress = "Trg Slobode, Novi Sad";
+        ride.destinationAddress = "Petrovaradin Fortress, Novi Sad";
+
+        ride.startLocation = new RoutePoint(45.2671, 19.8335, 0);
+        ride.destinationLocation = new RoutePoint(45.2517, 19.8369, 5);
+        ride.currentLocation = new RoutePoint(45.2671, 19.8335, 0);
+
+        List<RoutePoint> route = new ArrayList<>();
+        route.add(new RoutePoint(45.2671, 19.8335, 0));
+        route.add(new RoutePoint(45.2650, 19.8345, 1));
+        route.add(new RoutePoint(45.2620, 19.8355, 2));
+        route.add(new RoutePoint(45.2590, 19.8360, 3));
+        route.add(new RoutePoint(45.2560, 19.8365, 4));
+        route.add(new RoutePoint(45.2517, 19.8369, 5));
+        ride.route = route;
+        ride.estimatedArrivalTimeSec = calculateETA(ride.currentLocation, ride.destinationLocation);
+        return ride;
+    }
+
+    private int calculateETA(RoutePoint currentLocation, RoutePoint destination) {
+        double distanceMeters = calculateDistance(currentLocation, destination);
+        double averageSpeedKmh = 50.0;
+        double averageSpeedMs = averageSpeedKmh / 3.6;
+        double timeSeconds = distanceMeters / averageSpeedMs;
+        return Math.max(0, (int) Math.round(timeSeconds));
+    }
+
+    private double calculateDistance(RoutePoint point1, RoutePoint point2) {
+        double R = 6371000.0;
+        double dLat = toRad(point2.lat - point1.lat);
+        double dLng = toRad(point2.lng - point1.lng);
+        double lat1 = toRad(point1.lat);
+        double lat2 = toRad(point2.lat);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+            + Math.cos(lat1) * Math.cos(lat2)
+            * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+
+    private double calculateBearing(RoutePoint from, RoutePoint to) {
+        double dLng = toRad(to.lng - from.lng);
+        double lat1 = toRad(from.lat);
+        double lat2 = toRad(to.lat);
+
+        double y = Math.sin(dLng) * Math.cos(lat2);
+        double x = Math.cos(lat1) * Math.sin(lat2)
+            - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+        double bearing = Math.atan2(y, x);
+        bearing = toDeg(bearing);
+        return (bearing + 360.0) % 360.0;
+    }
+
+    private double toRad(double degrees) {
+        return degrees * Math.PI / 180.0;
+    }
+
+    private double toDeg(double radians) {
+        return radians * 180.0 / Math.PI;
+    }
+
+    public interface LocationUpdateListener {
+        void onLocationUpdate(LocationUpdate update);
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/mapbox/MapboxDirectionsResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/mapbox/MapboxDirectionsResponse.java
@@ -1,0 +1,16 @@
+package com.drumigo.mobile.data.model.mapbox;
+
+import java.util.List;
+
+public class MapboxDirectionsResponse {
+    public List<Route> routes;
+
+    public static class Route {
+        public Geometry geometry;
+    }
+
+    public static class Geometry {
+        public String type;
+        public List<List<Double>> coordinates;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/ActiveRide.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/ActiveRide.java
@@ -1,0 +1,19 @@
+package com.drumigo.mobile.data.model.ride;
+
+import java.util.List;
+
+public class ActiveRide {
+    public Long id;
+    public String status;
+    public String driverName;
+    public String driverSurname;
+    public String vehicleModel;
+    public String vehicleLicensePlate;
+    public String startAddress;
+    public String destinationAddress;
+    public RoutePoint startLocation;
+    public RoutePoint destinationLocation;
+    public RoutePoint currentLocation;
+    public Integer estimatedArrivalTimeSec;
+    public List<RoutePoint> route;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/LocationUpdate.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/LocationUpdate.java
@@ -1,0 +1,17 @@
+package com.drumigo.mobile.data.model.ride;
+
+public class LocationUpdate {
+    public double lat;
+    public double lng;
+    public long timestamp;
+    public int estimatedArrivalTimeSec;
+    public float bearing;
+
+    public LocationUpdate(double lat, double lng, long timestamp, int estimatedArrivalTimeSec, float bearing) {
+        this.lat = lat;
+        this.lng = lng;
+        this.timestamp = timestamp;
+        this.estimatedArrivalTimeSec = estimatedArrivalTimeSec;
+        this.bearing = bearing;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideResponse.java
@@ -1,0 +1,32 @@
+package com.drumigo.mobile.data.model.ride;
+
+import java.util.List;
+
+public class RideResponse {
+    public Long id;
+    public String status;
+    public String requestedAt;
+    public String scheduledFor;
+    public String startTime;
+    public String endTime;
+    public String paidAt;
+    public Long driverId;
+    public String driverName;
+    public String driverSurname;
+    public Long vehicleId;
+    public Double totalCost;
+    public Double totalDistanceKm;
+    public Integer estimatedDurationSec;
+    public String estimatedArrivalAt;
+    public Boolean babyTransport;
+    public Boolean petTransport;
+    public List<WaypointInfo> waypoints;
+
+    public static class WaypointInfo {
+        public Long locationId;
+        public String address;
+        public Double lat;
+        public Double lng;
+        public Integer order;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideTrackingResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideTrackingResponse.java
@@ -1,0 +1,32 @@
+package com.drumigo.mobile.data.model.ride;
+
+import java.util.List;
+
+public class RideTrackingResponse {
+    public Long id;
+    public String status;
+    public String requestedAt;
+    public String startTime;
+    public Long driverId;
+    public String driverName;
+    public String driverSurname;
+    public Long vehicleId;
+    public String vehicleModel;
+    public String vehicleLicensePlate;
+    public Double vehicleCurrentLat;
+    public Double vehicleCurrentLng;
+    public List<WaypointInfo> waypoints;
+    public String estimatedArrivalAt;
+    public Integer estimatedDurationSec;
+    public Double totalDistanceKm;
+    public Boolean babyTransport;
+    public Boolean petTransport;
+
+    public static class WaypointInfo {
+        public Long locationId;
+        public String address;
+        public Double lat;
+        public Double lng;
+        public Integer order;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RoutePoint.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RoutePoint.java
@@ -1,0 +1,13 @@
+package com.drumigo.mobile.data.model.ride;
+
+public class RoutePoint {
+    public double lat;
+    public double lng;
+    public int order;
+
+    public RoutePoint(double lat, double lng, int order) {
+        this.lat = lat;
+        this.lng = lng;
+        this.order = order;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingConfig.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingConfig.java
@@ -1,0 +1,9 @@
+package com.drumigo.mobile.ui.ride;
+
+public final class RideTrackingConfig {
+    public static final boolean USE_MOCK_UPDATES = true;
+    public static final long MOCK_RIDE_ID = 1L;
+
+    private RideTrackingConfig() {
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
@@ -1,0 +1,654 @@
+package com.drumigo.mobile.ui.ride;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.fragment.app.Fragment;
+
+import com.drumigo.mobile.BuildConfig;
+import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.api.ApiClient;
+import com.drumigo.mobile.data.api.MapboxApiClient;
+import com.drumigo.mobile.data.api.MapboxDirectionsService;
+import com.drumigo.mobile.data.api.RideApiService;
+import com.drumigo.mobile.data.mock.RideTrackingMockProvider;
+import com.drumigo.mobile.data.model.mapbox.MapboxDirectionsResponse;
+import com.drumigo.mobile.data.model.ride.ActiveRide;
+import com.drumigo.mobile.data.model.ride.LocationUpdate;
+import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
+import com.drumigo.mobile.data.model.ride.RoutePoint;
+import com.drumigo.mobile.databinding.FragmentRideTrackingBinding;
+import com.google.android.material.snackbar.Snackbar;
+import com.mapbox.common.MapboxOptions;
+import com.mapbox.geojson.Point;
+import com.mapbox.maps.CameraOptions;
+import com.mapbox.maps.MapView;
+import com.mapbox.maps.plugin.annotation.AnnotationPlugin;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions;
+import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions;
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class RideTrackingFragment extends Fragment {
+
+    private static final String ARG_RIDE_ID = "rideId";
+    private static final double DEFAULT_LNG = 19.8200;
+    private static final double DEFAULT_LAT = 45.2500;
+    private static final double DEFAULT_ZOOM = 13.5;
+    private static final String MAPBOX_STYLE_URI = "mapbox://styles/mapbox/streets-v12";
+    private static final long LOCATION_POLLING_INTERVAL_MS = 2500L;
+    private static final long ROUTE_REFRESH_INTERVAL_MS = 20_000L;
+
+    private FragmentRideTrackingBinding binding;
+    private MapView mapView;
+    private boolean mapReady = false;
+    private PointAnnotationManager pointAnnotationManager;
+    private PolylineAnnotationManager polylineAnnotationManager;
+    private Bitmap carIcon;
+    private Bitmap startIcon;
+    private Bitmap destinationIcon;
+
+    private RideApiService rideApiService;
+    private MapboxDirectionsService directionsService;
+    private RideTrackingMockProvider mockProvider;
+
+    private ActiveRide activeRide;
+    private long rideId;
+    private RoutePoint previousLocation;
+    private float currentBearing = 0f;
+    private long lastRouteRequestAt = 0L;
+    private final Handler pollingHandler = new Handler(Looper.getMainLooper());
+    private final Runnable backendPollingRunnable = new Runnable() {
+        @Override
+        public void run() {
+            fetchRideTracking();
+            pollingHandler.postDelayed(this, LOCATION_POLLING_INTERVAL_MS);
+        }
+    };
+
+    public RideTrackingFragment() {
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        MapboxOptions.setAccessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
+        rideApiService = ApiClient.getRideApiService();
+        directionsService = MapboxApiClient.getDirectionsService();
+        mockProvider = new RideTrackingMockProvider();
+        rideId = getArguments() != null ? getArguments().getLong(ARG_RIDE_ID, 0L) : 0L;
+        if (rideId == 0L) {
+            rideId = RideTrackingConfig.MOCK_RIDE_ID;
+        }
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(
+        @NonNull LayoutInflater inflater,
+        @Nullable ViewGroup container,
+        @Nullable Bundle savedInstanceState
+    ) {
+        binding = FragmentRideTrackingBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        mapView = binding.mapView;
+        setupMap();
+        setupActions();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        if (mapView != null) {
+            mapView.onStart();
+        }
+        startTracking();
+    }
+
+    @Override
+    public void onStop() {
+        stopTracking();
+        if (mapView != null) {
+            mapView.onStop();
+        }
+        super.onStop();
+    }
+
+    @Override
+    public void onLowMemory() {
+        super.onLowMemory();
+        if (mapView != null) {
+            mapView.onLowMemory();
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        stopTracking();
+        if (mapView != null) {
+            mapView.onDestroy();
+        }
+        mapView = null;
+        pointAnnotationManager = null;
+        polylineAnnotationManager = null;
+        carIcon = null;
+        startIcon = null;
+        destinationIcon = null;
+        binding = null;
+        super.onDestroyView();
+    }
+
+    private void setupMap() {
+        if (isMapboxTokenMissing()) {
+            showMapError();
+            return;
+        }
+        mapView.getMapboxMap().setCamera(new CameraOptions.Builder()
+            .center(Point.fromLngLat(DEFAULT_LNG, DEFAULT_LAT))
+            .zoom(DEFAULT_ZOOM)
+            .build());
+        mapView.getMapboxMap().loadStyleUri(MAPBOX_STYLE_URI, style -> {
+            mapReady = true;
+            updateMapContent();
+        });
+    }
+
+    private void setupActions() {
+        binding.btnBack.setOnClickListener(v ->
+            requireActivity().getOnBackPressedDispatcher().onBackPressed()
+        );
+        View.OnClickListener notImplementedListener = v -> showNotImplemented();
+        binding.btnStopRide.setOnClickListener(notImplementedListener);
+        binding.btnPanic.setOnClickListener(notImplementedListener);
+        binding.btnReportIssue.setOnClickListener(notImplementedListener);
+    }
+
+    private boolean isMapboxTokenMissing() {
+        String token = BuildConfig.MAPBOX_ACCESS_TOKEN;
+        return token == null || token.trim().isEmpty() || "MAPBOX_API_KEY".equals(token);
+    }
+
+    private void showMapError() {
+        if (binding == null) {
+            return;
+        }
+        binding.mapError.setVisibility(View.VISIBLE);
+        binding.mapError.setText(R.string.mapbox_token_missing);
+    }
+
+    private void startTracking() {
+        if (RideTrackingConfig.USE_MOCK_UPDATES) {
+            ActiveRide ride = mockProvider.getActiveRide(rideId);
+            applyRide(ride);
+            mockProvider.startLocationUpdates(rideId, this::applyLocationUpdate);
+            requestRouteIfNeeded(true);
+        } else {
+            fetchRideTracking();
+            pollingHandler.removeCallbacks(backendPollingRunnable);
+            pollingHandler.postDelayed(backendPollingRunnable, LOCATION_POLLING_INTERVAL_MS);
+        }
+    }
+
+    private void stopTracking() {
+        pollingHandler.removeCallbacks(backendPollingRunnable);
+        mockProvider.stopLocationUpdates();
+    }
+
+    private void fetchRideTracking() {
+        if (rideApiService == null) {
+            return;
+        }
+        rideApiService.getRideTracking(rideId).enqueue(new Callback<RideTrackingResponse>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<RideTrackingResponse> call,
+                @NonNull Response<RideTrackingResponse> response
+            ) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    showRideLoadError();
+                    return;
+                }
+                ActiveRide ride = mapToActiveRide(response.body());
+                if (ride == null) {
+                    showRideLoadError();
+                    return;
+                }
+                applyRide(ride);
+                updateFromTrackingResponse(response.body());
+                updateCompletionState();
+                requestRouteIfNeeded(false);
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<RideTrackingResponse> call, @NonNull Throwable t) {
+                showRideLoadError();
+            }
+        });
+    }
+
+    private void updateFromTrackingResponse(RideTrackingResponse response) {
+        if (response == null || activeRide == null) {
+            return;
+        }
+        Double lat = response.vehicleCurrentLat;
+        Double lng = response.vehicleCurrentLng;
+        if (lat == null || lng == null) {
+            return;
+        }
+        RoutePoint current = new RoutePoint(lat, lng, 0);
+        int eta = response.estimatedDurationSec != null ? response.estimatedDurationSec : 0;
+        float bearing = 0f;
+        if (previousLocation != null) {
+            bearing = (float) calculateBearing(previousLocation, current);
+        }
+        previousLocation = current;
+        applyLocationUpdate(new LocationUpdate(lat, lng, System.currentTimeMillis(), eta, bearing));
+    }
+
+    private void applyRide(ActiveRide ride) {
+        activeRide = ride;
+        if (binding == null || ride == null) {
+            return;
+        }
+        String rideIdLabel = ride.id == null ? "--" : String.valueOf(ride.id);
+        binding.rideId.setText(getString(R.string.ride_tracking_id_format, rideIdLabel));
+        binding.driverName.setText(buildDriverName(ride.driverName, ride.driverSurname));
+        binding.vehicleInfo.setText(buildVehicleInfo(ride.vehicleModel, ride.vehicleLicensePlate));
+        binding.fromAddress.setText(ride.startAddress == null ? "" : ride.startAddress);
+        binding.toAddress.setText(ride.destinationAddress == null ? "" : ride.destinationAddress);
+        binding.etaValue.setText(formatEta(ride.estimatedArrivalTimeSec));
+        updateMapContent();
+        updateCompletionState();
+    }
+
+    private void applyLocationUpdate(LocationUpdate update) {
+        if (activeRide == null || update == null) {
+            return;
+        }
+        activeRide.currentLocation = new RoutePoint(update.lat, update.lng, 0);
+        activeRide.estimatedArrivalTimeSec = update.estimatedArrivalTimeSec;
+        currentBearing = update.bearing;
+        if (binding != null) {
+            binding.etaValue.setText(formatEta(update.estimatedArrivalTimeSec));
+        }
+        updateMapContent();
+        requestRouteIfNeeded(false);
+    }
+
+    private void updateCompletionState() {
+        if (binding == null || activeRide == null) {
+            return;
+        }
+        boolean isCompleted = activeRide.status != null
+            && !"ACTIVE".equalsIgnoreCase(activeRide.status);
+        binding.rideCompletedMessage.setVisibility(isCompleted ? View.VISIBLE : View.GONE);
+        if (isCompleted) {
+            stopTracking();
+        }
+    }
+
+    private void updateMapContent() {
+        if (!mapReady || activeRide == null) {
+            return;
+        }
+        ensureAnnotationManagers();
+        updateRouteLine();
+        updateMarkers();
+        updateMapCamera();
+    }
+
+    private void updateMarkers() {
+        if (pointAnnotationManager == null || activeRide == null) {
+            return;
+        }
+        pointAnnotationManager.deleteAll();
+
+        if (activeRide.startLocation != null) {
+            pointAnnotationManager.create(new PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(activeRide.startLocation.lng, activeRide.startLocation.lat))
+                .withIconImage(getStartIcon())
+                .withIconAnchor(IconAnchor.CENTER));
+        }
+
+        if (activeRide.destinationLocation != null) {
+            pointAnnotationManager.create(new PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(activeRide.destinationLocation.lng, activeRide.destinationLocation.lat))
+                .withIconImage(getDestinationIcon())
+                .withIconAnchor(IconAnchor.CENTER));
+        }
+
+        if (activeRide.currentLocation != null) {
+            pointAnnotationManager.create(new PointAnnotationOptions()
+                .withPoint(Point.fromLngLat(activeRide.currentLocation.lng, activeRide.currentLocation.lat))
+                .withIconImage(getCarIcon())
+                .withIconRotate(currentBearing)
+                .withIconAnchor(IconAnchor.CENTER));
+        }
+    }
+
+    private void updateRouteLine() {
+        if (polylineAnnotationManager == null || activeRide == null || activeRide.route == null) {
+            return;
+        }
+        List<Point> points = new ArrayList<>();
+        for (RoutePoint routePoint : activeRide.route) {
+            points.add(Point.fromLngLat(routePoint.lng, routePoint.lat));
+        }
+        polylineAnnotationManager.deleteAll();
+        if (!points.isEmpty()) {
+            polylineAnnotationManager.create(new PolylineAnnotationOptions()
+                .withPoints(points)
+                .withLineColor("#5B4CDB")
+                .withLineWidth(5.0));
+        }
+    }
+
+    private void updateMapCamera() {
+        if (activeRide == null || activeRide.currentLocation == null || mapView == null) {
+            return;
+        }
+        mapView.getMapboxMap().setCamera(new CameraOptions.Builder()
+            .center(Point.fromLngLat(activeRide.currentLocation.lng, activeRide.currentLocation.lat))
+            .zoom(DEFAULT_ZOOM + 2.0)
+            .build());
+    }
+
+    private void requestRouteIfNeeded(boolean force) {
+        if (activeRide == null || activeRide.currentLocation == null || activeRide.destinationLocation == null) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (!force && now - lastRouteRequestAt < ROUTE_REFRESH_INTERVAL_MS) {
+            return;
+        }
+        lastRouteRequestAt = now;
+        fetchRouteFromMapbox(activeRide.currentLocation, activeRide.destinationLocation, "driving-traffic", true);
+    }
+
+    private void fetchRouteFromMapbox(
+        RoutePoint origin,
+        RoutePoint destination,
+        String profile,
+        boolean allowFallback
+    ) {
+        if (directionsService == null) {
+            fallbackToRoutePoints();
+            return;
+        }
+        String coordinates = origin.lng + "," + origin.lat + ";" + destination.lng + "," + destination.lat;
+        directionsService.getDirections(
+            profile,
+            coordinates,
+            "geojson",
+            "full",
+            BuildConfig.MAPBOX_ACCESS_TOKEN
+        ).enqueue(new Callback<MapboxDirectionsResponse>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<MapboxDirectionsResponse> call,
+                @NonNull Response<MapboxDirectionsResponse> response
+            ) {
+                if (response.isSuccessful() && response.body() != null && hasRouteCoordinates(response.body())) {
+                    updateRouteFromMapbox(response.body());
+                } else if (allowFallback) {
+                    fetchRouteFromMapbox(origin, destination, "driving", false);
+                } else {
+                    fallbackToRoutePoints();
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<MapboxDirectionsResponse> call, @NonNull Throwable t) {
+                if (allowFallback) {
+                    fetchRouteFromMapbox(origin, destination, "driving", false);
+                } else {
+                    fallbackToRoutePoints();
+                }
+            }
+        });
+    }
+
+    private boolean hasRouteCoordinates(MapboxDirectionsResponse response) {
+        return response.routes != null
+            && !response.routes.isEmpty()
+            && response.routes.get(0).geometry != null
+            && response.routes.get(0).geometry.coordinates != null
+            && !response.routes.get(0).geometry.coordinates.isEmpty();
+    }
+
+    private void updateRouteFromMapbox(MapboxDirectionsResponse response) {
+        if (activeRide == null || response.routes == null || response.routes.isEmpty()) {
+            return;
+        }
+        List<List<Double>> coordinates = response.routes.get(0).geometry.coordinates;
+        List<RoutePoint> route = new ArrayList<>();
+        int order = 0;
+        for (List<Double> pair : coordinates) {
+            if (pair.size() < 2) {
+                continue;
+            }
+            double lng = pair.get(0);
+            double lat = pair.get(1);
+            route.add(new RoutePoint(lat, lng, order++));
+        }
+        if (!route.isEmpty()) {
+            activeRide.route = route;
+            updateMapContent();
+        }
+    }
+
+    private void fallbackToRoutePoints() {
+        if (activeRide == null || activeRide.route == null || activeRide.route.isEmpty()) {
+            return;
+        }
+        updateMapContent();
+    }
+
+    private void ensureAnnotationManagers() {
+        if (mapView == null) {
+            return;
+        }
+        AnnotationPlugin annotationPlugin = mapView.getAnnotations();
+        if (pointAnnotationManager == null) {
+            pointAnnotationManager = annotationPlugin.createPointAnnotationManager();
+        }
+        if (polylineAnnotationManager == null) {
+            polylineAnnotationManager = annotationPlugin.createPolylineAnnotationManager();
+        }
+    }
+
+    private Bitmap getCarIcon() {
+        if (carIcon == null) {
+            carIcon = createTintedMarker(R.drawable.ic_car, R.color.primary);
+        }
+        return carIcon;
+    }
+
+    private Bitmap getStartIcon() {
+        if (startIcon == null) {
+            startIcon = createTintedMarker(R.drawable.ic_circle, R.color.primary);
+        }
+        return startIcon;
+    }
+
+    private Bitmap getDestinationIcon() {
+        if (destinationIcon == null) {
+            destinationIcon = createTintedMarker(R.drawable.ic_circle, R.color.success);
+        }
+        return destinationIcon;
+    }
+
+    private Bitmap createTintedMarker(int drawableResId, int colorResId) {
+        if (getContext() == null) {
+            return null;
+        }
+        Drawable drawable = ContextCompat.getDrawable(requireContext(), drawableResId);
+        if (drawable == null) {
+            return null;
+        }
+        Drawable wrapped = DrawableCompat.wrap(drawable.mutate());
+        DrawableCompat.setTint(wrapped, ContextCompat.getColor(requireContext(), colorResId));
+        int width = wrapped.getIntrinsicWidth() > 0 ? wrapped.getIntrinsicWidth() : 48;
+        int height = wrapped.getIntrinsicHeight() > 0 ? wrapped.getIntrinsicHeight() : 48;
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        wrapped.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        wrapped.draw(canvas);
+        return bitmap;
+    }
+
+    private ActiveRide mapToActiveRide(RideTrackingResponse response) {
+        if (response == null) {
+            return null;
+        }
+        ActiveRide ride = new ActiveRide();
+        ride.id = response.id;
+        ride.status = response.status;
+        ride.driverName = response.driverName;
+        ride.driverSurname = response.driverSurname;
+        ride.vehicleModel = response.vehicleModel;
+        ride.vehicleLicensePlate = response.vehicleLicensePlate;
+        ride.estimatedArrivalTimeSec = response.estimatedDurationSec != null
+            ? response.estimatedDurationSec
+            : 0;
+
+        List<RideTrackingResponse.WaypointInfo> waypoints = response.waypoints == null
+            ? new ArrayList<>()
+            : new ArrayList<>(response.waypoints);
+        Collections.sort(waypoints, Comparator.comparingInt(wp -> wp.order == null ? 0 : wp.order));
+        if (!waypoints.isEmpty()) {
+            RideTrackingResponse.WaypointInfo first = waypoints.get(0);
+            RideTrackingResponse.WaypointInfo last = waypoints.get(waypoints.size() - 1);
+            ride.startAddress = first.address;
+            ride.destinationAddress = last.address;
+            if (first.lat != null && first.lng != null) {
+                ride.startLocation = new RoutePoint(first.lat, first.lng, first.order == null ? 0 : first.order);
+            }
+            if (last.lat != null && last.lng != null) {
+                ride.destinationLocation = new RoutePoint(last.lat, last.lng, last.order == null ? 0 : last.order);
+            }
+            List<RoutePoint> route = new ArrayList<>();
+            for (RideTrackingResponse.WaypointInfo waypoint : waypoints) {
+                if (waypoint.lat == null || waypoint.lng == null) {
+                    continue;
+                }
+                int order = waypoint.order == null ? 0 : waypoint.order;
+                route.add(new RoutePoint(waypoint.lat, waypoint.lng, order));
+            }
+            ride.route = route;
+        }
+
+        if (response.vehicleCurrentLat != null && response.vehicleCurrentLng != null) {
+            ride.currentLocation = new RoutePoint(response.vehicleCurrentLat, response.vehicleCurrentLng, 0);
+        } else {
+            ride.currentLocation = ride.startLocation;
+        }
+        return ride;
+    }
+
+    private String buildDriverName(String firstName, String lastName) {
+        String first = firstName == null ? "" : firstName.trim();
+        String last = lastName == null ? "" : lastName.trim();
+        if (first.isEmpty() && last.isEmpty()) {
+            return getString(R.string.ride_tracking_driver_placeholder);
+        }
+        if (first.isEmpty()) {
+            return last;
+        }
+        if (last.isEmpty()) {
+            return first;
+        }
+        return first + " " + last;
+    }
+
+    private String buildVehicleInfo(String model, String licensePlate) {
+        String safeModel = model == null ? "" : model.trim();
+        String safePlate = licensePlate == null ? "" : licensePlate.trim();
+        if (safeModel.isEmpty() && safePlate.isEmpty()) {
+            return getString(R.string.ride_tracking_vehicle_placeholder);
+        }
+        if (safeModel.isEmpty()) {
+            return safePlate;
+        }
+        if (safePlate.isEmpty()) {
+            return safeModel;
+        }
+        return safeModel + " • " + safePlate;
+    }
+
+    private String formatEta(Integer etaSeconds) {
+        if (etaSeconds == null || etaSeconds <= 0) {
+            return getString(R.string.ride_tracking_eta_placeholder);
+        }
+        int minutes = Math.max(1, etaSeconds / 60);
+        if (minutes < 60) {
+            return minutes + " min";
+        }
+        int hours = minutes / 60;
+        int remainingMinutes = minutes % 60;
+        if (remainingMinutes == 0) {
+            return hours + "h";
+        }
+        return hours + "h " + remainingMinutes + "m";
+    }
+
+    private void showRideLoadError() {
+        if (binding == null) {
+            return;
+        }
+        Snackbar.make(
+            binding.getRoot(),
+            R.string.ride_tracking_load_failed,
+            Snackbar.LENGTH_SHORT
+        ).show();
+    }
+
+    private void showNotImplemented() {
+        if (binding == null) {
+            return;
+        }
+        Snackbar.make(
+            binding.getRoot(),
+            R.string.ride_tracking_not_implemented,
+            Snackbar.LENGTH_SHORT
+        ).show();
+    }
+
+    private double calculateBearing(RoutePoint from, RoutePoint to) {
+        double dLng = Math.toRadians(to.lng - from.lng);
+        double lat1 = Math.toRadians(from.lat);
+        double lat2 = Math.toRadians(to.lat);
+        double y = Math.sin(dLng) * Math.cos(lat2);
+        double x = Math.cos(lat1) * Math.sin(lat2)
+            - Math.sin(lat1) * Math.cos(lat2) * Math.cos(dLng);
+        double bearing = Math.atan2(y, x);
+        bearing = Math.toDegrees(bearing);
+        return (bearing + 360.0) % 360.0;
+    }
+}

--- a/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
+++ b/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_warm"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/trackingHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:padding="@dimen/spacing_md">
+
+        <ImageButton
+            android:id="@+id/btnBack"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/back"
+            android:src="@drawable/ic_arrow_back"
+            android:tint="@color/text_dark" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing_sm"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/rideTitle"
+                style="@style/TextStyle.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ride_tracking_title" />
+
+            <TextView
+                android:id="@+id/rideId"
+                style="@style/TextStyle.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ride_tracking_id_placeholder" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/driverName"
+                style="@style/TextStyle.Label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ride_tracking_driver_placeholder" />
+
+            <TextView
+                android:id="@+id/vehicleInfo"
+                style="@style/TextStyle.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/ride_tracking_vehicle_placeholder" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <com.mapbox.maps.MapView
+            android:id="@+id/mapView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@+id/mapError"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:background="@color/white"
+            android:padding="@dimen/spacing_md"
+            android:textColor="@color/error"
+            android:visibility="gone" />
+    </FrameLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_md">
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Drumigo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/spacing_md">
+
+                    <TextView
+                        style="@style/TextStyle.Caption"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/ride_tracking_eta_label" />
+
+                    <TextView
+                        android:id="@+id/etaValue"
+                        style="@style/TextStyle.Headline"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/ride_tracking_eta_placeholder" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Drumigo.Card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacing_md">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="@dimen/spacing_md">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <View
+                            android:layout_width="12dp"
+                            android:layout_height="12dp"
+                            android:background="@drawable/bg_route_dot_start" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/spacing_sm"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                style="@style/TextStyle.Caption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/ride_tracking_from" />
+
+                            <TextView
+                                android:id="@+id/fromAddress"
+                                style="@style/TextStyle.Body"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/ride_tracking_from_placeholder" />
+                        </LinearLayout>
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="2dp"
+                        android:layout_height="24dp"
+                        android:layout_marginStart="5dp"
+                        android:background="@color/primary" />
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal">
+
+                        <View
+                            android:layout_width="12dp"
+                            android:layout_height="12dp"
+                            android:background="@drawable/bg_route_dot_end" />
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/spacing_sm"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <TextView
+                                style="@style/TextStyle.Caption"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/ride_tracking_to" />
+
+                            <TextView
+                                android:id="@+id/toAddress"
+                                style="@style/TextStyle.Body"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/ride_tracking_to_placeholder" />
+                        </LinearLayout>
+                    </LinearLayout>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:id="@+id/actionButtons"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnStopRide"
+                    style="@style/Widget.Drumigo.Button.Primary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/ride_tracking_stop_ride" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnPanic"
+                    style="@style/Widget.Drumigo.Button.Secondary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_sm"
+                    android:text="@string/ride_tracking_panic" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnReportIssue"
+                    style="@style/Widget.Drumigo.Button.Secondary"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_sm"
+                    android:text="@string/ride_tracking_report_issue" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/rideCompletedMessage"
+                style="@style/TextStyle.Body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_md"
+                android:background="@drawable/bg_info_box"
+                android:padding="@dimen/spacing_md"
+                android:text="@string/ride_tracking_completed"
+                android:visibility="gone" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/mobile/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/app/src/main/res/navigation/nav_graph.xml
@@ -12,6 +12,18 @@
         tools:layout="@layout/fragment_active_vehicles_map" />
 
     <fragment
+        android:id="@+id/rideTrackingFragment"
+        android:name="com.drumigo.mobile.ui.ride.RideTrackingFragment"
+        android:label="@string/ride_tracking_title"
+        tools:layout="@layout/fragment_ride_tracking">
+
+        <argument
+            android:name="rideId"
+            app:argType="long"
+            android:defaultValue="0" />
+    </fragment>
+
+    <fragment
         android:id="@+id/loginFragment"
         android:name="com.drumigo.mobile.ui.auth.LoginFragment"
         android:label="Login"

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -102,6 +102,24 @@
     <string name="nav_active_vehicles">Active Vehicles</string>
     <string name="mapbox_token_missing">Mapbox token missing. Add it to mobile/secrets.properties.</string>
     <string name="active_vehicles_load_failed">Unable to load active vehicles</string>
+    <string name="back">Back</string>
+    <string name="ride_tracking_title">Tracking Ride</string>
+    <string name="ride_tracking_id_placeholder">Ride #--</string>
+    <string name="ride_tracking_id_format">Ride #%1$s</string>
+    <string name="ride_tracking_driver_placeholder">Driver</string>
+    <string name="ride_tracking_vehicle_placeholder">Vehicle</string>
+    <string name="ride_tracking_eta_label">Estimated arrival</string>
+    <string name="ride_tracking_eta_placeholder">--</string>
+    <string name="ride_tracking_from">From</string>
+    <string name="ride_tracking_to">To</string>
+    <string name="ride_tracking_from_placeholder">Start address</string>
+    <string name="ride_tracking_to_placeholder">Destination address</string>
+    <string name="ride_tracking_stop_ride">Stop Ride</string>
+    <string name="ride_tracking_panic">Emergency / Panic</string>
+    <string name="ride_tracking_report_issue">Report route issue</string>
+    <string name="ride_tracking_completed">Ride completed</string>
+    <string name="ride_tracking_load_failed">Unable to load ride tracking</string>
+    <string name="ride_tracking_not_implemented">This action is not implemented yet</string>
 
     <!-- Validation Messages -->
     <string name="error_email_required">Email is required</string>


### PR DESCRIPTION
This pull request introduces ride tracking and auto-navigation capabilities to the mobile app, including both real and mock ride tracking support. It adds new API service interfaces and models for ride and Mapbox directions, implements a periodic polling mechanism to check for active rides, and introduces a mock provider for simulating ride progress during development.

**Ride Tracking and Auto-Navigation:**

- Added periodic polling in `MainActivity` to check for active rides using the new `RideApiService`. If an active ride is found, the app automatically navigates to the ride tracking screen. Mock tracking is also supported via a config flag. [[1]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48R20-R50) [[2]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48R68-R81) [[3]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48R234-R290) [[4]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48R155-R156) [[5]](diffhunk://#diff-fa2fdbc8e2c3861ca25278df9a359b1a496777d4c9f0aa65faaba74353fe4b7cR1-R9)

**API Service Integrations:**

- Introduced `RideApiService` for ride-related API calls, including fetching active rides and ride tracking info. [[1]](diffhunk://#diff-16c1ac9ff07b80b6c523b737caf2da5cef91b523d61b945690ec39093beac80fR1-R19) [[2]](diffhunk://#diff-d7594e5356769eb882475183c3c3e4a0cbf45319fa74e290728bfd6d1064d7f2R19-R22)
- Added `MapboxApiClient` and `MapboxDirectionsService` for Mapbox directions API integration. [[1]](diffhunk://#diff-2f1febb78e3e753fa5b5bf5e25055d6651ec267ffa2e07a81fa4bd149758e93fR1-R27) [[2]](diffhunk://#diff-210006784d62a37819f5bfe5c8e33e2066c343521a4560126607d1c39c2fc23cR1-R20)

**Mock Ride Tracking:**

- Implemented `RideTrackingMockProvider` to simulate ride progress, location updates, and ETA calculations for development and testing purposes.

**Data Models:**

- Added models for ride tracking and Mapbox responses: `ActiveRide`, `RideResponse`, `RideTrackingResponse`, `LocationUpdate`, and `RoutePoint`, as well as `MapboxDirectionsResponse`. [[1]](diffhunk://#diff-827357211ee45222d81ad0f423b7536f15cb93737dfc855cf2fa62de756e5d0cR1-R19) [[2]](diffhunk://#diff-a5ba0bf5de939b50bd23fd262efbd7d403dc3d64feac8c50e0a4ae3e0da79650R1-R32) [[3]](diffhunk://#diff-cf67978aabdad0f4ddbb9bb0171bf19ed6089d520d0e1a614c03e9fadd76b449R1-R32) [[4]](diffhunk://#diff-bc396ffc4ddd3bc8074677fb638f9ece87b17b3331e91ba4ad8d26ba8c1534ccR1-R17) [[5]](diffhunk://#diff-ab3c733188ba359cff0fdb0b4830cc91b181cd584b163932982950c85791237dR1-R13) [[6]](diffhunk://#diff-27c203a41d9b926f98e19b7b985a6c7af4ff50015c9688050b9a46b8fb542b4aR1-R16)