### PR TITLE
[MISC 06] test: add selenium ride rating e2e

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -3,6 +3,7 @@
 This module contains Java Selenium + JUnit 5 E2E tests for:
 - **2.9.3 Filtering and sorting ride history**
 - **2.4.3 Order from favorite routes** (select favorite on order page → pre-fill; add/remove favorite in passenger history)
+- **2.8 Rating vehicle and driver** (Student 2)
 
 ## Preconditions
 
@@ -16,6 +17,7 @@ This module contains Java Selenium + JUnit 5 E2E tests for:
 Default credentials used by tests (must match seed data; seed uses `Password12345` for all users):
 - **Admin**: email `stefan.nikolic@drumigo.com`, password `Password12345`
 - **Passenger** (for 2.4.3): email `ana.petrovic@example.com`, password `Password12345`
+- **Rating passenger** (for 2.8): email `rating.passenger@test.local`, password `Password12345`
 
 If your local credentials differ, override them with env vars or JVM properties.
 
@@ -25,14 +27,22 @@ If your local credentials differ, override them with env vars or JVM properties.
 mvn -f tests/pom.xml test
 ```
 
+Run only Student 2 rating tests:
+
+```bash
+mvn -f tests/pom.xml -Dtest=RideRatingE2ETest test
+```
+
 ## Configuration
 
 ### Env vars
 - `E2E_FRONTEND_URL` (default `http://localhost:4200`)
 - `E2E_ADMIN_EMAIL` (default `stefan.nikolic@drumigo.com`)
-- `E2E_ADMIN_PASSWORD` (default `Sifra123`)
+- `E2E_ADMIN_PASSWORD` (default `Password12345`)
 - `E2E_PASSENGER_EMAIL` (default `ana.petrovic@example.com`) – for 2.4.3 favorite-route tests
-- `E2E_PASSENGER_PASSWORD` (default `password`)
+- `E2E_PASSENGER_PASSWORD` (default `Password12345`)
+- `E2E_RATING_PASSENGER_EMAIL` (default `rating.passenger@test.local`) – for 2.8 rating tests
+- `E2E_RATING_PASSENGER_PASSWORD` (default `Password12345`) – for 2.8 rating tests
 - `E2E_HEADLESS` (default `true`)
 
 ### JVM properties
@@ -41,6 +51,8 @@ mvn -f tests/pom.xml test
 - `-De2e.admin.password=...`
 - `-De2e.passenger.email=...`
 - `-De2e.passenger.password=...`
+- `-De2e.rating.passenger.email=...`
+- `-De2e.rating.passenger.password=...`
 - `-De2e.headless=true|false`
 
 Example:

