### PR TITLE
[BE 43] test: add unit tests for ride ordering

### DIFF
--- a/drumigo/src/test/java/com/ftn/drumigo/controller/RideControllerCreateRideIntegrationTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/controller/RideControllerCreateRideIntegrationTest.java
@@ -1,0 +1,213 @@
+package com.ftn.drumigo.controller;
+
+import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RideWaypoint;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import com.ftn.drumigo.exception.BadRequestException;
+import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.security.CustomUserDetails;
+import com.ftn.drumigo.service.RideService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RideControllerCreateRideIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RideService rideService;
+
+    @Test
+    void createRide_whenPassengerRoleAndValidRequest_returnsCreatedRide() throws Exception {
+        Ride ride = acceptedRide(101L, 7L);
+        List<RideWaypoint> waypoints = List.of(
+            waypoint(ride, 1, "Bulevar Oslobodjenja 1"),
+            waypoint(ride, 2, "Narodnog Fronta 10")
+        );
+        when(rideService.create(eq(7L), any())).thenReturn(ride);
+        when(rideService.getRideWaypoints(ride)).thenReturn(waypoints);
+
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(7L, "PASSENGER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(101))
+            .andExpect(jsonPath("$.status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.driverId").value(44))
+            .andExpect(jsonPath("$.waypoints.length()").value(2));
+    }
+
+    @Test
+    void createRide_whenUnauthenticated_returns4xxAndDoesNotCallService() throws Exception {
+        mockMvc.perform(post("/api/rides")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().is4xxClientError());
+
+        verify(rideService, never()).create(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createRide_whenDriverRole_returnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(77L, "DRIVER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().isForbidden());
+
+        verify(rideService, never()).create(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createRide_whenRequestValidationFails_returnsBadRequest() throws Exception {
+        String invalidJson = """
+            {
+              "waypoints": [],
+              "vehicleType": null
+            }
+            """;
+
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(7L, "PASSENGER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidJson))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+        verify(rideService, never()).create(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void createRide_whenServiceThrowsResourceNotFound_returnsNotFound() throws Exception {
+        when(rideService.create(eq(7L), any()))
+            .thenThrow(new ResourceNotFoundException("Vehicle type not found: STANDARD"));
+
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(7L, "PASSENGER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+            .andExpect(jsonPath("$.message").value("Vehicle type not found: STANDARD"));
+    }
+
+    @Test
+    void createRide_whenServiceThrowsBadRequest_returnsBadRequest() throws Exception {
+        when(rideService.create(eq(7L), any()))
+            .thenThrow(new BadRequestException("Ride must have at least 2 waypoints (start and destination)"));
+
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(7L, "PASSENGER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+            .andExpect(jsonPath("$.message").value("Ride must have at least 2 waypoints (start and destination)"));
+    }
+
+    @Test
+    void createRide_passesAuthenticatedPassengerIdToService() throws Exception {
+        Ride ride = acceptedRide(202L, 9L);
+        when(rideService.create(eq(9L), any())).thenReturn(ride);
+        when(rideService.getRideWaypoints(ride)).thenReturn(List.of());
+
+        mockMvc.perform(post("/api/rides")
+                .with(authenticatedUser(9L, "PASSENGER"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateRideRequestJson()))
+            .andExpect(status().isCreated());
+
+        ArgumentCaptor<Long> passengerIdCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(rideService).create(passengerIdCaptor.capture(), org.mockito.ArgumentMatchers.any());
+        org.junit.jupiter.api.Assertions.assertEquals(9L, passengerIdCaptor.getValue());
+    }
+
+    private static String validCreateRideRequestJson() {
+        return """
+            {
+              "waypoints": [
+                {"address":"Bulevar Oslobodjenja 1","lat":45.2551,"lng":19.8452,"order":1},
+                {"address":"Narodnog Fronta 10","lat":45.2466,"lng":19.8369,"order":2}
+              ],
+              "vehicleType":"STANDARD",
+              "babyTransport":false,
+              "petTransport":false,
+              "linkedPassengerEmails":[]
+            }
+            """;
+    }
+
+    private static RequestPostProcessor authenticatedUser(Long userId, String role) {
+        CustomUserDetails principal = new CustomUserDetails(userId, role.toLowerCase() + "@mail.com", role);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        return authentication(auth);
+    }
+
+    private static Ride acceptedRide(Long rideId, Long orderingPassengerId) {
+        com.ftn.drumigo.domain.users.Passenger orderingPassenger = new com.ftn.drumigo.domain.users.Passenger();
+        orderingPassenger.setId(orderingPassengerId);
+        orderingPassenger.setName("Passenger");
+        orderingPassenger.setSurname("Test");
+
+        com.ftn.drumigo.domain.users.Driver driver = new com.ftn.drumigo.domain.users.Driver();
+        driver.setId(44L);
+        driver.setName("Driver");
+        driver.setSurname("Assigned");
+
+        Ride ride = new Ride();
+        ride.setId(rideId);
+        ride.setStatus(RideStatus.ACCEPTED);
+        ride.setOrderingPassenger(orderingPassenger);
+        ride.setDriver(driver);
+        ride.setRequestedAt(Instant.now());
+        ride.setBabyTransport(false);
+        ride.setPetTransport(false);
+        ride.setTotalCost(BigDecimal.valueOf(900));
+        ride.setTotalDistanceKm(BigDecimal.valueOf(6.2));
+        ride.setEstimatedDurationSec(900);
+        ride.setEstimatedArrivalAt(Instant.now().plusSeconds(900));
+        return ride;
+    }
+
+    private static RideWaypoint waypoint(Ride ride, int order, String address) {
+        Location location = new Location();
+        location.setId((long) order);
+        location.setAddress(address);
+        location.setLat(BigDecimal.valueOf(45.20 + order));
+        location.setLng(BigDecimal.valueOf(19.80 + order));
+
+        RideWaypoint waypoint = new RideWaypoint();
+        waypoint.setRide(ride);
+        waypoint.setWaypointOrder(order);
+        waypoint.setLocation(location);
+        return waypoint;
+    }
+}

--- a/drumigo/src/test/java/com/ftn/drumigo/repository/RideOrderingRepositoryTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/repository/RideOrderingRepositoryTest.java
@@ -1,0 +1,127 @@
+package com.ftn.drumigo.repository;
+
+import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Vehicle;
+import com.ftn.drumigo.domain.VehicleType;
+import com.ftn.drumigo.domain.enums.UserRole;
+import com.ftn.drumigo.domain.enums.VehicleTypeName;
+import com.ftn.drumigo.domain.users.Driver;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class RideOrderingRepositoryTest {
+
+    @Autowired
+    private DriverRepository driverRepository;
+    @Autowired
+    private VehicleRepository vehicleRepository;
+    @Autowired
+    private VehicleTypeRepository vehicleTypeRepository;
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @Test
+    void vehicleTypeRepository_findByName_returnsVehicleType() {
+        Optional<VehicleType> standard = vehicleTypeRepository.findByName(VehicleTypeName.STANDARD);
+
+        assertTrue(standard.isPresent());
+        assertEquals(VehicleTypeName.STANDARD, standard.orElseThrow().getName());
+    }
+
+    @Test
+    void locationRepository_findByAddressAndLatAndLng_returnsExactMatch() {
+        Location location = new Location();
+        location.setAddress("Test pickup point");
+        location.setLat(BigDecimal.valueOf(45.254321));
+        location.setLng(BigDecimal.valueOf(19.842345));
+        location = locationRepository.saveAndFlush(location);
+
+        Optional<Location> found = locationRepository.findByAddressAndLatAndLng(
+            "Test pickup point",
+            BigDecimal.valueOf(45.254321),
+            BigDecimal.valueOf(19.842345)
+        );
+
+        assertTrue(found.isPresent());
+        assertEquals(location.getId(), found.orElseThrow().getId());
+    }
+
+    @Test
+    void vehicleRepository_findByDriver_returnsDriversVehicle() {
+        VehicleType standardType = vehicleTypeRepository.findByName(VehicleTypeName.STANDARD).orElseThrow();
+        Driver driver = persistDriver("vehicle.find.driver@mail.com", true);
+        Vehicle vehicle = persistVehicle(driver, standardType, "NS-100-TS");
+
+        Optional<Vehicle> found = vehicleRepository.findByDriver(driver);
+
+        assertTrue(found.isPresent());
+        assertEquals(vehicle.getId(), found.orElseThrow().getId());
+        assertEquals("NS-100-TS", found.orElseThrow().getLicensePlate());
+    }
+
+    @Test
+    void vehicleRepository_existsByLicensePlate_checksPresence() {
+        VehicleType standardType = vehicleTypeRepository.findByName(VehicleTypeName.STANDARD).orElseThrow();
+        Driver driver = persistDriver("vehicle.exists.plate@mail.com", true);
+        persistVehicle(driver, standardType, "NS-200-TS");
+
+        assertTrue(vehicleRepository.existsByLicensePlate("NS-200-TS"));
+        assertFalse(vehicleRepository.existsByLicensePlate("NS-404-TS"));
+    }
+
+    @Test
+    void vehicleRepository_findByDriverActiveDriverTrue_returnsOnlyVehiclesOfActiveDrivers() {
+        VehicleType standardType = vehicleTypeRepository.findByName(VehicleTypeName.STANDARD).orElseThrow();
+        Driver activeDriver = persistDriver("vehicle.active.driver@mail.com", true);
+        Driver inactiveDriver = persistDriver("vehicle.inactive.driver@mail.com", false);
+        Vehicle activeVehicle = persistVehicle(activeDriver, standardType, "NS-300-TS");
+        Vehicle inactiveVehicle = persistVehicle(inactiveDriver, standardType, "NS-301-TS");
+
+        List<Vehicle> activeDriverVehicles = vehicleRepository.findByDriverActiveDriverTrue();
+        Set<Long> vehicleIds = activeDriverVehicles.stream().map(Vehicle::getId).collect(Collectors.toSet());
+
+        assertTrue(vehicleIds.contains(activeVehicle.getId()));
+        assertFalse(vehicleIds.contains(inactiveVehicle.getId()));
+    }
+
+    private Driver persistDriver(String email, boolean activeDriver) {
+        Driver driver = new Driver();
+        driver.setName("Driver");
+        driver.setSurname("Ordering");
+        driver.setEmail(email);
+        driver.setActive(true);
+        driver.setRole(UserRole.DRIVER);
+        driver.setBlocked(false);
+        driver.setActiveDriver(activeDriver);
+        driver.setBusy(false);
+        return driverRepository.saveAndFlush(driver);
+    }
+
+    private Vehicle persistVehicle(Driver driver, VehicleType type, String licensePlate) {
+        Vehicle vehicle = new Vehicle();
+        vehicle.setDriver(driver);
+        vehicle.setModel("Model X");
+        vehicle.setLicensePlate(licensePlate);
+        vehicle.setVehicleType(type);
+        vehicle.setNumSeats(4);
+        vehicle.setBabyFriendly(true);
+        vehicle.setPetFriendly(true);
+        vehicle.setCurrentLat(BigDecimal.valueOf(45.25));
+        vehicle.setCurrentLng(BigDecimal.valueOf(19.84));
+        return vehicleRepository.saveAndFlush(vehicle);
+    }
+}

--- a/drumigo/src/test/java/com/ftn/drumigo/service/RideServiceCreateRideTest.java
+++ b/drumigo/src/test/java/com/ftn/drumigo/service/RideServiceCreateRideTest.java
@@ -1,0 +1,406 @@
+package com.ftn.drumigo.service;
+
+import com.ftn.drumigo.domain.Location;
+import com.ftn.drumigo.domain.Notification;
+import com.ftn.drumigo.domain.Ride;
+import com.ftn.drumigo.domain.RidePassenger;
+import com.ftn.drumigo.domain.Vehicle;
+import com.ftn.drumigo.domain.VehicleType;
+import com.ftn.drumigo.domain.enums.NotificationType;
+import com.ftn.drumigo.domain.enums.RideStatus;
+import com.ftn.drumigo.domain.enums.UserRole;
+import com.ftn.drumigo.domain.enums.VehicleTypeName;
+import com.ftn.drumigo.domain.users.Driver;
+import com.ftn.drumigo.domain.users.Passenger;
+import com.ftn.drumigo.dto.RideCreateRequest;
+import com.ftn.drumigo.dto.ride.response.EstimateResponse;
+import com.ftn.drumigo.exception.BadRequestException;
+import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.repository.DriverRepository;
+import com.ftn.drumigo.repository.LocationRepository;
+import com.ftn.drumigo.repository.NotificationRepository;
+import com.ftn.drumigo.repository.PanicEventRepository;
+import com.ftn.drumigo.repository.PassengerRepository;
+import com.ftn.drumigo.repository.ReviewRepository;
+import com.ftn.drumigo.repository.RideInconsistencyRepository;
+import com.ftn.drumigo.repository.RidePassengerRepository;
+import com.ftn.drumigo.repository.RideRepository;
+import com.ftn.drumigo.repository.RideWaypointRepository;
+import com.ftn.drumigo.repository.UserRepository;
+import com.ftn.drumigo.repository.VehicleRepository;
+import com.ftn.drumigo.repository.VehicleTypeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RideServiceCreateRideTest {
+
+    @Mock
+    private RideRepository rideRepository;
+    @Mock
+    private RideWaypointRepository rideWaypointRepository;
+    @Mock
+    private RideInconsistencyRepository rideInconsistencyRepository;
+    @Mock
+    private RidePassengerRepository ridePassengerRepository;
+    @Mock
+    private PassengerRepository passengerRepository;
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private DriverRepository driverRepository;
+    @Mock
+    private VehicleRepository vehicleRepository;
+    @Mock
+    private VehicleTypeRepository vehicleTypeRepository;
+    @Mock
+    private LocationRepository locationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PanicEventRepository panicEventRepository;
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private MapService mapService;
+    @Mock
+    private AssignmentNotificationService assignmentNotificationService;
+
+    @InjectMocks
+    private RideService rideService;
+
+    @Test
+    void create_whenPassengerHasActiveRide_throwsBadRequest() {
+        Passenger passenger = passenger(10L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of(), false, false);
+        when(passengerRepository.findById(10L)).thenReturn(Optional.of(passenger));
+        when(rideRepository.existsActiveRideForPassenger(10L, "orderer@mail.com",
+            List.of(RideStatus.PENDING, RideStatus.ACCEPTED, RideStatus.ACTIVE))).thenReturn(true);
+
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> rideService.create(10L, request));
+
+        assertEquals("Cannot create a new ride while you have an active ride. Please wait until your current ride is finished.", ex.getMessage());
+        verify(rideRepository, never()).save(any(Ride.class));
+    }
+
+    @Test
+    void create_whenWaypointsLessThanTwo_throwsBadRequest() {
+        Passenger passenger = passenger(11L, "orderer@mail.com");
+        RideCreateRequest request = new RideCreateRequest(
+            List.of(new RideCreateRequest.WaypointRequest("Only one", BigDecimal.valueOf(45.2), BigDecimal.valueOf(19.8), 1)),
+            VehicleTypeName.STANDARD,
+            false,
+            false,
+            List.of(),
+            null
+        );
+        when(passengerRepository.findById(11L)).thenReturn(Optional.of(passenger));
+        when(rideRepository.existsActiveRideForPassenger(any(), any(), anyList())).thenReturn(false);
+
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> rideService.create(11L, request));
+
+        assertEquals("Ride must have at least 2 waypoints (start and destination)", ex.getMessage());
+    }
+
+    @Test
+    void create_whenScheduledMoreThanFiveHoursAhead_throwsBadRequest() {
+        Passenger passenger = passenger(12L, "orderer@mail.com");
+        Instant tooLate = Instant.now().plusSeconds(6 * 3600);
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, tooLate, List.of(), false, false);
+        when(passengerRepository.findById(12L)).thenReturn(Optional.of(passenger));
+        when(rideRepository.existsActiveRideForPassenger(any(), any(), anyList())).thenReturn(false);
+
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> rideService.create(12L, request));
+
+        assertEquals("Ride cannot be scheduled more than 5 hours in advance", ex.getMessage());
+    }
+
+    @Test
+    void create_whenVehicleTypeMissing_throwsResourceNotFound() {
+        Passenger passenger = passenger(13L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of(), false, false);
+        when(passengerRepository.findById(13L)).thenReturn(Optional.of(passenger));
+        when(rideRepository.existsActiveRideForPassenger(any(), any(), anyList())).thenReturn(false);
+        when(vehicleTypeRepository.findByName(VehicleTypeName.STANDARD)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException ex = assertThrows(ResourceNotFoundException.class, () -> rideService.create(13L, request));
+
+        assertEquals("Vehicle type not found: STANDARD", ex.getMessage());
+    }
+
+    @Test
+    void create_whenNoActiveDrivers_rejectsRideAndCreatesRejectionNotification() {
+        Passenger passenger = passenger(14L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of(), false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of());
+
+        Ride result = rideService.create(14L, request);
+
+        assertEquals(RideStatus.REJECTED, result.getStatus());
+        ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(notificationCaptor.capture());
+        Notification rejection = notificationCaptor.getValue();
+        assertEquals(NotificationType.RIDE_REJECTED, rejection.getType());
+        assertEquals("Your ride request has been rejected. There are currently no active drivers.", rejection.getMessage());
+    }
+
+    @Test
+    void create_whenFreeEligibleDriverExists_assignsDriverAndMarksBusy() {
+        Passenger passenger = passenger(15L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of(), false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        Driver driver = driver(20L, true, false);
+        Vehicle vehicle = vehicle(driver, vehicleType, true, true, BigDecimal.valueOf(45.255), BigDecimal.valueOf(19.845));
+
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of(driver));
+        when(rideRepository.findDriverRidesWithActivitySince(eq(driver), any())).thenReturn(List.of());
+        when(vehicleRepository.findByDriver(driver)).thenReturn(Optional.of(vehicle));
+        when(rideRepository.findByDriverAndStatusIn(eq(driver), anyList())).thenReturn(List.of());
+
+        Ride result = rideService.create(15L, request);
+
+        assertEquals(RideStatus.ACCEPTED, result.getStatus());
+        assertEquals(driver.getId(), result.getDriver().getId());
+        verify(driverRepository).save(driver);
+        verify(notificationRepository, times(2)).save(any(Notification.class));
+    }
+
+    @Test
+    void create_whenScheduledRideInFuture_doesNotMarkDriverBusyImmediately() {
+        Passenger passenger = passenger(16L, "orderer@mail.com");
+        Instant scheduledFor = Instant.now().plusSeconds(3600);
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, scheduledFor, List.of(), false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        Driver driver = driver(21L, true, false);
+        Vehicle vehicle = vehicle(driver, vehicleType, true, true, BigDecimal.valueOf(45.255), BigDecimal.valueOf(19.845));
+
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of(driver));
+        when(rideRepository.findDriverRidesWithActivitySince(eq(driver), any())).thenReturn(List.of());
+        when(vehicleRepository.findByDriver(driver)).thenReturn(Optional.of(vehicle));
+        when(rideRepository.findByDriverAndStatusIn(eq(driver), anyList())).thenReturn(List.of());
+
+        Ride result = rideService.create(16L, request);
+
+        assertEquals(RideStatus.ACCEPTED, result.getStatus());
+        verify(driverRepository, never()).save(driver);
+    }
+
+    @Test
+    void create_whenFallbackBusyDriverFinishingWithinTenMinutes_assignsFallbackDriver() {
+        Passenger passenger = passenger(17L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of(), false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        Driver busyDriver = driver(22L, true, true);
+        Vehicle vehicle = vehicle(busyDriver, vehicleType, true, true, BigDecimal.valueOf(45.255), BigDecimal.valueOf(19.845));
+        Ride activeAssignment = new Ride();
+        activeAssignment.setStatus(RideStatus.ACTIVE);
+        activeAssignment.setStartTime(Instant.now().minusSeconds(300));
+        activeAssignment.setEstimatedArrivalAt(Instant.now().plusSeconds(300));
+        activeAssignment.setEstimatedDurationSec(900);
+
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of(busyDriver));
+        when(rideRepository.findDriverRidesWithActivitySince(eq(busyDriver), any())).thenReturn(List.of());
+        when(vehicleRepository.findByDriver(busyDriver)).thenReturn(Optional.of(vehicle));
+        when(rideRepository.findByDriverAndStatusIn(eq(busyDriver), anyList())).thenReturn(List.of(activeAssignment));
+
+        Ride result = rideService.create(17L, request);
+
+        assertEquals(RideStatus.ACCEPTED, result.getStatus());
+        assertEquals(busyDriver.getId(), result.getDriver().getId());
+    }
+
+    @Test
+    void create_whenLinkedEmailsContainOrderingPassenger_throwsBadRequest() {
+        Passenger passenger = passenger(18L, "orderer@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, List.of("orderer@mail.com"), false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        Driver driver = driver(23L, true, false);
+        Vehicle vehicle = vehicle(driver, vehicleType, true, true, BigDecimal.valueOf(45.255), BigDecimal.valueOf(19.845));
+
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of(driver));
+        when(rideRepository.findDriverRidesWithActivitySince(eq(driver), any())).thenReturn(List.of());
+        when(vehicleRepository.findByDriver(driver)).thenReturn(Optional.of(vehicle));
+        when(rideRepository.findByDriverAndStatusIn(eq(driver), anyList())).thenReturn(List.of());
+
+        BadRequestException ex = assertThrows(BadRequestException.class, () -> rideService.create(18L, request));
+
+        assertEquals("Cannot link the ordering passenger to their own ride", ex.getMessage());
+    }
+
+    @Test
+    void create_whenAcceptedWithLinkedPassengers_savesRidePassengersAndNotifiesAccepted() {
+        Passenger passenger = passenger(19L, "orderer@mail.com");
+        List<String> linked = List.of("friend1@mail.com", "friend2@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, linked, false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        Driver driver = driver(24L, true, false);
+        Vehicle vehicle = vehicle(driver, vehicleType, true, true, BigDecimal.valueOf(45.255), BigDecimal.valueOf(19.845));
+
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of(driver));
+        when(rideRepository.findDriverRidesWithActivitySince(eq(driver), any())).thenReturn(List.of());
+        when(vehicleRepository.findByDriver(driver)).thenReturn(Optional.of(vehicle));
+        when(rideRepository.findByDriverAndStatusIn(eq(driver), anyList())).thenReturn(List.of());
+        when(ridePassengerRepository.save(any(RidePassenger.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Ride result = rideService.create(19L, request);
+
+        assertEquals(RideStatus.ACCEPTED, result.getStatus());
+        verify(ridePassengerRepository, times(2)).save(any(RidePassenger.class));
+        verify(assignmentNotificationService).notifyLinkedPassengersAccepted(result, linked);
+        verify(assignmentNotificationService, never()).notifyLinkedPassengersRejected(any(), any(), anyList());
+    }
+
+    @Test
+    void create_whenRejectedWithLinkedPassengers_notifiesRejectedAndDoesNotSaveRidePassengers() {
+        Passenger passenger = passenger(20L, "orderer@mail.com");
+        List<String> linked = List.of("friend1@mail.com");
+        RideCreateRequest request = validRequest(VehicleTypeName.STANDARD, null, linked, false, false);
+        VehicleType vehicleType = vehicleType(1L, VehicleTypeName.STANDARD);
+        configureCreateBase(passenger, vehicleType);
+        when(driverRepository.findByActiveDriverTrue()).thenReturn(List.of());
+
+        Ride result = rideService.create(20L, request);
+
+        assertEquals(RideStatus.REJECTED, result.getStatus());
+        verify(ridePassengerRepository, never()).save(any(RidePassenger.class));
+        verify(assignmentNotificationService).notifyLinkedPassengersRejected(
+            eq(result),
+            eq("There are currently no active drivers."),
+            eq(linked)
+        );
+    }
+
+    private void configureCreateBase(Passenger passenger, VehicleType vehicleType) {
+        when(passengerRepository.findById(passenger.getId())).thenReturn(Optional.of(passenger));
+        when(rideRepository.existsActiveRideForPassenger(eq(passenger.getId()), eq(passenger.getEmail()), anyList())).thenReturn(false);
+        when(vehicleTypeRepository.findByName(vehicleType.getName())).thenReturn(Optional.of(vehicleType));
+        when(mapService.estimateRide(any())).thenReturn(new EstimateResponse("polyline", List.of(), 6.5, 12, 900.0));
+
+        AtomicLong rideIdCounter = new AtomicLong(1000);
+        when(rideRepository.save(any(Ride.class))).thenAnswer(invocation -> {
+            Ride ride = invocation.getArgument(0);
+            if (ride.getId() == null) {
+                ride.setId(rideIdCounter.getAndIncrement());
+            }
+            return ride;
+        });
+
+        AtomicLong locationIdCounter = new AtomicLong(2000);
+        when(locationRepository.findByAddressAndLatAndLng(any(), any(), any())).thenReturn(Optional.empty());
+        when(locationRepository.save(any(Location.class))).thenAnswer(invocation -> {
+            Location location = invocation.getArgument(0);
+            if (location.getId() == null) {
+                location.setId(locationIdCounter.getAndIncrement());
+            }
+            return location;
+        });
+        when(rideWaypointRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    private static RideCreateRequest validRequest(
+        VehicleTypeName vehicleTypeName,
+        Instant scheduledFor,
+        List<String> linkedEmails,
+        Boolean babyTransport,
+        Boolean petTransport
+    ) {
+        return new RideCreateRequest(
+            List.of(
+                new RideCreateRequest.WaypointRequest("Bulevar Oslobodjenja 1", BigDecimal.valueOf(45.2551), BigDecimal.valueOf(19.8452), 1),
+                new RideCreateRequest.WaypointRequest("Narodnog Fronta 10", BigDecimal.valueOf(45.2466), BigDecimal.valueOf(19.8369), 2)
+            ),
+            vehicleTypeName,
+            babyTransport,
+            petTransport,
+            linkedEmails,
+            scheduledFor
+        );
+    }
+
+    private static Passenger passenger(Long id, String email) {
+        Passenger passenger = new Passenger();
+        passenger.setId(id);
+        passenger.setEmail(email);
+        passenger.setName("Passenger");
+        passenger.setSurname("Tester");
+        passenger.setRole(UserRole.PASSENGER);
+        passenger.setActive(true);
+        passenger.setBlocked(false);
+        return passenger;
+    }
+
+    private static Driver driver(Long id, boolean activeDriver, boolean busy) {
+        Driver driver = new Driver();
+        driver.setId(id);
+        driver.setEmail("driver" + id + "@mail.com");
+        driver.setName("Driver");
+        driver.setSurname("Tester");
+        driver.setRole(UserRole.DRIVER);
+        driver.setActive(true);
+        driver.setBlocked(false);
+        driver.setActiveDriver(activeDriver);
+        driver.setBusy(busy);
+        return driver;
+    }
+
+    private static VehicleType vehicleType(Long id, VehicleTypeName name) {
+        VehicleType type = new VehicleType();
+        type.setId(id);
+        type.setName(name);
+        type.setStartPrice(BigDecimal.valueOf(200));
+        type.setPricePerKm(BigDecimal.valueOf(120));
+        return type;
+    }
+
+    private static Vehicle vehicle(
+        Driver driver,
+        VehicleType vehicleType,
+        Boolean babyFriendly,
+        Boolean petFriendly,
+        BigDecimal lat,
+        BigDecimal lng
+    ) {
+        Vehicle vehicle = new Vehicle();
+        vehicle.setId(driver.getId() + 100);
+        vehicle.setDriver(driver);
+        vehicle.setVehicleType(vehicleType);
+        vehicle.setLicensePlate("NS-" + driver.getId() + "-TS");
+        vehicle.setModel("Model");
+        vehicle.setNumSeats(4);
+        vehicle.setBabyFriendly(babyFriendly);
+        vehicle.setPetFriendly(petFriendly);
+        vehicle.setCurrentLat(lat);
+        vehicle.setCurrentLng(lng);
+        return vehicle;
+    }
+}


### PR DESCRIPTION
close #198 

This pull request introduces new integration and repository tests to improve the coverage and reliability of the ride creation flow and related repository methods in the Drumigo application. The most important changes are the addition of comprehensive integration tests for the ride creation controller and new repository tests for vehicle, driver, vehicle type, and location entities.

**Integration testing for ride creation:**

- Added `RideControllerCreateRideIntegrationTest` to cover successful ride creation, authentication and authorization checks, request validation, and error handling scenarios in the ride creation API endpoint. The tests verify correct service interactions and response payloads.

**Repository testing for ride ordering:**

- Added `RideOrderingRepositoryTest` to validate repository methods for `VehicleType`, `Location`, `Vehicle`, and `Driver` entities, including:
  - Finding vehicle types by name.
  - Finding locations by address and coordinates.
  - Retrieving vehicles by driver and checking license plate existence.
  - Ensuring only vehicles of active drivers are returned by the relevant query.