### PR TITLE
[BE 28] hotfix: account activation not working

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/domain/users/User.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/users/User.java
@@ -44,6 +44,9 @@ public abstract class User {
     
     @Column(nullable = false)
     private Boolean blocked = false;
+
+    @Column(nullable = false)
+    private Boolean active;
     
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/drumigo/src/main/java/com/ftn/drumigo/service/AuthService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/AuthService.java
@@ -47,6 +47,11 @@ public class AuthService {
         if (user.getBlocked()) {
             throw new BadRequestException("Account is blocked");
         }
+
+        // Check if account is activated
+        if (!user.getActive()) {
+            throw new BadRequestException("Account is not activated");
+        }
         
         // Verify password (CRUD-first: simple hash comparison)
         String passwordHash = PasswordUtil.hashPassword(request.password());

--- a/drumigo/src/main/java/com/ftn/drumigo/service/DriverService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/DriverService.java
@@ -58,6 +58,7 @@ public class DriverService {
         driver.setRole(UserRole.DRIVER);
         driver.setActiveDriver(false);
         driver.setBlocked(false);
+        driver.setActive(true);
         driver.setCreatedAt(Instant.now());
         driver.setUpdatedAt(Instant.now());
         

--- a/drumigo/src/main/java/com/ftn/drumigo/service/PassengerService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PassengerService.java
@@ -60,6 +60,7 @@ public class PassengerService {
         passenger.setRole(UserRole.PASSENGER);
 
         passenger.setBlocked(false);
+        passenger.setActive(false);
         passenger.setCreatedAt(Instant.now());
         passenger.setUpdatedAt(Instant.now());
         passenger.setPasswordHash(PasswordUtil.hashPassword(password)); // Hash password
@@ -89,6 +90,8 @@ public class PassengerService {
         // Fetch the Passenger entity directly to avoid proxy casting issues
         Passenger passenger = passengerRepository.findById(userToken.getUser().getId())
             .orElseThrow(() -> new BadRequestException("Passenger not found"));
+
+        passenger.setActive(true);
 
         // Update timestamp
         passenger.setUpdatedAt(Instant.now());


### PR DESCRIPTION
Closes #147 

This pull request introduces account activation functionality for users, specifically passengers. It adds a new `active` field to the `User` entity, ensures new passengers are inactive by default, checks for activation status during login, and activates the account upon successful token verification.

**User entity changes:**

* Added a new `active` Boolean field to the `User` class to track whether an account is activated (`User.java`).

**Passenger registration and activation:**

* Set `active` to `false` by default when registering a new passenger, so accounts require activation (`PassengerService.java`).
* Set `active` to `true` when activating a passenger account using a token (`PassengerService.java`).

**Authentication logic:**

* Updated the login process to throw an error if the account is not activated, preventing login for inactive users (`AuthService.java`).