### PR TITLE
[BE 45] test: add stop ride unit tests 

### DIFF
--- a/drumigo/pom.xml
+++ b/drumigo/pom.xml
@@ -140,6 +140,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>androidx.annotation</groupId>
 			<artifactId>annotation</artifactId>
 			<version>1.0.0</version>

--- a/drumigo/src/test/java/com/ftn/drumigo/controller/RideControllerStopRideIntegrationTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/controller/RideControllerStopRideIntegrationTest.java
@@ -1,0 +1,248 @@
+package com.ftn.drumigo.controller;
+
+import com.ftn.drumigo.config.SecurityConfig;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import com.ftn.drumigo.dto.ride.request.RideStopRequest;
+import com.ftn.drumigo.dto.ride.response.RideResponse;
+import com.ftn.drumigo.exception.BadRequestException;
+import com.ftn.drumigo.exception.GlobalExceptionHandler;
+import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.mapper.DriverMapper;
+import com.ftn.drumigo.mapper.PanicEventMapper;
+import com.ftn.drumigo.mapper.ReviewMapper;
+import com.ftn.drumigo.mapper.RideInconsistencyMapper;
+import com.ftn.drumigo.mapper.RideMapper;
+import com.ftn.drumigo.mapper.VehicleMapper;
+import com.ftn.drumigo.repository.UserRepository;
+import com.ftn.drumigo.security.CustomUserDetails;
+import com.ftn.drumigo.security.JwtFilter;
+import com.ftn.drumigo.service.RideService;
+import com.ftn.drumigo.service.RideTrackingSimulationService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = RideController.class)
+@Import({SecurityConfig.class, GlobalExceptionHandler.class})
+@TestPropertySource(properties = {
+    "jwt.secret=testSecretKeyThatIsAtLeast32CharactersLongForHS256",
+    "jwt.expiration=3600000",
+    "maintenance.basic.username=admin",
+    "maintenance.basic.password=admin"
+})
+class RideControllerStopRideIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean private RideService rideService;
+    @MockitoBean private RideMapper rideMapper;
+    @MockitoBean private RideInconsistencyMapper rideInconsistencyMapper;
+    @MockitoBean private ReviewMapper reviewMapper;
+    @MockitoBean private PanicEventMapper panicEventMapper;
+    @MockitoBean private DriverMapper driverMapper;
+    @MockitoBean private VehicleMapper vehicleMapper;
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private RideTrackingSimulationService rideTrackingSimulationService;
+    @MockitoBean private JwtFilter jwtFilter;
+
+    @BeforeEach
+    void setUpJwtFilterToContinueChain() throws Exception {
+        doAnswer(invocation -> {
+            ServletRequest request = invocation.getArgument(0);
+            ServletResponse response = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(request, response);
+            return null;
+        }).when(jwtFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    void shouldStopRideAndReturnRideResponse_whenRequestIsValid() throws Exception {
+        String requestJson = """
+            {
+              "stopAddress": "Bulevar Oslobodjenja 1",
+              "stopLat": 45.25100000,
+              "stopLng": 19.84500000
+            }
+            """;
+
+        Ride stoppedRide = new Ride();
+        stoppedRide.setId(10L);
+        stoppedRide.setStatus(RideStatus.FINISHED);
+
+        RideResponse response = new RideResponse(
+            10L,
+            "FINISHED",
+            Instant.parse("2026-02-18T10:00:00Z"),
+            null,
+            Instant.parse("2026-02-18T10:10:00Z"),
+            Instant.parse("2026-02-18T10:30:00Z"),
+            Instant.parse("2026-02-18T10:30:00Z"),
+            55L,
+            "Marko",
+            "Jovanovic",
+            null,
+            new BigDecimal("560.00"),
+            new BigDecimal("6.20"),
+            1200,
+            Instant.parse("2026-02-18T10:32:00Z"),
+            false,
+            false,
+            List.of()
+        );
+
+        when(rideService.stopRide(eq(10L), eq(55L), any(RideStopRequest.class))).thenReturn(stoppedRide);
+        when(rideService.getRideWaypoints(stoppedRide)).thenReturn(List.<RideWaypoint>of());
+        when(rideMapper.toResponse(eq(stoppedRide), any())).thenReturn(response);
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 10L)
+                .with(authenticatedUser(55L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(10))
+            .andExpect(jsonPath("$.status").value("FINISHED"))
+            .andExpect(jsonPath("$.driverId").value(55));
+
+        ArgumentCaptor<RideStopRequest> requestCaptor = ArgumentCaptor.forClass(RideStopRequest.class);
+        verify(rideService).stopRide(eq(10L), eq(55L), requestCaptor.capture());
+        RideStopRequest captured = requestCaptor.getValue();
+        org.junit.jupiter.api.Assertions.assertEquals("Bulevar Oslobodjenja 1", captured.stopAddress());
+        org.junit.jupiter.api.Assertions.assertEquals(new BigDecimal("45.25100000"), captured.stopLat());
+        org.junit.jupiter.api.Assertions.assertEquals(new BigDecimal("19.84500000"), captured.stopLng());
+    }
+
+    @Test
+    void shouldReturnForbidden_whenUserIsNotAuthenticated() throws Exception {
+        String requestJson = """
+            {
+              "stopAddress": "Bulevar Oslobodjenja 1",
+              "stopLat": 45.25100000,
+              "stopLng": 19.84500000
+            }
+            """;
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 10L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldReturnValidationError_whenStopAddressIsBlank() throws Exception {
+        String invalidRequestJson = """
+            {
+              "stopAddress": "   ",
+              "stopLat": 45.25100000,
+              "stopLng": 19.84500000
+            }
+            """;
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 10L)
+                .with(authenticatedUser(55L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidRequestJson))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.validationErrors[0].field").value("stopAddress"));
+    }
+
+    @Test
+    void shouldReturnValidationError_whenLatitudeIsMissing() throws Exception {
+        String invalidRequestJson = """
+            {
+              "stopAddress": "Bulevar Oslobodjenja 1",
+              "stopLng": 19.84500000
+            }
+            """;
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 10L)
+                .with(authenticatedUser(55L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidRequestJson))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenServiceRejectsStopRide() throws Exception {
+        String requestJson = """
+            {
+              "stopAddress": "Stop",
+              "stopLat": 45.25100000,
+              "stopLng": 19.84500000
+            }
+            """;
+        when(rideService.stopRide(eq(10L), eq(55L), any(RideStopRequest.class)))
+            .thenThrow(new BadRequestException("Ride must be ACTIVE to be stopped. Current status: ACCEPTED"));
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 10L)
+                .with(authenticatedUser(55L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("Ride must be ACTIVE to be stopped. Current status: ACCEPTED"));
+    }
+
+    @Test
+    void shouldReturnNotFound_whenRideDoesNotExist() throws Exception {
+        String requestJson = """
+            {
+              "stopAddress": "Stop",
+              "stopLat": 45.25100000,
+              "stopLng": 19.84500000
+            }
+            """;
+        when(rideService.stopRide(eq(404L), eq(55L), any(RideStopRequest.class)))
+            .thenThrow(new ResourceNotFoundException("Ride not found with id: 404"));
+
+        mockMvc.perform(put("/api/rides/{id}/stop", 404L)
+                .with(authenticatedUser(55L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.message").value("Ride not found with id: 404"));
+    }
+
+    private RequestPostProcessor authenticatedUser(Long userId, String role) {
+        CustomUserDetails principal = new CustomUserDetails(userId, "user@test.local", role);
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            principal.getAuthorities()
+        );
+        return authentication(auth);
+    }
+}

--- a/drumigo/src/test/java/com/ftn/drumigo/repository/LocationRepositoryTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/repository/LocationRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.ftn.drumigo.repository;
+
+import com.ftn.drumigo.domain.Location;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest(properties = {
+    "spring.profiles.active=test",
+    "spring.datasource.url=jdbc:h2:mem:location_repo_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.test.database.replace=NONE",
+    "maintenance.basic.username=admin",
+    "maintenance.basic.password=admin",
+    "jwt.secret=testSecretKeyThatIsAtLeast32CharactersLongForHS256",
+    "jwt.expiration=3600000"
+})
+class LocationRepositoryTest {
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Test
+    void shouldFindLocationByAddressAndCoordinates_whenExactMatchExists() {
+        Location location = new Location();
+        location.setAddress("Bulevar Oslobodjenja 1");
+        location.setLat(new BigDecimal("45.25100000"));
+        location.setLng(new BigDecimal("19.84500000"));
+        locationRepository.save(location);
+
+        Optional<Location> found = locationRepository.findByAddressAndLatAndLng(
+            "Bulevar Oslobodjenja 1",
+            new BigDecimal("45.25100000"),
+            new BigDecimal("19.84500000")
+        );
+
+        assertTrue(found.isPresent());
+        assertEquals("Bulevar Oslobodjenja 1", found.get().getAddress());
+    }
+
+    @Test
+    void shouldReturnEmpty_whenCoordinatesDiffer() {
+        Location location = new Location();
+        location.setAddress("Bulevar Oslobodjenja 1");
+        location.setLat(new BigDecimal("45.25100000"));
+        location.setLng(new BigDecimal("19.84500000"));
+        locationRepository.save(location);
+
+        Optional<Location> found = locationRepository.findByAddressAndLatAndLng(
+            "Bulevar Oslobodjenja 1",
+            new BigDecimal("45.25200000"),
+            new BigDecimal("19.84500000")
+        );
+
+        assertTrue(found.isEmpty());
+    }
+}

--- a/drumigo/src/test/java/com/ftn/drumigo/repository/RideWaypointRepositoryTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/repository/RideWaypointRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.ftn.drumigo.repository;
+
+import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest(properties = {
+    "spring.profiles.active=test",
+    "spring.datasource.url=jdbc:h2:mem:ride_waypoint_repo_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
+    "spring.test.database.replace=NONE",
+    "maintenance.basic.username=admin",
+    "maintenance.basic.password=admin",
+    "jwt.secret=testSecretKeyThatIsAtLeast32CharactersLongForHS256",
+    "jwt.expiration=3600000"
+})
+class RideWaypointRepositoryTest {
+
+    @Autowired
+    private RideWaypointRepository rideWaypointRepository;
+
+    @Autowired
+    private RideRepository rideRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Test
+    void shouldFindWaypointsOrderedAscendingByWaypointOrder() {
+        Ride ride = createRide();
+        RideWaypoint wp2 = createWaypoint(ride, "Destination", "45.26000000", "19.88000000", 2);
+        RideWaypoint wp0 = createWaypoint(ride, "Pickup", "45.25100000", "19.84500000", 0);
+        RideWaypoint wp1 = createWaypoint(ride, "Midpoint", "45.25500000", "19.86000000", 1);
+        rideWaypointRepository.saveAll(List.of(wp2, wp0, wp1));
+
+        List<RideWaypoint> ordered = rideWaypointRepository.findByRideOrderByWaypointOrderAsc(ride);
+
+        assertEquals(3, ordered.size());
+        assertEquals(0, ordered.get(0).getWaypointOrder());
+        assertEquals(1, ordered.get(1).getWaypointOrder());
+        assertEquals(2, ordered.get(2).getWaypointOrder());
+    }
+
+    @Test
+    void shouldFindLastWaypointByHighestOrder() {
+        Ride ride = createRide();
+        rideWaypointRepository.save(createWaypoint(ride, "Pickup", "45.25100000", "19.84500000", 0));
+        rideWaypointRepository.save(createWaypoint(ride, "Midpoint", "45.25500000", "19.86000000", 1));
+        rideWaypointRepository.save(createWaypoint(ride, "Destination", "45.26000000", "19.88000000", 2));
+
+        Optional<RideWaypoint> last = rideWaypointRepository.findFirstByRideOrderByWaypointOrderDesc(ride);
+
+        assertTrue(last.isPresent());
+        assertEquals(2, last.get().getWaypointOrder());
+        assertEquals("Destination", last.get().getLocation().getAddress());
+    }
+
+    @Test
+    void shouldDeleteWaypointsWithOrderGreaterThanThreshold() {
+        Ride ride = createRide();
+        rideWaypointRepository.save(createWaypoint(ride, "Pickup", "45.25100000", "19.84500000", 0));
+        rideWaypointRepository.save(createWaypoint(ride, "Midpoint", "45.25500000", "19.86000000", 1));
+        rideWaypointRepository.save(createWaypoint(ride, "Destination", "45.26000000", "19.88000000", 2));
+
+        rideWaypointRepository.deleteByRideAndWaypointOrderGreaterThan(ride, 0);
+        List<RideWaypoint> remaining = rideWaypointRepository.findByRideOrderByWaypointOrderAsc(ride);
+
+        assertEquals(1, remaining.size());
+        assertEquals(0, remaining.get(0).getWaypointOrder());
+        assertEquals("Pickup", remaining.get(0).getLocation().getAddress());
+    }
+
+    private Ride createRide() {
+        Ride ride = new Ride();
+        ride.setStatus(RideStatus.ACTIVE);
+        return rideRepository.save(ride);
+    }
+
+    private RideWaypoint createWaypoint(Ride ride, String address, String lat, String lng, int order) {
+        Location location = new Location();
+        location.setAddress(address);
+        location.setLat(new BigDecimal(lat));
+        location.setLng(new BigDecimal(lng));
+        location = locationRepository.save(location);
+
+        RideWaypoint waypoint = new RideWaypoint();
+        waypoint.setRide(ride);
+        waypoint.setLocation(location);
+        waypoint.setWaypointOrder(order);
+        return waypoint;
+    }
+}

--- a/drumigo/src/test/java/com/ftn/drumigo/service/RideServiceStopRideUnitTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/service/RideServiceStopRideUnitTest.java
@@ -1,0 +1,260 @@
+package com.ftn.drumigo.service;
+
+import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import com.ftn.drumigo.domain.users.Driver;
+import com.ftn.drumigo.dto.map.LocationDTO;
+import com.ftn.drumigo.dto.ride.request.RideStopRequest;
+import com.ftn.drumigo.dto.ride.request.EstimateRequest;
+import com.ftn.drumigo.dto.ride.response.EstimateResponse;
+import com.ftn.drumigo.event.RideFinishedEvent;
+import com.ftn.drumigo.exception.BadRequestException;
+import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.repository.DriverRepository;
+import com.ftn.drumigo.repository.LocationRepository;
+import com.ftn.drumigo.repository.NotificationRepository;
+import com.ftn.drumigo.repository.PanicEventRepository;
+import com.ftn.drumigo.repository.PassengerRepository;
+import com.ftn.drumigo.repository.ReviewRepository;
+import com.ftn.drumigo.repository.RideInconsistencyRepository;
+import com.ftn.drumigo.repository.RidePassengerRepository;
+import com.ftn.drumigo.repository.RideRepository;
+import com.ftn.drumigo.repository.RideWaypointRepository;
+import com.ftn.drumigo.repository.UserRepository;
+import com.ftn.drumigo.repository.VehicleRepository;
+import com.ftn.drumigo.repository.VehicleTypeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RideServiceStopRideUnitTest {
+
+    @Mock private RideRepository rideRepository;
+    @Mock private RideWaypointRepository rideWaypointRepository;
+    @Mock private RideInconsistencyRepository rideInconsistencyRepository;
+    @Mock private RidePassengerRepository ridePassengerRepository;
+    @Mock private PassengerRepository passengerRepository;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private DriverRepository driverRepository;
+    @Mock private VehicleRepository vehicleRepository;
+    @Mock private VehicleTypeRepository vehicleTypeRepository;
+    @Mock private LocationRepository locationRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private PanicEventRepository panicEventRepository;
+    @Mock private ReviewRepository reviewRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private MapService mapService;
+    @Mock private AssignmentNotificationService assignmentNotificationService;
+
+    @InjectMocks
+    private RideService rideService;
+
+    private Driver assignedDriver;
+    private Ride activeRide;
+    private RideStopRequest stopRequest;
+
+    @BeforeEach
+    void setUp() {
+        assignedDriver = new Driver();
+        assignedDriver.setId(77L);
+        assignedDriver.setBusy(true);
+
+        activeRide = new Ride();
+        activeRide.setId(1001L);
+        activeRide.setStatus(RideStatus.ACTIVE);
+        activeRide.setDriver(assignedDriver);
+        activeRide.setRequestedAt(Instant.now().minusSeconds(1200));
+        activeRide.setStartTime(Instant.now().minusSeconds(900));
+        activeRide.setPricingPricePerKm(new BigDecimal("100.00"));
+        activeRide.setTotalCost(new BigDecimal("1000.00"));
+        activeRide.setTotalDistanceKm(new BigDecimal("10.00"));
+
+        stopRequest = new RideStopRequest(
+            "Stop Point 1",
+            new BigDecimal("45.25100000"),
+            new BigDecimal("19.84500000")
+        );
+
+        lenient().when(rideRepository.findById(activeRide.getId())).thenReturn(Optional.of(activeRide));
+        lenient().when(rideRepository.save(any(Ride.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(driverRepository.save(any(Driver.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().doNothing().when(rideWaypointRepository).deleteByRideAndWaypointOrderGreaterThan(any(Ride.class), eq(0));
+    }
+
+    @Test
+    void shouldStopRideAndRecalculateCostAndDistance_whenActiveAndDriverAssigned() {
+        Location existingStop = createLocation(501L, stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng());
+        Location destinationLocation = createLocation(502L, "Destination", new BigDecimal("45.27000000"), new BigDecimal("19.90000000"));
+        RideWaypoint destination = new RideWaypoint(9001L, activeRide, destinationLocation, 2);
+
+        when(locationRepository.findByAddressAndLatAndLng(
+            stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng()
+        )).thenReturn(Optional.of(existingStop));
+        when(rideWaypointRepository.findFirstByRideOrderByWaypointOrderDesc(activeRide)).thenReturn(Optional.of(destination));
+        when(mapService.estimateRide(any(EstimateRequest.class))).thenReturn(
+            new EstimateResponse("poly", List.of(List.of(19.0, 45.0)), 5.0, 10, 500.0)
+        );
+
+        Ride stoppedRide = rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest);
+
+        assertEquals(RideStatus.FINISHED, stoppedRide.getStatus());
+        assertEquals(0, stoppedRide.getTotalCost().compareTo(new BigDecimal("500.00")));
+        assertEquals(0, stoppedRide.getTotalDistanceKm().compareTo(new BigDecimal("5.00")));
+        assertEquals(existingStop, stoppedRide.getStopLocation());
+        assertNotNull(stoppedRide.getStoppedAt());
+        assertNotNull(stoppedRide.getEndTime());
+        assertNotNull(stoppedRide.getPaidAt());
+        assertEquals(false, assignedDriver.isBusy());
+
+        verify(locationRepository, never()).save(any(Location.class));
+        verify(rideWaypointRepository).deleteByRideAndWaypointOrderGreaterThan(activeRide, 0);
+        verify(rideRepository).save(activeRide);
+        verify(driverRepository).save(assignedDriver);
+
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertInstanceOf(RideFinishedEvent.class, eventCaptor.getValue());
+        assertEquals(activeRide.getId(), ((RideFinishedEvent) eventCaptor.getValue()).rideId());
+    }
+
+    @Test
+    void shouldCreateStopLocation_whenLocationDoesNotExist() {
+        when(locationRepository.findByAddressAndLatAndLng(
+            stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng()
+        )).thenReturn(Optional.empty());
+        when(locationRepository.save(any(Location.class))).thenAnswer(invocation -> {
+            Location saved = invocation.getArgument(0);
+            saved.setId(777L);
+            return saved;
+        });
+        when(rideWaypointRepository.findFirstByRideOrderByWaypointOrderDesc(activeRide)).thenReturn(Optional.empty());
+
+        Ride stoppedRide = rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest);
+
+        assertNotNull(stoppedRide.getStopLocation());
+        assertEquals(777L, stoppedRide.getStopLocation().getId());
+        verify(locationRepository).save(any(Location.class));
+        verify(mapService, never()).estimateRide(any(EstimateRequest.class));
+    }
+
+    @Test
+    void shouldClampCostAndDistanceToZero_whenRemainingIsGreaterThanOriginal() {
+        activeRide.setTotalCost(new BigDecimal("100.00"));
+        activeRide.setTotalDistanceKm(new BigDecimal("1.00"));
+        activeRide.setPricingPricePerKm(new BigDecimal("200.00"));
+
+        Location existingStop = createLocation(501L, stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng());
+        Location destinationLocation = createLocation(502L, "Destination", new BigDecimal("45.27000000"), new BigDecimal("19.90000000"));
+        RideWaypoint destination = new RideWaypoint(9001L, activeRide, destinationLocation, 2);
+
+        when(locationRepository.findByAddressAndLatAndLng(
+            stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng()
+        )).thenReturn(Optional.of(existingStop));
+        when(rideWaypointRepository.findFirstByRideOrderByWaypointOrderDesc(activeRide)).thenReturn(Optional.of(destination));
+        when(mapService.estimateRide(any(EstimateRequest.class))).thenReturn(
+            new EstimateResponse("poly", List.of(), 2.0, 5, 100.0)
+        );
+
+        Ride stoppedRide = rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest);
+
+        assertEquals(0, stoppedRide.getTotalCost().compareTo(BigDecimal.ZERO));
+        assertEquals(0, stoppedRide.getTotalDistanceKm().compareTo(BigDecimal.ZERO));
+    }
+
+    @Test
+    void shouldStillStopRide_whenMapServiceFails() {
+        Location existingStop = createLocation(501L, stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng());
+        Location destinationLocation = createLocation(502L, "Destination", new BigDecimal("45.27000000"), new BigDecimal("19.90000000"));
+        RideWaypoint destination = new RideWaypoint(9001L, activeRide, destinationLocation, 2);
+        BigDecimal originalCost = activeRide.getTotalCost();
+        BigDecimal originalDistance = activeRide.getTotalDistanceKm();
+
+        when(locationRepository.findByAddressAndLatAndLng(
+            stopRequest.stopAddress(), stopRequest.stopLat(), stopRequest.stopLng()
+        )).thenReturn(Optional.of(existingStop));
+        when(rideWaypointRepository.findFirstByRideOrderByWaypointOrderDesc(activeRide)).thenReturn(Optional.of(destination));
+        when(mapService.estimateRide(any(EstimateRequest.class))).thenThrow(new RuntimeException("Map provider unavailable"));
+
+        Ride stoppedRide = rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest);
+
+        assertEquals(RideStatus.FINISHED, stoppedRide.getStatus());
+        assertEquals(0, stoppedRide.getTotalCost().compareTo(originalCost));
+        assertEquals(0, stoppedRide.getTotalDistanceKm().compareTo(originalDistance));
+    }
+
+    @Test
+    void shouldThrowBadRequest_whenDriverIsNotAssignedToRide() {
+        Driver anotherDriver = new Driver();
+        anotherDriver.setId(88L);
+        activeRide.setDriver(anotherDriver);
+
+        BadRequestException ex = assertThrows(
+            BadRequestException.class,
+            () -> rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest)
+        );
+
+        assertEquals("Driver is not assigned to this ride", ex.getMessage());
+        verify(locationRepository, never()).findByAddressAndLatAndLng(any(), any(), any());
+        verify(rideRepository, never()).save(any(Ride.class));
+    }
+
+    @Test
+    void shouldThrowBadRequest_whenRideIsNotActive() {
+        activeRide.setStatus(RideStatus.ACCEPTED);
+
+        BadRequestException ex = assertThrows(
+            BadRequestException.class,
+            () -> rideService.stopRide(activeRide.getId(), assignedDriver.getId(), stopRequest)
+        );
+
+        assertEquals("Ride must be ACTIVE to be stopped. Current status: ACCEPTED", ex.getMessage());
+        verify(locationRepository, never()).findByAddressAndLatAndLng(any(), any(), any());
+        verify(rideRepository, never()).save(any(Ride.class));
+    }
+
+    @Test
+    void shouldThrowResourceNotFound_whenRideDoesNotExist() {
+        when(rideRepository.findById(404L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(
+            ResourceNotFoundException.class,
+            () -> rideService.stopRide(404L, assignedDriver.getId(), stopRequest)
+        );
+
+        assertEquals("Ride not found with id: 404", ex.getMessage());
+    }
+
+    private Location createLocation(Long id, String address, BigDecimal lat, BigDecimal lng) {
+        Location location = new Location();
+        location.setId(id);
+        location.setAddress(address);
+        location.setLat(lat);
+        location.setLng(lng);
+        return location;
+    }
+}


### PR DESCRIPTION
Closes #196 

This pull request introduces comprehensive integration and repository tests for the ride and location-related functionality, and ensures proper test database setup by adding the H2 database as a test dependency. The new tests cover controller integration for stopping rides and repository behaviors for both locations and ride waypoints, improving confidence in the correctness of these components.

**Test Infrastructure Improvements:**

* Added the H2 in-memory database as a test-scoped dependency in `pom.xml` to support JPA repository and integration tests.

**Integration and Repository Test Coverage:**

* Added `RideControllerStopRideIntegrationTest` to cover the `/api/rides/{id}/stop` endpoint, including scenarios for successful ride stopping, authentication, validation, and error handling.

* Added `LocationRepositoryTest` to verify correct behavior of `LocationRepository`, including finding locations by address and coordinates and handling mismatches.

* Added `RideWaypointRepositoryTest` to test `RideWaypointRepository` methods for ordering, finding the last waypoint, and deleting waypoints above a certain order, using real database interactions.