### PR TITLE
[BE 39] One active ride only

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/repository/RideRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/RideRepository.java
@@ -93,6 +93,21 @@ public interface RideRepository extends JpaRepository<Ride, Long> {
                                     Pageable pageable);
 
     /**
+     * Checks if a passenger has any ride in the given statuses (e.g. PENDING, ACCEPTED, ACTIVE).
+     * Passenger is matched as ordering passenger or linked passenger (spec 2.6.1).
+     */
+    @Query("""
+           SELECT COUNT(r) > 0 FROM Ride r
+           WHERE r.status IN :statuses
+             AND (r.orderingPassenger.id = :passengerId OR EXISTS
+             (SELECT rp FROM RidePassenger rp WHERE rp.ride = r AND rp.passengerEmail = :passengerEmail))
+           """)
+    boolean existsActiveRideForPassenger(
+            @Param("passengerId") Long passengerId,
+            @Param("passengerEmail") String passengerEmail,
+            @Param("statuses") List<RideStatus> statuses);
+
+    /**
      * Rides that are accepted, scheduled, and start within the next 15 minutes (for reminder notifications).
      */
     @Query("""

--- a/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
@@ -184,6 +184,12 @@ public class RideService {
         Passenger orderingPassenger = passengerRepository.findById(orderingPassengerId)
             .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with id: " + orderingPassengerId));
         
+        // Prevent creating new ride while having active ride (spec 2.6.1)
+        List<RideStatus> activeStatuses = List.of(RideStatus.PENDING, RideStatus.ACCEPTED, RideStatus.ACTIVE);
+        if (rideRepository.existsActiveRideForPassenger(orderingPassenger.getId(), orderingPassenger.getEmail(), activeStatuses)) {
+            throw new BadRequestException("Cannot create a new ride while you have an active ride. Please wait until your current ride is finished.");
+        }
+        
         // Validate minimum waypoints (at least start and destination)
         if (request.waypoints() == null || request.waypoints().size() < 2) {
             throw new BadRequestException("Ride must have at least 2 waypoints (start and destination)");


### PR DESCRIPTION
This pull request introduces a new validation to prevent passengers from creating a new ride while they already have an active ride. The implementation checks for active rides in multiple statuses and enforces this restriction at the service layer, improving business rule enforcement and user experience.

Ride creation validation:

* Added the `existsActiveRideForPassenger` method in `RideRepository.java` to check if a passenger (either as ordering or linked passenger) has any ride in the specified active statuses (PENDING, ACCEPTED, ACTIVE).
* Updated `RideService.java` to use the new repository method before creating a ride, throwing a `BadRequestException` if the passenger has an active ride.