### PR TITLE
[MISC 03] fix: seed script

### DIFF
--- a/drumigo/src/main/resources/db/seed/mysql-seed.sql
+++ b/drumigo/src/main/resources/db/seed/mysql-seed.sql
@@ -20,17 +20,17 @@ ON DUPLICATE KEY UPDATE
 -- =====================================================================
 INSERT INTO users (dtype, name, surname, email, password_hash, address, phone, profile_picture_url, blocked, role, created_at, updated_at)
 VALUES
-    ('Passenger', 'Ana', 'Petrović', 'ana.petrovic@example.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Passenger', 'Ana', 'Petrović', 'ana.petrovic@example.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Bulevar Oslobođenja 10, Novi Sad', '+381641234567', NULL, FALSE, 'PASSENGER', NOW(), NOW()),
-    ('Driver', 'Marko', 'Jovanović', 'marko.jovanovic@example.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Driver', 'Marko', 'Jovanović', 'marko.jovanovic@example.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Narodnih Heroja 25, Beograd', '+381652345678', NULL, FALSE, 'DRIVER', NOW(), NOW()),
-    ('Admin', 'Stefan', 'Nikolić', 'stefan.nikolic@drumigo.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Admin', 'Stefan', 'Nikolić', 'stefan.nikolic@drumigo.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Trg Republike 1, Beograd', '+381663456789', NULL, FALSE, 'ADMIN', NOW(), NOW()),
-    ('Driver', 'Jelena', 'Milošević', 'jelena.milosevic@example.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Driver', 'Jelena', 'Milošević', 'jelena.milosevic@example.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Knez Mihailova 30, Beograd', '+381641112222', NULL, FALSE, 'DRIVER', NOW(), NOW()),
-    ('Driver', 'Nikola', 'Đorđević', 'nikola.djordjevic@example.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Driver', 'Nikola', 'Đorđević', 'nikola.djordjevic@example.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Cara Dušana 15, Niš', '+381652223333', NULL, FALSE, 'DRIVER', NOW(), NOW()),
-    ('Passenger', 'Milica', 'Stojanović', 'milica.stojanovic@example.com', '008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601',
+    ('Passenger', 'Milica', 'Stojanović', 'milica.stojanovic@example.com', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Kraljevića Marka 5, Kragujevac', '+381663334444', NULL, FALSE, 'PASSENGER', NOW(), NOW())
 ON DUPLICATE KEY UPDATE
     dtype = VALUES(dtype),
@@ -89,15 +89,15 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (6001, 'Tracking', 'TestDriver', 'tracking.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (6001, 'Tracking', 'TestDriver', 'tracking.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Driver Test Address 1', '+381 64 600 0001', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (6002, 'Main', 'Passenger', 'main.passenger@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (6002, 'Main', 'Passenger', 'main.passenger@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 1', '+381 64 600 0002', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (6003, 'Linked', 'Passenger', 'linked.passenger@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (6003, 'Linked', 'Passenger', 'linked.passenger@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 2', '+381 64 600 0003', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (6004, 'Another', 'LinkedPassenger', 'another.linked@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (6004, 'Another', 'LinkedPassenger', 'another.linked@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 3', '+381 64 600 0004', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (6005, 'Unauthorized', 'Passenger', 'unauthorized.passenger@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (6005, 'Unauthorized', 'Passenger', 'unauthorized.passenger@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 4', '+381 64 600 0005', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
@@ -202,15 +202,15 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (7001, 'History', 'TestDriver', 'history.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (7001, 'History', 'TestDriver', 'history.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Driver Test Address 1', '+381 64 700 0001', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (7002, 'Marko', 'Petrovic', 'marko.petrovic@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (7002, 'Marko', 'Petrovic', 'marko.petrovic@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 1', '+381 64 700 0002', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (7003, 'Ana', 'Jovanovic', 'ana.jovanovic@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (7003, 'Ana', 'Jovanovic', 'ana.jovanovic@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 2', '+381 64 700 0003', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (7004, 'Nikola', 'Stojanovic', 'nikola.stojanovic@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (7004, 'Nikola', 'Stojanovic', 'nikola.stojanovic@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 3', '+381 64 700 0004', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (7005, 'Jovana', 'Nikolic', 'jovana.nikolic@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (7005, 'Jovana', 'Nikolic', 'jovana.nikolic@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Test Address 4', '+381 64 700 0005', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
@@ -412,25 +412,25 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (8001, 'Marko', 'Petrovic', 'marko.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8001, 'Marko', 'Petrovic', 'marko.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Bulevar Oslobodjenja 50', '+381 64 800 0001', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8002, 'Ana', 'Jovanovic', 'ana.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8002, 'Ana', 'Jovanovic', 'ana.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Liman 4', '+381 64 800 0002', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8003, 'Milica', 'Stojanovic', 'milica.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8003, 'Milica', 'Stojanovic', 'milica.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Detelinara 15', '+381 64 800 0003', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8004, 'Luka', 'Djordjevic', 'luka.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8004, 'Luka', 'Djordjevic', 'luka.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Telep 22', '+381 64 800 0004', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8005, 'Stefan', 'Nikolic', 'stefan.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8005, 'Stefan', 'Nikolic', 'stefan.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Petrovaradin', '+381 64 800 0005', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8006, 'Sara', 'Popovic', 'sara.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8006, 'Sara', 'Popovic', 'sara.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Grbavica', '+381 64 800 0006', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8007, 'Nikola', 'Radovic', 'nikola.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8007, 'Nikola', 'Radovic', 'nikola.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Kej, Novi Sad', '+381 64 800 0007', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8008, 'Jovana', 'Ilic', 'jovana.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8008, 'Jovana', 'Ilic', 'jovana.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Rotkvarija', '+381 64 800 0008', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8009, 'Jovan', 'Markovic', 'jovan.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8009, 'Jovan', 'Markovic', 'jovan.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Sremska Kamenica', '+381 64 800 0009', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8010, 'Marija', 'Tomic', 'marija.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8010, 'Marija', 'Tomic', 'marija.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Centar', '+381 64 800 0010', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
@@ -507,11 +507,11 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (8501, 'Rating', 'TestDriver', 'rating.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8501, 'Rating', 'TestDriver', 'rating.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Test Driver Address', '+381 64 111 0001', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (8502, 'Rating', 'TestPassenger', 'rating.passenger@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8502, 'Rating', 'TestPassenger', 'rating.passenger@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Test Passenger Address', '+381 64 222 0002', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (8503, 'Linked', 'Passenger', 'linked.passenger@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (8503, 'Linked', 'Passenger', 'linked.passenger@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Linked Passenger Address', '+381 64 333 0003', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
@@ -680,9 +680,9 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (9001, 'Test', 'Driver', 'driver9001@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (9001, 'Test', 'Driver', 'driver9001@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Driver Address', '000-000', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (9002, 'Test', 'Passenger', 'passenger9002@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (9002, 'Test', 'Passenger', 'passenger9002@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Passenger Address', '111-111', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),
@@ -775,11 +775,11 @@ INSERT INTO users (
     id, name, surname, email, password_hash, address, phone,
     profile_picture_url, blocked, role, created_at, updated_at, dtype
 ) VALUES
-    (9501, 'Sample', 'Driver', 'sample.driver@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (9501, 'Sample', 'Driver', 'sample.driver@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Sample Driver Address', '+381 64 950 0001', NULL, FALSE, 'DRIVER', NOW(), NOW(), 'Driver'),
-    (9502, 'Sample', 'Passenger1', 'sample.passenger1@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (9502, 'Sample', 'Passenger1', 'sample.passenger1@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Sample Passenger Address 1', '+381 64 950 0002', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger'),
-    (9503, 'Sample', 'Passenger2', 'sample.passenger2@test.local', '07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573',
+    (9503, 'Sample', 'Passenger2', 'sample.passenger2@test.local', 'b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4',
      'Sample Passenger Address 2', '+381 64 950 0003', NULL, FALSE, 'PASSENGER', NOW(), NOW(), 'Passenger')
 ON DUPLICATE KEY UPDATE
     name = VALUES(name),


### PR DESCRIPTION
This pull request updates the seed data for user accounts in the `drumigo/src/main/resources/db/seed/mysql-seed.sql` file. The main change is the replacement of all user password hashes with a new hash value, ensuring consistency and potentially improving security for seeded users across various test and production scenarios.

Password hash updates for users:

* Replaced the previous password hash (`008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601` and `07480fb9e85b9396af06f006cf1c95024af2531c65fb505cfbd0add1e2f31573`) with a new hash (`b46ea4ca5b6cb70b2965d8483a1ba85b92644fe9f9e04a860c891d92589a1cf4`) for all users in the seed SQL file. This affects both named users and test users across all `INSERT INTO users` statements. [[1]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL23-R33) [[2]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL92-R100) [[3]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL205-R213) [[4]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL415-R433) [[5]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL510-R514) [[6]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL683-R685) [[7]](diffhunk://#diff-14e020584bf2292c3408568b6e9c803d0fddbc0a29cd069dcb5d1f0b7691d28dL778-R782)