### PR TITLE
[BE 46] refactor: favorite route management

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/controller/FavoriteRouteController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/FavoriteRouteController.java
@@ -42,6 +42,23 @@ public class FavoriteRouteController {
             .collect(Collectors.toList());
         return ResponseEntity.ok(responses);
     }
+
+    @PostMapping("/passengers/{passengerId}/favorite-routes/from-ride/{rideId}")
+    public ResponseEntity<FavoriteRouteResponse> createFavoriteRouteFromRide(
+            @PathVariable Long passengerId,
+            @PathVariable Long rideId) {
+        FavoriteRoute favoriteRoute = favoriteRouteService.createFromRide(passengerId, rideId);
+        List<FavoriteRouteWaypoint> waypoints = favoriteRouteService.getWaypoints(favoriteRoute);
+        return ResponseEntity.status(201).body(favoriteRouteMapper.toResponse(favoriteRoute, waypoints));
+    }
+
+    @DeleteMapping("/passengers/{passengerId}/favorite-routes/by-ride/{rideId}")
+    public ResponseEntity<Void> deleteFavoriteRouteByRide(
+            @PathVariable Long passengerId,
+            @PathVariable Long rideId) {
+        favoriteRouteService.deleteByPassengerAndSourceRideId(passengerId, rideId);
+        return ResponseEntity.noContent().build();
+    }
     
     @DeleteMapping("/favorite-routes/{id}")
     public ResponseEntity<Void> deleteFavoriteRoute(@PathVariable Long id) {

--- a/drumigo/src/main/java/com/ftn/drumigo/controller/PassengerController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/PassengerController.java
@@ -1,5 +1,6 @@
 package com.ftn.drumigo.controller;
 
+import com.ftn.drumigo.domain.FavoriteRoute;
 import com.ftn.drumigo.domain.Ride;
 import com.ftn.drumigo.domain.RideWaypoint;
 import com.ftn.drumigo.domain.enums.RideStatus;
@@ -12,6 +13,9 @@ import com.ftn.drumigo.mapper.RideMapper;
 import com.ftn.drumigo.mapper.UserMapper;
 import com.ftn.drumigo.service.PassengerService;
 import com.ftn.drumigo.service.RideService;
+import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.repository.FavoriteRouteRepository;
+import com.ftn.drumigo.repository.PassengerRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -20,6 +24,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/passengers")
@@ -30,6 +36,8 @@ public class PassengerController {
     private final RideService rideService;
     private final RideMapper rideMapper;
     private final UserMapper userMapper;
+    private final FavoriteRouteRepository favoriteRouteRepository;
+    private final PassengerRepository passengerRepository;
     
     @PostMapping
     public ResponseEntity<UserResponse> register(@Valid @RequestBody PassengerRegisterRequest request) {
@@ -51,6 +59,8 @@ public class PassengerController {
         Pageable pageable = request.toPageable();
         List<RideStatus> statuses = request.parseStatuses();
 
+        Passenger passenger = passengerRepository.findById(passengerId)
+            .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with id: " + passengerId));
         Page<Ride> rides = passengerService.getPassengerRideHistory(
                 passengerId,
                 request.getFrom(),
@@ -60,10 +70,19 @@ public class PassengerController {
                 pageable
         );
 
+        List<Long> rideIds = rides.getContent().stream().map(Ride::getId).toList();
+        Map<Long, FavoriteRoute> favoriteByRideId = favoriteRouteRepository
+            .findByPassengerAndSourceRideIdIn(passenger, rideIds)
+            .stream()
+            .collect(Collectors.toMap(FavoriteRoute::getSourceRideId, fr -> fr, (a, b) -> a));
+
         Page<PassengerRideHistoryItemResponse> responses = rides.map(ride -> {
             List<RideWaypoint> waypoints = rideService.getRideWaypoints(ride);
             boolean hasPanicForRide = rideService.hasPanic(ride.getId());
-            return rideMapper.toPassengerHistoryResponse(ride, waypoints, hasPanicForRide);
+            FavoriteRoute fav = favoriteByRideId.get(ride.getId());
+            boolean isFavorite = fav != null;
+            Long favoriteRouteId = fav != null ? fav.getId() : null;
+            return rideMapper.toPassengerHistoryResponse(ride, waypoints, hasPanicForRide, isFavorite, favoriteRouteId);
         });
 
         return ResponseEntity.ok(responses);

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/FavoriteRoute.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/FavoriteRoute.java
@@ -37,5 +37,12 @@ public class FavoriteRoute {
     
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
+
+    /**
+     * When set, this favorite was created from a past ride (ride history).
+     * Used to show isFavorite in history and to remove-by-ride.
+     */
+    @Column(name = "source_ride_id")
+    private Long sourceRideId;
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/domain/Notification.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/domain/Notification.java
@@ -49,5 +49,10 @@ public class Notification {
      */
     @Column(name = "reminder_minutes_before")
     private Integer reminderMinutes;
+
+    /** Explicit setter so IDEs and reflection reliably see it (column: reminder_minutes_before). */
+    public void setReminderMinutes(Integer reminderMinutes) {
+        this.reminderMinutes = reminderMinutes;
+    }
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/history/response/PassengerRideHistoryItemResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/history/response/PassengerRideHistoryItemResponse.java
@@ -17,6 +17,8 @@ public record PassengerRideHistoryItemResponse(
     BigDecimal totalCost,
     Boolean canceled,
     String canceledBy,
-    Boolean hasPanic
+    Boolean hasPanic,
+    Boolean isFavorite,
+    Long favoriteRouteId
 ) {}
 

--- a/drumigo/src/main/java/com/ftn/drumigo/mapper/RideMapper.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/mapper/RideMapper.java
@@ -112,7 +112,33 @@ public class RideMapper {
             ride.getTotalCost(),
             canceled,
             canceledBy,
-            hasPanic
+            hasPanic,
+            null,
+            null
+        );
+    }
+
+    public PassengerRideHistoryItemResponse toPassengerHistoryResponse(
+            Ride ride, List<RideWaypoint> waypoints, boolean hasPanic, boolean isFavorite, Long favoriteRouteId) {
+        PassengerRideHistoryItemResponse base = toPassengerHistoryResponse(ride, waypoints, hasPanic);
+        if (base == null) {
+            return null;
+        }
+        return new PassengerRideHistoryItemResponse(
+            base.id(),
+            base.status(),
+            base.requestedAt(),
+            base.scheduledFor(),
+            base.startTime(),
+            base.endTime(),
+            base.startAddress(),
+            base.destinationAddress(),
+            base.totalCost(),
+            base.canceled(),
+            base.canceledBy(),
+            base.hasPanic(),
+            isFavorite,
+            favoriteRouteId
         );
     }
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/FavoriteRouteRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/FavoriteRouteRepository.java
@@ -5,10 +5,16 @@ import com.ftn.drumigo.domain.users.Passenger;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface FavoriteRouteRepository extends JpaRepository<FavoriteRoute, Long> {
     List<FavoriteRoute> findByPassenger(Passenger passenger);
+
+    Optional<FavoriteRoute> findByPassengerAndSourceRideId(Passenger passenger, Long sourceRideId);
+
+    List<FavoriteRoute> findByPassengerAndSourceRideIdIn(Passenger passenger, Collection<Long> sourceRideIds);
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/FavoriteRouteService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/FavoriteRouteService.java
@@ -3,14 +3,20 @@ package com.ftn.drumigo.service;
 import com.ftn.drumigo.domain.FavoriteRoute;
 import com.ftn.drumigo.domain.FavoriteRouteWaypoint;
 import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
 import com.ftn.drumigo.domain.users.Passenger;
 import com.ftn.drumigo.domain.VehicleType;
+import com.ftn.drumigo.domain.enums.VehicleTypeName;
 import com.ftn.drumigo.dto.FavoriteRouteCreateRequest;
+import com.ftn.drumigo.exception.BadRequestException;
+import com.ftn.drumigo.exception.ConflictException;
 import com.ftn.drumigo.exception.ResourceNotFoundException;
 import com.ftn.drumigo.repository.FavoriteRouteRepository;
 import com.ftn.drumigo.repository.FavoriteRouteWaypointRepository;
 import com.ftn.drumigo.repository.LocationRepository;
 import com.ftn.drumigo.repository.PassengerRepository;
+import com.ftn.drumigo.repository.RidePassengerRepository;
 import com.ftn.drumigo.repository.VehicleTypeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,12 +28,14 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional
 public class FavoriteRouteService {
-    
+
     private final FavoriteRouteRepository favoriteRouteRepository;
     private final FavoriteRouteWaypointRepository waypointRepository;
     private final PassengerRepository passengerRepository;
     private final VehicleTypeRepository vehicleTypeRepository;
     private final LocationRepository locationRepository;
+    private final RideService rideService;
+    private final RidePassengerRepository ridePassengerRepository;
     
     public FavoriteRoute create(Long passengerId, FavoriteRouteCreateRequest request) {
         Passenger passenger = passengerRepository.findById(passengerId)
@@ -82,15 +90,89 @@ public class FavoriteRouteService {
     public void delete(Long favoriteRouteId) {
         FavoriteRoute favoriteRoute = favoriteRouteRepository.findById(favoriteRouteId)
             .orElseThrow(() -> new ResourceNotFoundException("Favorite route not found with id: " + favoriteRouteId));
-        
+
         // Delete waypoints first
         List<FavoriteRouteWaypoint> waypoints = waypointRepository.findByFavoriteRouteOrderByWaypointOrderAsc(favoriteRoute);
         waypointRepository.deleteAll(waypoints);
-        
+
         // Delete favorite route
         favoriteRouteRepository.delete(favoriteRoute);
     }
-    
+
+    /**
+     * Create a favorite route from a completed ride. The passenger must be the ordering passenger or a linked passenger.
+     * Returns 409 if this ride is already a favorite for this passenger.
+     */
+    public FavoriteRoute createFromRide(Long passengerId, Long rideId) {
+        Passenger passenger = passengerRepository.findById(passengerId)
+            .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with id: " + passengerId));
+        Ride ride = rideService.getById(rideId);
+
+        boolean isOrdering = ride.getOrderingPassenger() != null
+            && ride.getOrderingPassenger().getId().equals(passengerId);
+        boolean isLinked = ridePassengerRepository.existsByRideAndPassengerEmail(ride, passenger.getEmail());
+        if (!isOrdering && !isLinked) {
+            throw new BadRequestException("You are not a passenger of this ride");
+        }
+
+        if (favoriteRouteRepository.findByPassengerAndSourceRideId(passenger, rideId).isPresent()) {
+            throw new ConflictException("This ride is already in your favorites");
+        }
+
+        String typeName = ride.getPricingVehicleTypeName();
+        if (typeName == null || typeName.isBlank()) {
+            throw new BadRequestException("Ride has no vehicle type; cannot create favorite");
+        }
+        VehicleType vehicleType = vehicleTypeRepository.findByName(VehicleTypeName.valueOf(typeName))
+            .orElseThrow(() -> new ResourceNotFoundException("Vehicle type not found: " + typeName));
+
+        List<RideWaypoint> rideWaypoints = rideService.getRideWaypoints(ride);
+        if (rideWaypoints.size() < 2) {
+            throw new BadRequestException("Ride must have at least 2 waypoints to save as favorite");
+        }
+
+        FavoriteRoute favoriteRoute = new FavoriteRoute();
+        favoriteRoute.setPassenger(passenger);
+        favoriteRoute.setVehicleType(vehicleType);
+        favoriteRoute.setBabyTransport(ride.getBabyTransport() != null ? ride.getBabyTransport() : false);
+        favoriteRoute.setPetTransport(ride.getPetTransport() != null ? ride.getPetTransport() : false);
+        favoriteRoute.setSourceRideId(rideId);
+        favoriteRoute = favoriteRouteRepository.save(favoriteRoute);
+
+        for (RideWaypoint rw : rideWaypoints) {
+            Location loc = rw.getLocation();
+            Location location = locationRepository.findByAddressAndLatAndLng(
+                    loc.getAddress(), loc.getLat(), loc.getLng())
+                .orElseGet(() -> {
+                    Location newLoc = new Location();
+                    newLoc.setAddress(loc.getAddress());
+                    newLoc.setLat(loc.getLat());
+                    newLoc.setLng(loc.getLng());
+                    return locationRepository.save(newLoc);
+                });
+            FavoriteRouteWaypoint waypoint = new FavoriteRouteWaypoint();
+            waypoint.setFavoriteRoute(favoriteRoute);
+            waypoint.setLocation(location);
+            waypoint.setWaypointOrder(rw.getWaypointOrder());
+            waypointRepository.save(waypoint);
+        }
+
+        return favoriteRoute;
+    }
+
+    /**
+     * Delete the favorite route that was created from the given ride for this passenger. 404 if not found.
+     */
+    public void deleteByPassengerAndSourceRideId(Long passengerId, Long rideId) {
+        Passenger passenger = passengerRepository.findById(passengerId)
+            .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with id: " + passengerId));
+        FavoriteRoute favoriteRoute = favoriteRouteRepository.findByPassengerAndSourceRideId(passenger, rideId)
+            .orElseThrow(() -> new ResourceNotFoundException("No favorite route found for this ride"));
+        List<FavoriteRouteWaypoint> waypoints = waypointRepository.findByFavoriteRouteOrderByWaypointOrderAsc(favoriteRoute);
+        waypointRepository.deleteAll(waypoints);
+        favoriteRouteRepository.delete(favoriteRoute);
+    }
+
     public List<FavoriteRouteWaypoint> getWaypoints(FavoriteRoute favoriteRoute) {
         return waypointRepository.findByFavoriteRouteOrderByWaypointOrderAsc(favoriteRoute);
     }

--- a/drumigo/src/main/java/com/ftn/drumigo/service/ScheduledRideReminderService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/ScheduledRideReminderService.java
@@ -55,8 +55,10 @@ public class ScheduledRideReminderService {
             if (secondsUntilStart <= 0) {
                 continue;
             }
+            // Send at most one reminder per run: the first one that is due and not yet sent.
+            // "Due" = we are at or past the reminder time (secondsUntilStart <= reminderMin * 60).
             for (int reminderMin : REMINDER_MINUTES) {
-                if (isWithinReminderSlot(secondsUntilStart, reminderMin)) {
+                if (secondsUntilStart <= reminderMin * 60L) {
                     sendReminderIfNotSent(ride, reminderMin);
                     break;
                 }
@@ -100,12 +102,6 @@ public class ScheduledRideReminderService {
             minutesBefore,
             pickup
         );
-    }
-
-    private boolean isWithinReminderSlot(long secondsUntilStart, int reminderMinutesBefore) {
-        long upperBoundSeconds = reminderMinutesBefore * 60L;
-        long lowerBoundSeconds = upperBoundSeconds - 60L;
-        return secondsUntilStart <= upperBoundSeconds && secondsUntilStart > lowerBoundSeconds;
     }
 
     private Optional<User> collectRecipient(Ride ride) {

--- a/frontend/src/app/features/order-ride/order-ride.component.html
+++ b/frontend/src/app/features/order-ride/order-ride.component.html
@@ -78,6 +78,24 @@
       @if (currentStep() === 1) {
         <div class="step-content">
           <h2 class="step-title">Where are you going?</h2>
+
+          @if (favoriteRoutes().length > 0) {
+            <div class="form-group">
+              <label for="favorite-select">Choose from favorites</label>
+              <select
+                id="favorite-select"
+                class="form-input"
+                [value]="selectedFavoriteId() ?? ''"
+                (change)="onFavoriteSelected($any($event.target).value)"
+              >
+                <option value="">None – enter address manually</option>
+                @for (fav of favoriteRoutes(); track fav.id) {
+                  <option [value]="fav.id">{{ getFavoriteLabel(fav) }}</option>
+                }
+              </select>
+            </div>
+          }
+
           @if (estimateLoading()) {
             <p class="estimate-loading">Calculating route and price...</p>
           }

--- a/frontend/src/app/features/order-ride/order-ride.component.ts
+++ b/frontend/src/app/features/order-ride/order-ride.component.ts
@@ -12,6 +12,10 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
 import { VehicleTypeName } from '../landing/models/estimate.model';
 import { LocationDTO } from '../landing/models/estimate.model';
+import {
+  FavoriteRoutesService,
+  FavoriteRouteDto,
+} from '../ride-history/services/favorite-routes.service';
 
 export interface Stop {
   id: string;
@@ -89,9 +93,14 @@ export class OrderRideComponent implements OnInit {
   addressSuggestions = signal<AddressSuggestion[]>([]);
   showSuggestionsFor = signal<'pickup' | 'destination' | string | null>(null);
 
+  /** Favorite routes for pre-fill (passenger only). */
+  favoriteRoutes = signal<FavoriteRouteDto[]>([]);
+  selectedFavoriteId = signal<number | null>(null);
+
   private estimateService = inject(EstimateService);
   private http = inject(HttpClient);
   private auth = inject(AuthService);
+  private favoriteRoutesService = inject(FavoriteRoutesService);
   private router = inject(Router);
   private destroyRef = inject(DestroyRef);
   private apiUrl = environment.apiBaseUrl;
@@ -163,6 +172,16 @@ export class OrderRideComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const userId = this.auth.getUserId();
+    if (userId != null) {
+      this.favoriteRoutesService
+        .getByPassenger(userId)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (list) => this.favoriteRoutes.set(list),
+          error: () => this.favoriteRoutes.set([]),
+        });
+    }
     const order = this.rideOrder();
     if (order.pickup && order.destination) {
       this.calculatePrice();
@@ -441,5 +460,72 @@ export class OrderRideComponent implements OnInit {
     if (step === this.currentStep()) return 'active';
     if (step < this.currentStep()) return 'completed';
     return 'pending';
+  }
+
+  /** Label for a favorite in the dropdown (e.g. "Start address → End address"). */
+  getFavoriteLabel(fav: FavoriteRouteDto): string {
+    const waypoints = [...(fav.waypoints ?? [])].sort((a, b) => a.order - b.order);
+    if (waypoints.length === 0) return `Favorite #${fav.id}`;
+    if (waypoints.length === 1) return waypoints[0].address;
+    const first = waypoints[0].address;
+    const last = waypoints[waypoints.length - 1].address;
+    return `${first} → ${last}`;
+  }
+
+  onFavoriteSelected(value: string): void {
+    const id = value === '' || value === 'none' ? null : Number(value);
+    if (Number.isNaN(id)) return;
+    this.selectedFavoriteId.set(id);
+    if (id == null) {
+      // Clear form
+      this.rideOrder.set({
+        pickup: '',
+        destination: '',
+        stops: [],
+        passengers: this.rideOrder().passengers,
+        vehicleType: 'standard',
+        scheduleNow: this.rideOrder().scheduleNow,
+        specialRequests: this.rideOrder().specialRequests,
+        babySeat: false,
+        petTransport: false,
+        estimatedPrice: 0,
+        estimatedDistance: 0,
+        estimatedDuration: 0,
+      });
+      this.nextStopId.set(0);
+      this.routeCoordinates.set(undefined);
+      this.showRoute.set(false);
+      this.lastGeocodedWaypoints.set(null);
+      return;
+    }
+    const fav = this.favoriteRoutes().find((f) => f.id === id);
+    if (fav) this.applyFavoriteRoute(fav);
+  }
+
+  private applyFavoriteRoute(fav: FavoriteRouteDto): void {
+    const waypoints = [...(fav.waypoints ?? [])].sort((a, b) => a.order - b.order);
+    if (waypoints.length < 2) return;
+    const pickup = waypoints[0].address;
+    const destination = waypoints[waypoints.length - 1].address;
+    const stopWaypoints = waypoints.slice(1, waypoints.length - 1);
+    const nextId = this.nextStopId();
+    const stops: Stop[] = stopWaypoints.map((wp, i) => ({
+      id: `stop-${nextId + i}`,
+      address: wp.address,
+    }));
+    this.nextStopId.set(nextId + stopWaypoints.length);
+    const vt = (fav.vehicleTypeName ?? 'STANDARD').toLowerCase() as 'standard' | 'luxury' | 'van';
+    const vehicleType = vt === 'standard' || vt === 'luxury' || vt === 'van' ? vt : 'standard';
+    const order = this.rideOrder();
+    this.rideOrder.set({
+      ...order,
+      pickup,
+      destination,
+      stops,
+      vehicleType,
+      babySeat: fav.babyTransport ?? false,
+      petTransport: fav.petTransport ?? false,
+    });
+    this.calculatePrice();
   }
 }

--- a/frontend/src/app/features/ride-history/models/ride-api.model.ts
+++ b/frontend/src/app/features/ride-history/models/ride-api.model.ts
@@ -90,6 +90,8 @@ export interface PassengerRideHistoryItemDto {
   canceled: boolean;
   canceledBy: string | null;
   hasPanic: boolean;
+  isFavorite?: boolean;
+  favoriteRouteId?: number | null;
 }
 
 export interface RideDetailsDriverDto {

--- a/frontend/src/app/features/ride-history/models/ride.model.ts
+++ b/frontend/src/app/features/ride-history/models/ride.model.ts
@@ -39,8 +39,8 @@ export interface Ride {
   daysRemainingToRate?: number;
   ratingDeadline?: Date;
   
-  // TODO: Backend Integration - Link to RidePassenger.isFavorite
-  // This should be: isFavorite: boolean; (per user per ride)
-  // Currently local state only - Backend needs RidePassenger entity update
+  /** Set when ride is in passenger's favorites (from history star). */
   isFavorite?: boolean;
+  /** Favorite route id when isFavorite is true; used to remove from favorites. */
+  favoriteRouteId?: number | null;
 }

--- a/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.ts
+++ b/frontend/src/app/features/ride-history/pages/passenger-history-page/passenger-history-page.component.ts
@@ -13,6 +13,7 @@ import {
   RideForRating,
 } from '../../components/rating-modal/rating-modal.component';
 import { ReviewResponse, ReviewService } from '../../services/review.service';
+import { FavoriteRoutesService } from '../../services/favorite-routes.service';
 import { AuthService } from '../../../../shared/services/auth.service';
 import { ToastService } from '../../../../shared/services/toast.service';
 
@@ -37,6 +38,7 @@ import { ToastService } from '../../../../shared/services/toast.service';
 export class PassengerHistoryPageComponent implements OnInit {
   private readonly rideHistoryService = inject(RideHistoryService);
   private readonly reviewService = inject(ReviewService);
+  private readonly favoriteRoutesService = inject(FavoriteRoutesService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly authService = inject(AuthService);
   private readonly toastService = inject(ToastService);
@@ -230,22 +232,48 @@ export class PassengerHistoryPageComponent implements OnInit {
   }
 
   onFavoriteToggled(ride: Ride): void {
-    // TODO: Backend Integration - Implement API call to mark ride as favorite
-    // 1. Create or update RidePassenger.isFavorite in the database
-    // 2. Call backend endpoint: PATCH /api/rides/{rideId}/favorite with { isFavorite: boolean }
-    // 3. Handle optimistic UI update vs. pessimistic (wait for response)
-    // 4. Add error handling and user feedback (toast notification)
-    // 5. Consider adding isFavorite to the Ride DTO in backend
-    
-    // For now: local toggle only
-    const updatedRide = { ...ride, isFavorite: !ride.isFavorite };
+    const passengerId = this.authService.getUserId();
+    if (!passengerId) {
+      this.toastService.error('Please log in to update favorites');
+      return;
+    }
 
-    this.allRides.update((rides) => rides.map((r) => (r.id === ride.id ? updatedRide : r)));
-    this.applySortingAndPagination();
-    
-    // Update selectedRide if it's the same ride
-    if (this.selectedRide()?.id === ride.id) {
-      this.selectedRide.set(updatedRide);
+    const rideIdNum = Number(ride.id);
+    if (ride.isFavorite) {
+      // Remove from favorites: use by-ride endpoint (we have ride id)
+      this.favoriteRoutesService
+        .deleteByRide(passengerId, rideIdNum)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: () => {
+            const updatedRide = { ...ride, isFavorite: false, favoriteRouteId: undefined };
+            this.allRides.update((rides) => rides.map((r) => (r.id === ride.id ? updatedRide : r)));
+            this.applySortingAndPagination();
+            if (this.selectedRide()?.id === ride.id) this.selectedRide.set(updatedRide);
+            this.toastService.success('Removed from favorites');
+          },
+          error: (err) => {
+            this.toastService.error(err?.error?.message ?? 'Failed to remove from favorites');
+          },
+        });
+    } else {
+      // Add to favorites
+      this.favoriteRoutesService
+        .createFromRide(passengerId, rideIdNum)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe({
+          next: (fav) => {
+            const updatedRide = { ...ride, isFavorite: true, favoriteRouteId: fav.id };
+            this.allRides.update((rides) => rides.map((r) => (r.id === ride.id ? updatedRide : r)));
+            this.applySortingAndPagination();
+            if (this.selectedRide()?.id === ride.id) this.selectedRide.set(updatedRide);
+            this.toastService.success('Added to favorites');
+          },
+          error: (err) => {
+            const msg = err?.error?.message ?? err?.message ?? 'Failed to add to favorites';
+            this.toastService.error(msg);
+          },
+        });
     }
   }
 

--- a/frontend/src/app/features/ride-history/services/favorite-routes.service.ts
+++ b/frontend/src/app/features/ride-history/services/favorite-routes.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+
+export interface FavoriteRouteWaypointDto {
+  id: number;
+  locationId: number;
+  address: string;
+  lat: number;
+  lng: number;
+  order: number;
+}
+
+export interface FavoriteRouteDto {
+  id: number;
+  passengerId: number;
+  vehicleTypeId: number;
+  vehicleTypeName: string;
+  babyTransport: boolean;
+  petTransport: boolean;
+  waypoints: FavoriteRouteWaypointDto[];
+  createdAt: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class FavoriteRoutesService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = environment.apiBaseUrl;
+
+  getByPassenger(passengerId: number): Observable<FavoriteRouteDto[]> {
+    return this.http.get<FavoriteRouteDto[]>(
+      `${this.apiUrl}/passengers/${passengerId}/favorite-routes`
+    );
+  }
+
+  createFromRide(passengerId: number, rideId: number): Observable<FavoriteRouteDto> {
+    return this.http.post<FavoriteRouteDto>(
+      `${this.apiUrl}/passengers/${passengerId}/favorite-routes/from-ride/${rideId}`,
+      {}
+    );
+  }
+
+  deleteById(favoriteRouteId: number): Observable<void> {
+    return this.http.delete<void>(
+      `${this.apiUrl}/favorite-routes/${favoriteRouteId}`
+    );
+  }
+
+  deleteByRide(passengerId: number, rideId: number): Observable<void> {
+    return this.http.delete<void>(
+      `${this.apiUrl}/passengers/${passengerId}/favorite-routes/by-ride/${rideId}`
+    );
+  }
+}

--- a/frontend/src/app/features/ride-history/services/ride-history.service.ts
+++ b/frontend/src/app/features/ride-history/services/ride-history.service.ts
@@ -574,6 +574,8 @@ export class RideHistoryService {
       status: item.status,
       scheduledFor: item.scheduledFor ? new Date(item.scheduledFor) : null,
       requestedAt: item.requestedAt ? new Date(item.requestedAt) : null,
+      isFavorite: item.isFavorite ?? false,
+      favoriteRouteId: item.favoriteRouteId ?? undefined,
     };
   }
 


### PR DESCRIPTION
close #195 

This pull request introduces the ability for passengers to mark rides as favorites directly from their ride history and to manage (create/delete) these "favorite routes" by ride. It also enhances the ride history API and UI to indicate which rides are favorites and streamlines related backend and frontend logic. Additionally, several minor improvements and refactorings are included.

**Favorite Route Management by Ride:**

* Added endpoints to `FavoriteRouteController` to create a favorite route from a ride (`POST /passengers/{passengerId}/favorite-routes/from-ride/{rideId}`) and to delete a favorite route by ride (`DELETE /passengers/{passengerId}/favorite-routes/by-ride/{rideId}`), delegating logic to the service layer.
* Implemented `createFromRide` and `deleteByPassengerAndSourceRideId` methods in `FavoriteRouteService` to handle creation (with validation and duplication checks) and deletion of favorite routes tied to specific rides.
* Updated `FavoriteRoute` entity to include a `sourceRideId` field, enabling linkage between favorite routes and the rides they originated from.
* Extended `FavoriteRouteRepository` with methods to find favorites by passenger and ride or by a set of ride IDs.

**Ride History API and DTO Enhancements:**

* Updated `PassengerRideHistoryItemResponse` DTO and `RideMapper` to include `isFavorite` and `favoriteRouteId` fields, allowing clients to know if a ride is a favorite and reference the associated favorite route. [[1]](diffhunk://#diff-ac99002cc88c0eb96544fbb50b19f60a68377dcf3f8d675cfc4f6cf7487fc2afL20-R22) [[2]](diffhunk://#diff-9b1c2aad2d935101fefcd0eea8a1e3c8f195d7dc901e361bed680d3cddfe0166L115-R141)
* Modified `PassengerController` to inject necessary repositories, efficiently batch-fetch favorite routes for rides in history, and populate the new DTO fields accordingly. [[1]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R3) [[2]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R16-R18) [[3]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R27-R28) [[4]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R39-R40) [[5]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R62-R63) [[6]](diffhunk://#diff-710c9b6745585d3a4ae6e3f214624aa0a64c10eef85f14af10a77781a7ac3fd5R73-R85)

**Frontend: Favorite Route Selection in Ride Ordering:**

* Enhanced the ride ordering UI (`order-ride.component.html`) to present a dropdown for selecting from favorite routes, and updated the component logic to fetch and manage the passenger's favorite routes. [[1]](diffhunk://#diff-f9105487de3730e777f8fdbec7c96cdd0f472f983201c6f4591dbb451be4dd67R81-R98) [[2]](diffhunk://#diff-30dd149e12f0d0a83c82035114fd710a0bbb1b187b1aa34c6fa375d8340be11fR15-R18) [[3]](diffhunk://#diff-30dd149e12f0d0a83c82035114fd710a0bbb1b187b1aa34c6fa375d8340be11fR96-R103) [[4]](diffhunk://#diff-30dd149e12f0d0a83c82035114fd710a0bbb1b187b1aa34c6fa375d8340be11fR175-R184)

**Other Improvements:**

* Added an explicit setter for `reminderMinutes` in the `Notification` entity for better IDE/reflection support.
* Simplified the scheduled ride reminder logic to send reminders at the correct time, removing an unnecessary helper method. [[1]](diffhunk://#diff-99c878d4905f4ee2b9dc4d30775d38d269515135fce3bc2d84174dc3a7ed85c7R58-R61) [[2]](diffhunk://#diff-99c878d4905f4ee2b9dc4d30775d38d269515135fce3bc2d84174dc3a7ed85c7L105-L110)