### PR TITLE
[MOB 19] feat: mobile driver ride history connect to api

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -62,7 +62,7 @@
 
         <!-- Ride History activity (explicit full name because it's in a different Java package) -->
         <activity
-            android:name="com.ridesharing.app.ui.history.RideHistoryActivity"
+            android:name="com.drumigo.mobile.ui.history.RideHistoryActivity"
             android:exported="false"
             android:label="@string/nav_ride_history" />
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -179,7 +179,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             navController.navigate(R.id.loginFragment);
         } else if (itemId == R.id.nav_ride_history) {
             // Launch RideHistoryActivity
-            Intent intent = new Intent(this, com.ridesharing.app.ui.history.RideHistoryActivity.class);
+            Intent intent = new Intent(this, com.drumigo.mobile.ui.history.RideHistoryActivity.class);
             startActivity(intent);
         } else if (itemId == R.id.nav_profile) {
             // Navigate to profile fragment

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
@@ -20,6 +20,10 @@ public class ApiClient {
         return getRetrofit().create(RideApiService.class);
     }
 
+    public static DriverApiService getDriverApiService() {
+        return getRetrofit().create(DriverApiService.class);
+    }
+
     private static Retrofit getRetrofit() {
         if (retrofit == null) {
             retrofit = new Retrofit.Builder()

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/DriverApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/DriverApiService.java
@@ -1,0 +1,22 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.history.DriverRideHistoryItemResponse;
+import com.drumigo.mobile.data.model.history.PageResponse;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface DriverApiService {
+
+    @GET("drivers/{driverId}/rides/history")
+    Call<PageResponse<DriverRideHistoryItemResponse>> getDriverRideHistory(
+        @Path("driverId") long driverId,
+        @Query("from") String from,
+        @Query("to") String to,
+        @Query("page") int page,
+        @Query("size") int size,
+        @Query("sort") String sort
+    );
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/Ride.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/Ride.java
@@ -1,4 +1,4 @@
-package com.ridesharing.app.data.model;
+package com.drumigo.mobile.data.model;
 
 public class Ride {
     private Long id;

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/DriverRideHistoryItemResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/DriverRideHistoryItemResponse.java
@@ -1,0 +1,19 @@
+package com.drumigo.mobile.data.model.history;
+
+import java.util.List;
+
+public class DriverRideHistoryItemResponse {
+    public Long id;
+    public String status;
+    public String startTime;
+    public String endTime;
+    public LocationInfo startLocation;
+    public LocationInfo endLocation;
+    public Boolean cancelled;
+    public Long canceledByUserId;
+    public String canceledByName;
+    public String canceledBySurname;
+    public Double totalCost;
+    public List<PassengerInfo> passengers;
+    public Boolean panicOccurred;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/LocationInfo.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/LocationInfo.java
@@ -1,0 +1,7 @@
+package com.drumigo.mobile.data.model.history;
+
+public class LocationInfo {
+    public String address;
+    public Double lat;
+    public Double lng;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PageResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PageResponse.java
@@ -1,0 +1,11 @@
+package com.drumigo.mobile.data.model.history;
+
+import java.util.List;
+
+public class PageResponse<T> {
+    public List<T> content;
+    public int totalElements;
+    public int totalPages;
+    public int size;
+    public int number;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PassengerInfo.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PassengerInfo.java
@@ -1,0 +1,7 @@
+package com.drumigo.mobile.data.model.history;
+
+public class PassengerInfo {
+    public Long id;
+    public String name;
+    public String surname;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/DriverRideHistoryMapper.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/DriverRideHistoryMapper.java
@@ -1,0 +1,167 @@
+package com.drumigo.mobile.ui.history;
+
+import com.drumigo.mobile.data.model.Ride;
+import com.drumigo.mobile.data.model.history.DriverRideHistoryItemResponse;
+import com.drumigo.mobile.data.model.history.PassengerInfo;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class DriverRideHistoryMapper {
+
+    private static final DateTimeFormatter DATE_FORMAT =
+        DateTimeFormatter.ofPattern("MMM dd, yyyy", Locale.ENGLISH);
+    private static final DateTimeFormatter TIME_FORMAT =
+        DateTimeFormatter.ofPattern("HH:mm", Locale.ENGLISH);
+    private static final int MAX_INITIALS = 3;
+
+    private DriverRideHistoryMapper() {
+    }
+
+    public static Ride toRide(DriverRideHistoryItemResponse item) {
+        if (item == null) {
+            return null;
+        }
+
+        ZonedDateTime start = parseDateTime(item.startTime);
+        ZonedDateTime end = parseDateTime(item.endTime);
+
+        String dateLabel = start != null ? DATE_FORMAT.format(start) : "";
+        String timeLabel = formatTimeRange(start, end);
+
+        String origin = item.startLocation != null && item.startLocation.address != null
+            ? item.startLocation.address
+            : "Unknown pickup";
+        String destination = item.endLocation != null && item.endLocation.address != null
+            ? item.endLocation.address
+            : "Unknown destination";
+
+        List<PassengerInfo> passengers = item.passengers == null
+            ? new ArrayList<>()
+            : item.passengers;
+        int passengerCount = passengers.size();
+        String[] initials = buildPassengerInitials(passengers);
+
+        String statusLabel = mapStatus(item);
+        String cancelledBy = mapCancelledBy(item);
+        String priceLabel = mapPrice(item);
+        boolean hasPanic = item.panicOccurred != null && item.panicOccurred;
+
+        return new Ride(
+            item.id,
+            dateLabel,
+            timeLabel,
+            origin,
+            destination,
+            initials,
+            passengerCount,
+            statusLabel,
+            cancelledBy,
+            priceLabel,
+            hasPanic
+        );
+    }
+
+    private static ZonedDateTime parseDateTime(String iso) {
+        if (iso == null || iso.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Instant.parse(iso).atZone(ZoneId.systemDefault());
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static String formatTimeRange(ZonedDateTime start, ZonedDateTime end) {
+        if (start == null) {
+            return "";
+        }
+        String startLabel = TIME_FORMAT.format(start);
+        if (end == null) {
+            return startLabel;
+        }
+        return startLabel + " - " + TIME_FORMAT.format(end);
+    }
+
+    private static String mapStatus(DriverRideHistoryItemResponse item) {
+        if (item == null) {
+            return "Completed";
+        }
+        String status = item.status == null ? "" : item.status.trim().toUpperCase(Locale.ENGLISH);
+        boolean cancelled = item.cancelled != null && item.cancelled;
+        if (cancelled || "CANCELLED".equals(status)) {
+            return "Cancelled";
+        }
+        if ("COMPLETED".equals(status) || "FINISHED".equals(status)) {
+            return "Completed";
+        }
+        return "Completed";
+    }
+
+    private static String mapCancelledBy(DriverRideHistoryItemResponse item) {
+        if (item == null || item.cancelled == null || !item.cancelled) {
+            return null;
+        }
+        String name = item.canceledByName == null ? "" : item.canceledByName.trim();
+        String surname = item.canceledBySurname == null ? "" : item.canceledBySurname.trim();
+        String fullName = (name + " " + surname).trim();
+        if (!fullName.isEmpty()) {
+            return "By " + fullName;
+        }
+        return null;
+    }
+
+    private static String mapPrice(DriverRideHistoryItemResponse item) {
+        if (item == null || item.totalCost == null) {
+            return "—";
+        }
+        if (item.cancelled != null && item.cancelled) {
+            return "—";
+        }
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.ENGLISH);
+        DecimalFormat formatter = new DecimalFormat("0.##", symbols);
+        return "+" + formatter.format(item.totalCost) + " RSD";
+    }
+
+    private static String[] buildPassengerInitials(List<PassengerInfo> passengers) {
+        if (passengers == null || passengers.isEmpty()) {
+            return new String[0];
+        }
+        int total = passengers.size();
+        int limit = total > MAX_INITIALS ? MAX_INITIALS - 1 : total;
+        List<String> initials = new ArrayList<>();
+        for (int i = 0; i < limit; i++) {
+            PassengerInfo passenger = passengers.get(i);
+            initials.add(buildInitials(passenger));
+        }
+        if (total > MAX_INITIALS) {
+            initials.add("+" + (total - (MAX_INITIALS - 1)));
+        }
+        return initials.toArray(new String[0]);
+    }
+
+    private static String buildInitials(PassengerInfo passenger) {
+        if (passenger == null) {
+            return "";
+        }
+        String first = passenger.name == null ? "" : passenger.name.trim();
+        String last = passenger.surname == null ? "" : passenger.surname.trim();
+        StringBuilder builder = new StringBuilder();
+        if (!first.isEmpty()) {
+            builder.append(first.substring(0, 1).toUpperCase(Locale.ENGLISH));
+        }
+        if (!last.isEmpty()) {
+            builder.append(last.substring(0, 1).toUpperCase(Locale.ENGLISH));
+        }
+        return builder.toString();
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
@@ -1,27 +1,43 @@
-package com.ridesharing.app.ui.history;
+package com.drumigo.mobile.ui.history;
 
 import android.app.DatePickerDialog;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Button;
 import android.widget.TextView;
-import android.util.Log;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.drumigo.mobile.R;
-import com.ridesharing.app.data.model.Ride;
+import com.drumigo.mobile.data.api.ApiClient;
+import com.drumigo.mobile.data.api.DriverApiService;
+import com.drumigo.mobile.data.model.Ride;
+import com.drumigo.mobile.data.model.history.DriverRideHistoryItemResponse;
+import com.drumigo.mobile.data.model.history.PageResponse;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class RideHistoryActivity extends AppCompatActivity {
 
     private static final String TAG = "RideHistoryActivity";
+    private static final long DRIVER_ID = 7001L;
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final String DEFAULT_SORT = "requestedAt,desc";
 
     private RecyclerView recyclerView;
     private RideHistoryAdapter adapter;
@@ -29,6 +45,7 @@ public class RideHistoryActivity extends AppCompatActivity {
     private Button applyFilterButton;
     private Calendar fromDate, toDate;
     private SimpleDateFormat dateFormat;
+    private DriverApiService driverApiService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,6 +62,7 @@ public class RideHistoryActivity extends AppCompatActivity {
             initializeViews();
             setupRecyclerView();
             setupDatePickers();
+            driverApiService = ApiClient.getDriverApiService();
             loadRideHistory();
         } catch (Exception e) {
             // Log and show a toast instead of crashing so we can diagnose in logs
@@ -101,7 +119,7 @@ public class RideHistoryActivity extends AppCompatActivity {
 
     private void showDatePicker(boolean isFromDate) {
         Calendar calendar = isFromDate ? fromDate : toDate;
-        
+
         DatePickerDialog datePickerDialog = new DatePickerDialog(
                 this,
                 0,
@@ -117,7 +135,7 @@ public class RideHistoryActivity extends AppCompatActivity {
                 calendar.get(Calendar.MONTH),
                 calendar.get(Calendar.DAY_OF_MONTH)
         );
-        
+
         datePickerDialog.show();
     }
 
@@ -126,35 +144,90 @@ public class RideHistoryActivity extends AppCompatActivity {
     }
 
     private void loadRideHistory() {
-        List<Ride> rides = getDummyRides();
-        if (adapter != null) adapter.updateRides(rides);
-        if (resultsCountText != null) resultsCountText.setText("Showing " + rides.size() + " rides");
+        if (driverApiService == null) {
+            driverApiService = ApiClient.getDriverApiService();
+        }
+        if (driverApiService == null) {
+            showHistoryLoadError();
+            return;
+        }
+
+        String from = toIsoStartOfDay(fromDate);
+        String to = toIsoEndOfDay(toDate);
+        driverApiService.getDriverRideHistory(
+            DRIVER_ID,
+            from,
+            to,
+            DEFAULT_PAGE,
+            DEFAULT_PAGE_SIZE,
+            DEFAULT_SORT
+        ).enqueue(new Callback<PageResponse<DriverRideHistoryItemResponse>>() {
+            @Override
+            public void onResponse(
+                Call<PageResponse<DriverRideHistoryItemResponse>> call,
+                Response<PageResponse<DriverRideHistoryItemResponse>> response
+            ) {
+                if (!response.isSuccessful() || response.body() == null || response.body().content == null) {
+                    showHistoryLoadError();
+                    updateHistoryResults(new ArrayList<>());
+                    return;
+                }
+                List<Ride> rides = new ArrayList<>();
+                for (DriverRideHistoryItemResponse item : response.body().content) {
+                    Ride mapped = DriverRideHistoryMapper.toRide(item);
+                    if (mapped != null) {
+                        rides.add(mapped);
+                    }
+                }
+                updateHistoryResults(rides);
+            }
+
+            @Override
+            public void onFailure(
+                Call<PageResponse<DriverRideHistoryItemResponse>> call,
+                Throwable t
+            ) {
+                showHistoryLoadError();
+                updateHistoryResults(new ArrayList<>());
+            }
+        });
     }
 
-    private List<Ride> getDummyRides() {
-        List<Ride> rides = new ArrayList<>();
-        
-        rides.add(new Ride(1L, "Dec 18, 2024", "14:30 - 14:52",
-                "Bulevar Oslobođenja 76", "Faculty of Technical Sciences",
-                new String[]{"JD"}, 1, "Completed", null, "+450 RSD", false));
+    private void updateHistoryResults(List<Ride> rides) {
+        if (adapter != null) {
+            adapter.updateRides(rides);
+        }
+        if (resultsCountText != null) {
+            resultsCountText.setText("Showing " + (rides == null ? 0 : rides.size()) + " rides");
+        }
+    }
 
-        rides.add(new Ride(2L, "Dec 18, 2024", "12:15 - 12:38",
-                "City Center Mall", "Novi Sad Airport",
-                new String[]{"AN", "MK"}, 2, "Completed", null, "+980 RSD", false));
+    private void showHistoryLoadError() {
+        Toast.makeText(this, "Failed to load ride history", Toast.LENGTH_SHORT).show();
+    }
 
-        rides.add(new Ride(3L, "Dec 17, 2024", "18:45 - 19:02",
-                "Liman Park", "Spens Sports Center",
-                new String[]{"SV"}, 1, "Cancelled", "By Passenger", "—", false));
+    private String toIsoStartOfDay(Calendar calendar) {
+        if (calendar == null) {
+            return null;
+        }
+        ZoneId zone = ZoneId.systemDefault();
+        LocalDate localDate = Instant.ofEpochMilli(calendar.getTimeInMillis())
+            .atZone(zone)
+            .toLocalDate();
+        ZonedDateTime start = localDate.atStartOfDay(zone);
+        return start.toInstant().toString();
+    }
 
-        rides.add(new Ride(4L, "Dec 16, 2024", "22:10 - 22:35",
-                "Petrovaradin Fortress", "Grbavica District",
-                new String[]{"NK"}, 1, "Completed", null, "+620 RSD", true));
-
-        rides.add(new Ride(5L, "Dec 15, 2024", "08:30 - 08:45",
-                "Bus Station", "University Campus",
-                new String[]{"TM", "LP", "+1"}, 3, "Completed", null, "+380 RSD", false));
-
-        return rides;
+    private String toIsoEndOfDay(Calendar calendar) {
+        if (calendar == null) {
+            return null;
+        }
+        ZoneId zone = ZoneId.systemDefault();
+        LocalDate localDate = Instant.ofEpochMilli(calendar.getTimeInMillis())
+            .atZone(zone)
+            .toLocalDate();
+        ZonedDateTime end = localDate.atTime(LocalTime.MAX).atZone(zone);
+        return end.toInstant().toString();
     }
 
     @Override

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
@@ -1,4 +1,4 @@
-package com.ridesharing.app.ui.history;
+package com.drumigo.mobile.ui.history;
 
 import android.content.Context;
 import android.util.Log;
@@ -12,7 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.drumigo.mobile.R;
-import com.ridesharing.app.data.model.Ride;
+import com.drumigo.mobile.data.model.Ride;
 import java.util.List;
 
 public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.RideViewHolder> {


### PR DESCRIPTION
This pull request introduces backend integration for the driver's ride history feature in the mobile app, replacing the previous use of dummy data. It adds new API service interfaces and data models for fetching and displaying ride history from the server, updates the relevant activities and adapters, and standardizes package naming across the codebase.

**Backend Integration for Driver Ride History:**

* Implemented `DriverApiService` interface for fetching driver ride history from the backend, and exposed it via `ApiClient`. [[1]](diffhunk://#diff-f19e440b5e35b1157093a195e12fdb3b125554ece5f973ddf51d4155585f219dR1-R22) [[2]](diffhunk://#diff-d7594e5356769eb882475183c3c3e4a0cbf45319fa74e290728bfd6d1064d7f2R23-R26)
* Introduced new data models for API responses: `DriverRideHistoryItemResponse`, `PageResponse`, `LocationInfo`, and `PassengerInfo`. [[1]](diffhunk://#diff-de9d8588d4a5db4ffc3efceafc972ac067e29b3a965c60209d5661e1aaad2408R1-R19) [[2]](diffhunk://#diff-3a7ff74195551537e1242a094d5e3b834bac81275ff739b3e82537d8054ec029R1-R11) [[3]](diffhunk://#diff-95f99c2b064582d96c4b4e9d024ba1cc78a34c7837d6ff2a602ebac11677981fR1-R7) [[4]](diffhunk://#diff-572932ef0cd0f9d75babcfae1392ac52da9fb4c0275d166e2faafa8dbede4085R1-R7)
* Added `DriverRideHistoryMapper` to convert API response objects into UI-friendly `Ride` objects.

**UI and Activity Updates:**

* Updated `RideHistoryActivity` to fetch ride history from the backend using the new API service and mapper, replacing dummy data. Added error handling and filtering by date range. [[1]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2L1-R48) [[2]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R65) [[3]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2L129-R230)
* Updated `RideHistoryAdapter` and related references to use the new package and data model locations. [[1]](diffhunk://#diff-75e46fabf02b11a879a9051d7a581e06e3604f5a53172d23bb3d30bdce1e2d40L1-R1) [[2]](diffhunk://#diff-75e46fabf02b11a879a9051d7a581e06e3604f5a53172d23bb3d30bdce1e2d40L15-R15)

**Package and Naming Refactor:**

* Standardized package names for ride history-related classes and updated references in the manifest and main activity. [[1]](diffhunk://#diff-bce0c3202d674f0041e23230c200feb777301569b8d8d0ed586dff00021b3c84L65-R65) [[2]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L182-R182) [[3]](diffhunk://#diff-04580f58c3b9b3e8cb0982b6918315927bf27d0591d5eda691a584e7b3c88c64L1-R1)

These changes collectively enable the app to display real driver ride history data, improve maintainability, and prepare for future enhancements.