### PR TITLE
[BE 38] Pre-ride notifications

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/DrumigoApplication.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/DrumigoApplication.java
@@ -3,9 +3,11 @@ package com.ftn.drumigo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class DrumigoApplication {
 
 	public static void main(String[] args) {

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/Notification.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/Notification.java
@@ -42,5 +42,12 @@ public class Notification {
     
     @Column(name = "read_at")
     private Instant readAt;
+
+    /**
+     * For SCHEDULED_RIDE_REMINDER: minutes before ride start (15, 10, or 5).
+     * Null for other notification types.
+     */
+    @Column(name = "reminder_minutes_before")
+    private Integer reminderMinutesBefore;
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/NotificationResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/NotificationResponse.java
@@ -9,6 +9,7 @@ public record NotificationResponse(
     String type,
     String message,
     Instant createdAt,
-    Instant readAt
+    Instant readAt,
+    Integer reminderMinutesBefore
 ) {}
 

--- a/drumigo/src/main/java/com/ftn/drumigo/mapper/NotificationMapper.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/mapper/NotificationMapper.java
@@ -18,7 +18,8 @@ public class NotificationMapper {
             notification.getType().name(),
             notification.getMessage(),
             notification.getCreatedAt(),
-            notification.getReadAt()
+            notification.getReadAt(),
+            notification.getReminderMinutesBefore()
         );
     }
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/NotificationRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/NotificationRepository.java
@@ -1,6 +1,8 @@
 package com.ftn.drumigo.repository;
 
 import com.ftn.drumigo.domain.Notification;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.enums.NotificationType;
 import com.ftn.drumigo.domain.users.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -10,5 +12,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+
+    boolean existsByRideAndTypeAndReminderMinutesBefore(Ride ride, NotificationType type, Integer reminderMinutesBefore);
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/RideRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/RideRepository.java
@@ -91,4 +91,20 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
                                     @Param("statuses") List<RideStatus> statuses,
                                     @Param("hasPanic") Boolean hasPanic,
                                     Pageable pageable);
+
+    /**
+     * Rides that are accepted, scheduled, and start within the next 15 minutes (for reminder notifications).
+     */
+    @Query("""
+           SELECT r FROM Ride r
+           WHERE r.status = :status
+             AND r.scheduledFor IS NOT NULL
+             AND r.scheduledFor > :after
+             AND r.scheduledFor <= :before
+           """)
+    List<Ride> findAcceptedScheduledRidesInReminderWindow(
+        @Param("status") RideStatus status,
+        @Param("after") Instant after,
+        @Param("before") Instant before
+    );
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/service/ScheduledRideReminderService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/ScheduledRideReminderService.java
@@ -1,0 +1,114 @@
+package com.ftn.drumigo.service;
+
+import com.ftn.drumigo.domain.Notification;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
+import com.ftn.drumigo.domain.enums.NotificationType;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import com.ftn.drumigo.domain.users.User;
+import com.ftn.drumigo.repository.NotificationRepository;
+import com.ftn.drumigo.repository.RideRepository;
+import com.ftn.drumigo.repository.RideWaypointRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Sends reminder notifications for scheduled rides: 15 minutes before start,
+ * then every 5 minutes (10 min, 5 min) until start.
+ */
+@Service
+@RequiredArgsConstructor
+public class ScheduledRideReminderService {
+
+    private static final Logger log = LoggerFactory.getLogger(ScheduledRideReminderService.class);
+
+    private static final int REMINDER_WINDOW_MINUTES = 15;
+    private static final int[] REMINDER_MINUTES = { 15, 10, 5 };
+
+    private final RideRepository rideRepository;
+    private final RideWaypointRepository rideWaypointRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Scheduled(fixedRate = 60_000) // every minute
+    @Transactional
+    public void sendScheduledRideReminders() {
+        Instant now = Instant.now();
+        Instant windowEnd = now.plus(REMINDER_WINDOW_MINUTES, ChronoUnit.MINUTES);
+
+        List<Ride> rides = rideRepository.findAcceptedScheduledRidesInReminderWindow(
+            RideStatus.ACCEPTED,
+            now,
+            windowEnd
+        );
+
+        for (Ride ride : rides) {
+            long secondsUntilStart = ChronoUnit.SECONDS.between(now, ride.getScheduledFor());
+            if (secondsUntilStart <= 0) {
+                continue;
+            }
+            for (int reminderMin : REMINDER_MINUTES) {
+                if (isWithinReminderSlot(secondsUntilStart, reminderMin)) {
+                    sendReminderIfNotSent(ride, reminderMin);
+                    break;
+                }
+            }
+        }
+    }
+
+    private void sendReminderIfNotSent(Ride ride, int minutesBefore) {
+        if (notificationRepository.existsByRideAndTypeAndReminderMinutesBefore(
+            ride, NotificationType.SCHEDULED_RIDE_REMINDER, minutesBefore)) {
+            return;
+        }
+
+        String message = buildReminderMessage(ride, minutesBefore);
+        Optional<User> recipient = collectRecipient(ride);
+        if (recipient.isEmpty()) {
+            return;
+        }
+
+        Notification n = new Notification();
+        n.setUser(recipient.get());
+        n.setRide(ride);
+        n.setType(NotificationType.SCHEDULED_RIDE_REMINDER);
+        n.setMessage(message);
+        n.setReminderMinutesBefore(minutesBefore);
+        notificationRepository.save(n);
+
+        log.info("Sent scheduled ride reminder: rideId={}, minutesBefore={}, recipientUserId={}",
+            ride.getId(), minutesBefore, recipient.get().getId());
+    }
+
+    private String buildReminderMessage(Ride ride, int minutesBefore) {
+        String pickup = "your pickup location";
+        List<RideWaypoint> waypoints = rideWaypointRepository.findByRideOrderByWaypointOrderAsc(ride);
+        if (!waypoints.isEmpty() && waypoints.get(0).getLocation() != null) {
+            pickup = waypoints.get(0).getLocation().getAddress();
+        }
+        return String.format(
+            "Reminder: Your scheduled ride #%d starts in %d minutes. Pickup: %s",
+            ride.getId(),
+            minutesBefore,
+            pickup
+        );
+    }
+
+    private boolean isWithinReminderSlot(long secondsUntilStart, int reminderMinutesBefore) {
+        long upperBoundSeconds = reminderMinutesBefore * 60L;
+        long lowerBoundSeconds = upperBoundSeconds - 60L;
+        return secondsUntilStart <= upperBoundSeconds && secondsUntilStart > lowerBoundSeconds;
+    }
+
+    private Optional<User> collectRecipient(Ride ride) {
+        return Optional.ofNullable(ride.getOrderingPassenger());
+    }
+}


### PR DESCRIPTION
This pull request introduces scheduled reminder notifications for upcoming rides, ensuring users receive timely alerts before their scheduled ride begins. The main changes include adding a scheduled service to send reminders, updating the data model to support reminder details, and exposing this information in notification responses.

**Scheduled ride reminder notifications:**

* Added `ScheduledRideReminderService`, which runs every minute to send reminder notifications for scheduled rides at 15, 10, and 5 minutes before the ride start time. The service checks for eligible rides, avoids duplicate notifications, and constructs personalized reminder messages. (`drumigo/src/main/java/com/ftn/drumigo/service/ScheduledRideReminderService.java`)
* Enabled scheduling in the application by adding `@EnableScheduling` to `DrumigoApplication`. (`drumigo/src/main/java/com/ftn/drumigo/DrumigoApplication.java`)

**Repository and data model updates:**

* Extended the `Notification` entity to include a `reminderMinutesBefore` field, which stores how many minutes before the ride start the reminder was sent. (`drumigo/src/main/java/com/ftn/drumigo/domain/Notification.java`)
* Added a query method to `NotificationRepository` to check if a reminder notification has already been sent for a specific ride and time window, preventing duplicates. (`drumigo/src/main/java/com/ftn/drumigo/repository/NotificationRepository.java`)
* Added a query to `RideRepository` to find accepted, scheduled rides starting within the next 15 minutes, supporting the reminder logic. (`drumigo/src/main/java/com/ftn/drumigo/repository/RideRepository.java`)

**API and DTO enhancements:**

* Updated `NotificationResponse` and its mapper to include the `reminderMinutesBefore` field, so API consumers can identify reminder notifications and their timing. (`drumigo/src/main/java/com/ftn/drumigo/dto/NotificationResponse.java`, `drumigo/src/main/java/com/ftn/drumigo/mapper/NotificationMapper.java`) [[1]](diffhunk://#diff-f0942d194c904c28a33dc83a0992a79e99b52dc8bb029d2d3cb73284d6022f65L12-R13) [[2]](diffhunk://#diff-cfca5eac6e2ccca00a2dff93a222a703dbaf3a7c16fc73978f0c71bf5b1f78dfL21-R22)ta in notification responses.