### PR TITLE
[BE 33] feat: send notifications to all admin during PANIC event

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
@@ -50,11 +50,32 @@ public class PanicService {
         PanicEvent panicEvent = new PanicEvent();
         panicEvent.setRide(ride);
         panicEvent.setUser(user);
-        panicEvent.setCreatedAt(Instant.now());
+
+        panicEventRepository.save(panicEvent);
         
-        panicEvent = panicEventRepository.save(panicEvent);
-        
-        //TODO: Send admin notifications
+        // Send notifications to all admins
+        sendAdminPanicNotifications(ride, user);
+    }
+
+    private void sendAdminPanicNotifications(Ride ride, User user) {
+        // Get all admins
+        List<Admin> admins = adminRepository.findAll();
+
+        // Send notification to each admin
+        for (Admin admin : admins) {
+            Notification notification = new Notification();
+            notification.setUser(admin);
+            notification.setRide(ride);
+            notification.setType(NotificationType.PANIC_ALERT);
+            notification.setMessage(String.format(
+                "PANIC EVENT: Ride #%d - User: %s %s (%s)",
+                ride.getId(),
+                user.getName(),
+                user.getSurname(),
+                user.getEmail()
+            ));
+            notificationRepository.save(notification);
+        }
     }
     
     public Page<PanicEvent> getAll(Pageable pageable) {

--- a/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PanicService.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.util.List;
 
 @Service


### PR DESCRIPTION
Closes #160 

This pull request enhances the panic event handling in the `PanicService` by implementing notification functionality for admin users. The main change is the addition of logic to send notifications to all admins when a panic event occurs.

Notification functionality:

* Added the `sendAdminPanicNotifications` private method to `PanicService`, which retrieves all admins and sends a `PANIC_ALERT` notification to each, containing ride and user details.
* Updated the `create` method to call `sendAdminPanicNotifications` after saving a panic event, replacing the previous TODO comment.