### PR TITLE
[FE 51] refactor: improve favorite route ride ordering UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bun-debug.log
 
 # Cursor
 .cursor/
+scripts/
 
 # Visual Studio Code
 .vscode/*

--- a/frontend/src/app/features/order-ride/order-ride.component.html
+++ b/frontend/src/app/features/order-ride/order-ride.component.html
@@ -80,19 +80,38 @@
           <h2 class="step-title">Where are you going?</h2>
 
           @if (favoriteRoutes().length > 0) {
-            <div class="form-group">
-              <label for="favorite-select">Choose from favorites</label>
-              <select
-                id="favorite-select"
-                class="form-input"
-                [value]="selectedFavoriteId() ?? ''"
-                (change)="onFavoriteSelected($any($event.target).value)"
-              >
-                <option value="">None – enter address manually</option>
+            <div class="favorite-routes-picker" role="group" aria-label="Quick pick from favorites">
+              <h3 class="favorite-routes-picker__title">
+                <svg class="favorite-routes-picker__icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" fill="none"/>
+                </svg>
+                Quick pick from favorites
+              </h3>
+              <div class="favorite-routes-cards">
+                <button
+                  type="button"
+                  class="favorite-route-card favorite-route-card--manual"
+                  [class.active]="selectedFavoriteId() === null"
+                  [attr.aria-pressed]="selectedFavoriteId() === null"
+                  (click)="selectManualEntry()"
+                >
+                  <span class="favorite-route-card__label">Enter address manually</span>
+                </button>
                 @for (fav of favoriteRoutes(); track fav.id) {
-                  <option [value]="fav.id">{{ getFavoriteLabel(fav) }}</option>
+                  <button
+                    type="button"
+                    class="favorite-route-card"
+                    [class.active]="selectedFavoriteId() === fav.id"
+                    [attr.aria-pressed]="selectedFavoriteId() === fav.id"
+                    (click)="onFavoriteSelected(fav.id + '')"
+                  >
+                    <svg class="favorite-route-card__icon" viewBox="0 0 24 24" aria-hidden="true">
+                      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="2" fill="none"/>
+                    </svg>
+                    <span class="favorite-route-card__label">{{ getFavoriteLabel(fav) }}</span>
+                  </button>
                 }
-              </select>
+              </div>
             </div>
           }
 

--- a/frontend/src/app/features/order-ride/order-ride.component.scss
+++ b/frontend/src/app/features/order-ride/order-ride.component.scss
@@ -453,6 +453,104 @@
   }
 }
 
+/* Favorite routes picker */
+.favorite-routes-picker {
+  margin-bottom: 24px;
+  padding: 16px;
+  background: rgba(91, 76, 219, 0.06);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.favorite-routes-picker__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-dark);
+  margin: 0 0 12px 0;
+}
+
+.favorite-routes-picker__icon {
+  width: 18px;
+  height: 18px;
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+.favorite-routes-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.favorite-route-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 14px 16px;
+  text-align: left;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--white);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-dark);
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+
+  &:hover {
+    border-color: var(--primary);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 4px rgba(91, 76, 219, 0.1);
+  }
+
+  &.active {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+    border-color: var(--primary);
+    color: var(--white);
+
+    .favorite-route-card__icon {
+      color: var(--white);
+    }
+  }
+}
+
+.favorite-route-card__icon {
+  width: 18px;
+  height: 18px;
+  color: var(--primary);
+  flex-shrink: 0;
+}
+
+.favorite-route-card__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (min-width: 480px) {
+  .favorite-route-card__label {
+    white-space: normal;
+  }
+}
+
+.favorite-route-card--manual .favorite-route-card__icon {
+  display: none;
+}
+
 /* Schedule Toggle */
 
 .schedule-label {

--- a/frontend/src/app/features/order-ride/order-ride.component.ts
+++ b/frontend/src/app/features/order-ride/order-ride.component.ts
@@ -472,6 +472,11 @@ export class OrderRideComponent implements OnInit {
     return `${first} → ${last}`;
   }
 
+  /** Switch to manual address entry (clears favorite selection and form route). */
+  selectManualEntry(): void {
+    this.onFavoriteSelected('');
+  }
+
   onFavoriteSelected(value: string): void {
     const id = value === '' || value === 'none' ? null : Number(value);
     if (Number.isNaN(id)) return;

--- a/frontend/src/app/layout/config/navbar.config.ts
+++ b/frontend/src/app/layout/config/navbar.config.ts
@@ -19,7 +19,6 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Order a Ride', icon: 'clock', path: '/order-ride', section: 'main' },
     { label: 'Ride Tracking', icon: 'map-pin', path: '/ride-tracking/1', section: 'main' },
     { label: 'Ride History', icon: 'file-text', path: '/ride-history', section: 'main' },
-    { label: 'Favorite Routes', icon: 'bookmark', path: '/favorite-routes', section: 'main', disabled: true },
 
     // Account Section
     { label: 'Profile', icon: 'user', path: '/profile', section: 'account' },


### PR DESCRIPTION
close #206 


This pull request updates the "Order a Ride" flow to improve the user experience when selecting favorite routes. The main change replaces the basic dropdown for picking a favorite route with a visually enhanced "quick pick" card interface, making it easier and more intuitive for users to select or manually enter a destination. Supporting style and accessibility improvements are also included.

**UI/UX Improvements for Favorite Route Selection:**

* Replaced the `<select>` dropdown for favorite routes in `order-ride.component.html` with a card-based "quick pick" interface, including a dedicated button for manual address entry and visually distinct cards for each favorite. This change enhances usability and accessibility.
* Added a new `selectManualEntry()` method in `order-ride.component.ts` to handle manual address entry selection, clearing any favorite selection.

**Styling Enhancements:**

* Introduced new SCSS styles in `order-ride.component.scss` for the favorite routes picker, including layout, card appearance, hover/focus states, and responsive label handling.

**Navigation Cleanup:**

* Removed the disabled "Favorite Routes" item from the navigation bar configuration in `navbar.config.ts` for a cleaner navigation experience.