--- a/tests/src/test/java/com/ftn/drumigo/tests/RideRatingE2ETest.java
+++ b/tests/src/test/java/com/ftn/drumigo/tests/RideRatingE2ETest.java
@@ -1,0 +1,132 @@
+package com.ftn.drumigo.tests;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.ftn.drumigo.tests.base.BaseE2ETest;
+import com.ftn.drumigo.tests.pages.LoginPage;
+import com.ftn.drumigo.tests.pages.PassengerRideHistoryPage;
+
+class RideRatingE2ETest extends BaseE2ETest {
+
+    private static final String DEFAULT_RATING_PASSENGER_EMAIL = "rating.passenger@test.local";
+    private static final String DEFAULT_RATING_PASSENGER_PASSWORD = "Password12345";
+
+    @Test
+    void shouldSubmitDriverAndVehicleRatings_happyPath() {
+        PassengerRideHistoryPage historyPage = loginAndOpenPassengerHistory();
+
+        historyPage.selectRideByRoute("Podbara", "Grbavica");
+        historyPage.waitForRatingStatusResolved();
+        Assertions.assertTrue(historyPage.isRateButtonVisible(),
+            "Expected selected ride to be rateable before submission.");
+
+        historyPage.openRatingModal();
+        historyPage.setDriverRating(5);
+        historyPage.setVehicleRating(4);
+        historyPage.setComment("Automated Student 2 E2E rating submission.");
+        historyPage.submitRating();
+        historyPage.waitForRatingStatusResolved();
+
+        Assertions.assertFalse(historyPage.isRateButtonVisible(),
+            "Rate button should disappear after successful submission.");
+        Assertions.assertTrue(historyPage.isRatingSubmittedVisible(),
+            "Submitted state should be shown after successful rating.");
+
+        List<String> ratingValues = historyPage.getDisplayedRatingValues();
+        Assertions.assertTrue(ratingValues.contains("5/5"),
+            "Expected submitted driver rating 5/5 in details panel, got: " + ratingValues);
+        Assertions.assertTrue(ratingValues.contains("4/5"),
+            "Expected submitted vehicle rating 4/5 in details panel, got: " + ratingValues);
+    }
+
+    @Test
+    void shouldNotAllowRatingWhenRideAlreadyReviewed_exceptionCase() {
+        PassengerRideHistoryPage historyPage = loginAndOpenPassengerHistory();
+
+        historyPage.selectRideByRoute("Bulevar Oslobodjenja", "Trg Slobode");
+        historyPage.waitForRatingStatusResolved();
+
+        Assertions.assertTrue(historyPage.isRatingSubmittedVisible(),
+            "Already reviewed ride should show submitted-rating state.");
+        Assertions.assertFalse(historyPage.isRateButtonVisible(),
+            "Already reviewed ride must not display rate button.");
+    }
+
+    @Test
+    void shouldNotAllowRatingWhenDeadlinePassed_exceptionCase() {
+        PassengerRideHistoryPage historyPage = loginAndOpenPassengerHistory();
+
+        historyPage.selectRideByRoute("Detelinara", "Telep");
+        historyPage.waitForRatingStatusResolved();
+
+        Assertions.assertTrue(historyPage.isRatingExpiredVisible(),
+            "Expired ride should show rating deadline passed state.");
+        Assertions.assertFalse(historyPage.isRateButtonVisible(),
+            "Expired ride must not display rate button.");
+    }
+
+    @Test
+    void shouldRequireBothRatingsBeforeSubmit_validationCase() {
+        PassengerRideHistoryPage historyPage = loginAndOpenPassengerHistory();
+
+        historyPage.selectRideByRoute("Petrovaradin", "Liman");
+        historyPage.waitForRatingStatusResolved();
+        Assertions.assertTrue(historyPage.isRateButtonVisible(),
+            "Selected ride should be rateable for validation scenario.");
+
+        historyPage.openRatingModal();
+        historyPage.submitRatingExpectingValidationError();
+
+        Assertions.assertTrue(historyPage.isRatingModalVisible(),
+            "Rating modal should remain open when required ratings are missing.");
+        Assertions.assertTrue(historyPage.isDriverRatingValidationVisible(),
+            "Driver rating validation should be shown when missing.");
+        Assertions.assertTrue(historyPage.isVehicleRatingValidationVisible(),
+            "Vehicle rating validation should be shown when missing.");
+
+        historyPage.closeRatingModal();
+        Assertions.assertTrue(historyPage.isRateButtonVisible(),
+            "Ride should remain rateable after closing invalid submission attempt.");
+    }
+
+    private PassengerRideHistoryPage loginAndOpenPassengerHistory() {
+        LoginPage loginPage = new LoginPage(driver, wait);
+        loginPage.open(frontendUrl);
+        loginPage.loginExpectingRedirect(
+            resolveConfig(
+                new String[] {"e2e.rating.passenger.email", "e2e.passenger.email"},
+                new String[] {"E2E_RATING_PASSENGER_EMAIL", "E2E_PASSENGER_EMAIL"},
+                DEFAULT_RATING_PASSENGER_EMAIL
+            ),
+            resolveConfig(
+                new String[] {"e2e.rating.passenger.password", "e2e.passenger.password"},
+                new String[] {"E2E_RATING_PASSENGER_PASSWORD", "E2E_PASSENGER_PASSWORD"},
+                DEFAULT_RATING_PASSENGER_PASSWORD
+            ),
+            "/order-ride"
+        );
+
+        PassengerRideHistoryPage historyPage = new PassengerRideHistoryPage(driver, wait);
+        historyPage.open(frontendUrl);
+        return historyPage;
+    }
+
+    private String resolveConfig(String[] propertyKeys, String[] envKeys, String defaultValue) {
+        for (String propertyKey : propertyKeys) {
+            String propertyValue = System.getProperty(propertyKey);
+            if (propertyValue != null && !propertyValue.isBlank()) {
+                return propertyValue;
+            }
+        }
+        for (String envKey : envKeys) {
+            String envValue = System.getenv(envKey);
+            if (envValue != null && !envValue.isBlank()) {
+                return envValue;
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/tests/src/test/java/com/ftn/drumigo/tests/pages/PassengerRideHistoryPage.java
+++ b/tests/src/test/java/com/ftn/drumigo/tests/pages/PassengerRideHistoryPage.java
@@ -1,9 +1,11 @@
 package com.ftn.drumigo.tests.pages;
 
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -16,6 +18,25 @@ public class PassengerRideHistoryPage {
     private static final By TABLE_ROWS = By.cssSelector("app-ride-history-table tbody tr");
     private static final By EMPTY_STATE = By.cssSelector("app-ride-history-table .empty-state");
     private static final By FAVORITE_BUTTON_IN_ROW = By.cssSelector(".favorite-btn");
+    private static final By DETAIL_PANEL = By.cssSelector(".detail-panel");
+    private static final By DETAIL_CLOSE_BUTTON = By.cssSelector(".btn-close-detail");
+    private static final By ROUTE_FROM = By.cssSelector(".route-from");
+    private static final By ROUTE_TO = By.cssSelector(".route-to");
+    private static final By RATE_BUTTON = By.cssSelector(".btn-rate");
+    private static final By RATING_SUBMITTED = By.cssSelector(".rating-submitted");
+    private static final By RATING_EXPIRED = By.cssSelector(".rating-expired");
+    private static final By RATING_LOADING = By.cssSelector(".rating-loading");
+    private static final By RATING_VALUES = By.cssSelector(".rating-value");
+    private static final By RATING_MODAL = By.cssSelector("app-rating-modal .modal");
+    private static final By RATING_MODAL_CLOSE = By.cssSelector("app-rating-modal .modal__close");
+    private static final By COMMENT_INPUT = By.cssSelector("app-rating-modal textarea#comment");
+    private static final By SUBMIT_RATING_BUTTON = By.cssSelector("app-rating-modal button[type='submit']");
+    private static final By DRIVER_RATING_ERROR = By.cssSelector(
+        "app-rating-modal .rating-form__field:nth-of-type(1) .rating-form__error"
+    );
+    private static final By VEHICLE_RATING_ERROR = By.cssSelector(
+        "app-rating-modal .rating-form__field:nth-of-type(2) .rating-form__error"
+    );
 
     private final WebDriver driver;
     private final WebDriverWait wait;
@@ -25,13 +46,23 @@ public class PassengerRideHistoryPage {
         this.wait = wait;
     }
 
+    public void open(String frontendUrl) {
+        driver.get(frontendUrl + "/ride-history");
+        waitUntilLoaded();
+        waitForLoadingToFinish();
+    }
+
     public void waitUntilLoaded() {
         WebElement title = wait.until(ExpectedConditions.visibilityOfElementLocated(PAGE_TITLE));
-        Assertions.assertTrue(title.getText().contains("My Rides"),
+        Assertions.assertTrue(title.getText().toLowerCase(Locale.ROOT).contains("my rides"),
             "Passenger ride history page title not detected. Found: " + title.getText());
     }
 
     public void waitForTableOrEmpty() {
+        waitForLoadingToFinish();
+    }
+
+    public void waitForLoadingToFinish() {
         wait.until(d -> {
             try {
                 List<WebElement> banners = d.findElements(LOADING_BANNER);
@@ -78,5 +109,177 @@ public class PassengerRideHistoryPage {
             }
         }
         return false;
+    }
+
+    public void selectRideByRoute(String fromContains, String toContains) {
+        waitForLoadingToFinish();
+
+        String fromNeedle = fromContains.toLowerCase(Locale.ROOT);
+        String toNeedle = toContains.toLowerCase(Locale.ROOT);
+
+        boolean clicked = wait.until(d -> {
+            try {
+                List<WebElement> rows = d.findElements(TABLE_ROWS);
+                for (WebElement row : rows) {
+                    String fromText = row.findElement(ROUTE_FROM).getText().toLowerCase(Locale.ROOT);
+                    String toText = row.findElement(ROUTE_TO).getText().toLowerCase(Locale.ROOT);
+
+                    if (fromText.contains(fromNeedle) && toText.contains(toNeedle)) {
+                        ((JavascriptExecutor) d).executeScript(
+                            "arguments[0].scrollIntoView({block:'center'});",
+                            row
+                        );
+                        row.click();
+                        return true;
+                    }
+                }
+                return false;
+            } catch (StaleElementReferenceException e) {
+                return false;
+            }
+        });
+
+        if (!clicked) {
+            Assertions.fail("Could not find ride row for route: " + fromContains + " -> " + toContains);
+        }
+
+        wait.until(ExpectedConditions.visibilityOfElementLocated(DETAIL_PANEL));
+    }
+
+    public void closeRideDetailsIfOpen() {
+        List<WebElement> panels = driver.findElements(DETAIL_PANEL);
+        if (panels.isEmpty() || !panels.get(0).isDisplayed()) {
+            return;
+        }
+
+        wait.until(ExpectedConditions.elementToBeClickable(DETAIL_CLOSE_BUTTON)).click();
+        wait.until(ExpectedConditions.invisibilityOfElementLocated(DETAIL_PANEL));
+    }
+
+    public void waitForRatingStatusResolved() {
+        wait.until(d -> {
+            try {
+                List<WebElement> loaders = d.findElements(RATING_LOADING);
+                if (loaders.isEmpty()) {
+                    return true;
+                }
+                return loaders.stream().noneMatch(WebElement::isDisplayed);
+            } catch (StaleElementReferenceException e) {
+                return false;
+            }
+        });
+
+        wait.until(d ->
+            isDisplayed(d, RATE_BUTTON) || isDisplayed(d, RATING_SUBMITTED) || isDisplayed(d, RATING_EXPIRED)
+        );
+    }
+
+    public boolean isRateButtonVisible() {
+        return isDisplayed(driver, RATE_BUTTON);
+    }
+
+    public boolean isRatingSubmittedVisible() {
+        return isDisplayed(driver, RATING_SUBMITTED);
+    }
+
+    public boolean isRatingExpiredVisible() {
+        return isDisplayed(driver, RATING_EXPIRED);
+    }
+
+    public void openRatingModal() {
+        wait.until(ExpectedConditions.elementToBeClickable(RATE_BUTTON)).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(RATING_MODAL));
+    }
+
+    public boolean isRatingModalVisible() {
+        return isDisplayed(driver, RATING_MODAL);
+    }
+
+    public void setDriverRating(int stars) {
+        setRating(1, stars);
+    }
+
+    public void setVehicleRating(int stars) {
+        setRating(2, stars);
+    }
+
+    public void setComment(String comment) {
+        WebElement textarea = wait.until(ExpectedConditions.visibilityOfElementLocated(COMMENT_INPUT));
+        textarea.clear();
+        textarea.sendKeys(comment);
+    }
+
+    public void submitRating() {
+        wait.until(ExpectedConditions.elementToBeClickable(SUBMIT_RATING_BUTTON)).click();
+        wait.until(ExpectedConditions.invisibilityOfElementLocated(RATING_MODAL));
+    }
+
+    public void submitRatingExpectingValidationError() {
+        wait.until(ExpectedConditions.elementToBeClickable(SUBMIT_RATING_BUTTON)).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(RATING_MODAL));
+    }
+
+    public void closeRatingModal() {
+        wait.until(ExpectedConditions.elementToBeClickable(RATING_MODAL_CLOSE)).click();
+        wait.until(ExpectedConditions.invisibilityOfElementLocated(RATING_MODAL));
+    }
+
+    public boolean isDriverRatingValidationVisible() {
+        return isDisplayed(driver, DRIVER_RATING_ERROR);
+    }
+
+    public boolean isVehicleRatingValidationVisible() {
+        return isDisplayed(driver, VEHICLE_RATING_ERROR);
+    }
+
+    public List<String> getDisplayedRatingValues() {
+        return wait.until(d -> {
+            List<WebElement> values = d.findElements(RATING_VALUES);
+            if (values.isEmpty()) {
+                return null;
+            }
+            return values.stream()
+                .map(WebElement::getText)
+                .map(String::trim)
+                .filter(text -> !text.isBlank())
+                .toList();
+        });
+    }
+
+    private void setRating(int fieldIndex, int stars) {
+        if (stars < 1 || stars > 5) {
+            throw new IllegalArgumentException("Rating stars must be in range 1-5.");
+        }
+
+        String ariaLabel = stars == 1 ? "1 star" : stars + " stars";
+        By field = By.cssSelector("app-rating-modal .rating-form__field:nth-of-type(" + fieldIndex + ")");
+        By starButton = By.cssSelector("button.star-rating__star[aria-label='" + ariaLabel + "']");
+
+        boolean clicked = wait.until(d -> {
+            try {
+                WebElement formField = d.findElement(field);
+                WebElement star = formField.findElement(starButton);
+                if (star.isDisplayed() && star.isEnabled()) {
+                    star.click();
+                    return true;
+                }
+                return false;
+            } catch (StaleElementReferenceException e) {
+                return false;
+            }
+        });
+
+        if (!clicked) {
+            Assertions.fail("Could not click rating star " + stars + " in field index " + fieldIndex + ".");
+        }
+    }
+
+    private boolean isDisplayed(WebDriver contextDriver, By locator) {
+        try {
+            List<WebElement> elements = contextDriver.findElements(locator);
+            return elements.stream().anyMatch(WebElement::isDisplayed);
+        } catch (StaleElementReferenceException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
This pull request adds end-to-end (E2E) tests for the ride rating feature (student story 2.8) and updates the test documentation and configuration to support these tests. The main changes include a new test class for rating vehicles and drivers, enhancements to the `PassengerRideHistoryPage` page object to support rating interactions, and updates to the `README.md` to document usage and configuration for the new tests.

**New E2E tests for ride rating:**

* Added `RideRatingE2ETest` with tests covering happy path, already-reviewed, expired, and validation scenarios for rating drivers and vehicles after a ride. (`tests/src/test/java/com/ftn/drumigo/tests/RideRatingE2ETest.java`)

**Enhancements to page objects for rating support:**

* Extended `PassengerRideHistoryPage` with methods and locators to select rides by route, open and interact with the rating modal, submit ratings, and validate UI states for rating (e.g., button visibility, validation errors, submitted/expired states). (`tests/src/test/java/com/ftn/drumigo/tests/pages/PassengerRideHistoryPage.java`) [[1]](diffhunk://#diff-d55941ec85d8c0b132188a676e024e84f165f43061df3c53b69c75358c406a2cR4-R8) [[2]](diffhunk://#diff-d55941ec85d8c0b132188a676e024e84f165f43061df3c53b69c75358c406a2cR21-R39) [[3]](diffhunk://#diff-d55941ec85d8c0b132188a676e024e84f165f43061df3c53b69c75358c406a2cR49-R65) [[4]](diffhunk://#diff-d55941ec85d8c0b132188a676e024e84f165f43061df3c53b69c75358c406a2cR113-R284)

**Documentation and configuration updates:**

* Updated `tests/README.md` to document the new 2.8 rating tests, credentials for the rating passenger, how to run only the rating tests, and new environment variables/JVM properties for configuration. (`tests/README.md`) [[1]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acR6) [[2]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acR20) [[3]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acR30-R45) [[4]](diffhunk://#diff-dacac2ebf9792f0d23c0f922a744486ded01901957d5281290925acd89cf83acR54-R55)