### PR TITLE
[FE 52] fix: correct profile picture sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ target/
 # Local Spring Boot dev config
 **/application-dev.properties
 
+# Backend uploads (profile pictures, etc.)
+uploads/
+
 # Gradle (for mobile)
 .gradle/
 build/

--- a/drumigo/src/main/java/com/ftn/drumigo/config/SecurityConfig.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/config/SecurityConfig.java
@@ -59,7 +59,8 @@ public class SecurityConfig {
                     "/api/users/*/notifications",
                     "/api/passengers",
                     "/api/passengers/activate/**",
-                    "/api/activation/**"
+                    "/api/activation/**",
+                    "/api/uploads/profile/**"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/drumigo/src/main/java/com/ftn/drumigo/config/WebConfig.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/config/WebConfig.java
@@ -1,11 +1,18 @@
 package com.ftn.drumigo.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.uploads.profile-dir:uploads/profile}")
+    private String profileUploadDir;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -15,5 +22,16 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path uploadPath = Path.of(profileUploadDir).toAbsolutePath().normalize();
+        String location = uploadPath.toUri().toString();
+        if (!location.endsWith("/")) {
+            location = location + "/";
+        }
+        registry.addResourceHandler("/api/uploads/profile/**")
+                .addResourceLocations(location);
     }
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/controller/ProfileController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/ProfileController.java
@@ -6,28 +6,51 @@ import com.ftn.drumigo.security.CustomUserDetails;
 import com.ftn.drumigo.service.ProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/profile")
 @RequiredArgsConstructor
 public class ProfileController {
-    
+
     private final ProfileService profileService;
-    
+
     @GetMapping
     public ResponseEntity<ProfileResponse> getProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
         ProfileResponse response = profileService.getProfile(userDetails.getUserId());
         return ResponseEntity.ok(response);
     }
-    
+
     @PutMapping
     public ResponseEntity<ProfileResponse> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody ProfileUpdateRequest request) {
         ProfileResponse response = profileService.updateProfile(userDetails.getUserId(), request);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Upload profile picture. Returns the URL path to store; client should then call PUT /api/profile with profilePictureUrl set to this value.
+     */
+    @PostMapping(value = "/picture", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, String>> uploadProfilePicture(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file) {
+        try {
+            String url = profileService.saveProfilePicture(userDetails.getUserId(), file);
+            return ResponseEntity.ok(Map.of("url", url));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "Failed to save picture"));
+        }
     }
 }

--- a/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
@@ -1,28 +1,51 @@
 package com.ftn.drumigo.service;
 
+import com.ftn.drumigo.domain.Ride;
 import com.ftn.drumigo.domain.Vehicle;
+import com.ftn.drumigo.domain.enums.RideStatus;
 import com.ftn.drumigo.domain.users.Driver;
 import com.ftn.drumigo.domain.users.User;
 import com.ftn.drumigo.dto.profile.request.ProfileUpdateRequest;
+import com.ftn.drumigo.dto.profile.response.ActiveHoursResponse;
 import com.ftn.drumigo.dto.profile.response.ProfileResponse;
 import com.ftn.drumigo.dto.profile.response.VehicleInfoResponse;
 import com.ftn.drumigo.exception.ConflictException;
 import com.ftn.drumigo.exception.ResourceNotFoundException;
+import com.ftn.drumigo.repository.RideRepository;
 import com.ftn.drumigo.repository.UserRepository;
 import com.ftn.drumigo.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ProfileService {
-    
+
+    private static final long MAX_PICTURE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/gif", "image/webp");
+
+    @Value("${app.uploads.profile-dir:uploads/profile}")
+    private String profileUploadDir;
+
+    private static final int MAX_DRIVING_HOURS_PER_24H = 8;
+
     private final UserRepository userRepository;
     private final VehicleRepository vehicleRepository;
+    private final RideRepository rideRepository;
     
     public ProfileResponse getProfile(Long userId) {
         User user = userRepository.findById(userId)
@@ -60,6 +83,8 @@ public class ProfileService {
                 vehicleInfo.setPetFriendly(vehicle.getPetFriendly());
                 response.setVehicle(vehicleInfo);
             }
+
+            response.setActiveHoursLast24h(computeActiveHoursLast24h(driver));
         }
         
         return response;
@@ -100,5 +125,81 @@ public class ProfileService {
         
         // Return updated profile
         return getProfile(userId);
+    }
+
+    /**
+     * Save profile picture file to disk and return the URL path to store in DB.
+     * Caller should then call updateProfile with that URL.
+     */
+    @Transactional
+    public String saveProfilePicture(Long userId, MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("Profile picture file is required");
+        }
+        if (file.getSize() > MAX_PICTURE_SIZE_BYTES) {
+            throw new IllegalArgumentException("Profile picture must be at most 5MB");
+        }
+        String contentType = file.getContentType();
+        if (contentType != null && !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("Profile picture must be JPEG, PNG, GIF, or WebP");
+        }
+
+        Path dir = Path.of(profileUploadDir).toAbsolutePath().normalize();
+        Files.createDirectories(dir);
+
+        String extension = getExtensionFromContentTypeOrFilename(contentType, file.getOriginalFilename());
+        String filename = userId + extension;
+        Path target = dir.resolve(filename).normalize();
+        if (!target.startsWith(dir)) {
+            throw new IllegalArgumentException("Invalid file path");
+        }
+        file.transferTo(target);
+
+        return "/api/uploads/profile/" + filename;
+    }
+
+    private static String getExtensionFromContentTypeOrFilename(String contentType, String originalFilename) {
+        if (contentType != null) {
+            String lower = contentType.toLowerCase(Locale.ROOT);
+            if (lower.contains("png")) return ".png";
+            if (lower.contains("gif")) return ".gif";
+            if (lower.contains("webp")) return ".webp";
+            if (lower.contains("jpeg") || lower.contains("jpg")) return ".jpg";
+        }
+        if (originalFilename != null) {
+            String name = originalFilename.toLowerCase(Locale.ROOT);
+            if (name.endsWith(".png")) return ".png";
+            if (name.endsWith(".gif")) return ".gif";
+            if (name.endsWith(".webp")) return ".webp";
+        }
+        return ".jpg";
+    }
+
+    /**
+     * Computes how many hours the driver has been driving in the last 24 hours
+     * (ACTIVE and FINISHED rides only), for the 8h daily limit.
+     */
+    private ActiveHoursResponse computeActiveHoursLast24h(Driver driver) {
+        Instant now = Instant.now();
+        Instant windowStart = now.minus(24, ChronoUnit.HOURS);
+        List<Ride> rides = rideRepository.findDriverRidesWithActivitySince(driver, windowStart);
+
+        long totalSeconds = 0;
+        for (Ride r : rides) {
+            if (r.getStatus() != RideStatus.ACTIVE && r.getStatus() != RideStatus.FINISHED) {
+                continue;
+            }
+            Instant start = r.getStartTime();
+            if (start == null) continue;
+            Instant end = r.getEndTime() != null ? r.getEndTime() : now;
+            if (end.isBefore(windowStart)) continue;
+
+            Instant effectiveStart = start.isBefore(windowStart) ? windowStart : start;
+            Instant effectiveEnd = end.isAfter(now) ? now : end;
+            totalSeconds += Duration.between(effectiveStart, effectiveEnd).getSeconds();
+        }
+
+        double hoursWorked = totalSeconds / 3600.0;
+        return new ActiveHoursResponse(hoursWorked, MAX_DRIVING_HOURS_PER_24H);
     }
 }

--- a/drumigo/src/main/resources/application.properties
+++ b/drumigo/src/main/resources/application.properties
@@ -33,3 +33,10 @@ spring.jpa.properties.hibernate.format_sql=true
 maintenance.basic.username=
 maintenance.basic.password=
 app.maintenance.seed-script=classpath:db/seed/mysql-seed.sql
+
+# Profile picture uploads (relative to working directory)
+app.uploads.profile-dir=uploads/profile
+
+# Allow multipart uploads up to 6MB (profile pictures)
+spring.servlet.multipart.max-file-size=6MB
+spring.servlet.multipart.max-request-size=6MB

--- a/frontend/src/app/features/profile/profile-page/profile-page.component.html
+++ b/frontend/src/app/features/profile/profile-page/profile-page.component.html
@@ -181,8 +181,8 @@
       </div>
     </div>
 
-    <!-- Driver Active Hours Section -->
-    @if (isDriver() && profile()!.activeHoursLast24h) {
+    <!-- Driver Active Hours Section (shows 0/8 when backend does not yet send activeHoursLast24h) -->
+    @if (isDriver()) {
       <div class="profile-card active-hours-card">
         <div class="active-hours-header">
           <div class="active-hours-title">

--- a/frontend/src/app/features/profile/profile-page/profile-page.component.ts
+++ b/frontend/src/app/features/profile/profile-page/profile-page.component.ts
@@ -14,6 +14,7 @@ import { NotificationApiService } from '../services/notification-api.service';
 import { UserNotification } from '../models/notification.model';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthService } from '../../../shared/services/auth.service';
+import { CurrentUserService } from '../../../layout/services/current-user.service';
 
 @Component({
   selector: 'app-profile-page',
@@ -29,6 +30,7 @@ export class ProfilePageComponent implements OnInit {
   private readonly notificationService = inject(NotificationApiService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly authService = inject(AuthService);
+  private readonly currentUserService = inject(CurrentUserService);
 
   readonly profile = signal<ProfileData | null>(null);
   readonly profileLoading = signal<boolean>(true);
@@ -148,34 +150,39 @@ export class ProfilePageComponent implements OnInit {
   /**
    * Handle file selection from shared component.
    * File is already cropped to 1:1 by the component.
+   * Uploads file to backend, then updates profile with returned URL.
    */
   onPhotoSelected(file: File): void {
     this.selectedFile = file;
-    console.log('Photo selected (auto-cropped to 1:1):', file.name, file.size, 'bytes');
+    const p = this.profile();
+    if (!p) return;
 
-    // For now, use FileReader to convert to base64 data URL for backend storage
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const dataUrl = e.target?.result as string;
-      const p = this.profile();
-      if (!p) return;
-
-      // Update profile with new picture
-      this.profileService
-        .updateProfile({ profilePictureUrl: dataUrl })
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe({
-          next: (updatedProfile) => {
-            this.profile.set(updatedProfile);
-            this.showSuccess('Profile photo updated successfully');
-          },
-          error: (err) => {
-            console.error('Upload failed:', err);
-            this.showSuccess('Failed to update profile photo');
-          },
-        });
-    };
-    reader.readAsDataURL(file);
+    this.profileService
+      .uploadProfilePicture(file)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.profileService
+            .updateProfile({ profilePictureUrl: res.url })
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+              next: (updatedProfile) => {
+                this.profile.set(updatedProfile);
+                this.currentUserService.setFromProfile(updatedProfile);
+                this.showSuccess('Profile photo updated successfully');
+              },
+              error: (err) => {
+                console.error('Failed to update profile with picture URL:', err);
+                this.showSuccess('Failed to update profile photo');
+              },
+            });
+        },
+        error: (err) => {
+          console.error('Upload failed:', err);
+          const message = err?.error?.error ?? err?.message ?? 'Upload failed';
+          this.showSuccess(typeof message === 'string' ? message : 'Failed to update profile photo');
+        },
+      });
   }
 
   /**
@@ -256,6 +263,7 @@ export class ProfilePageComponent implements OnInit {
       .subscribe({
         next: (updatedProfile) => {
           this.profile.set(updatedProfile);
+          this.currentUserService.setFromProfile(updatedProfile);
           this.showSuccess('Your profile has been updated successfully!');
           console.log('Passenger profile updated:', values);
         },

--- a/frontend/src/app/features/profile/services/profile-api.service.ts
+++ b/frontend/src/app/features/profile/services/profile-api.service.ts
@@ -30,15 +30,27 @@ interface ProfileResponse {
   activeDriver?: boolean;
   lastStateChangeAt?: string;
   vehicle?: VehicleInfoResponse;
+  /** Hours driven in the last 24h; present for drivers when backend supports it. */
+  activeHoursLast24h?: { hoursWorked: number; maxHours: number };
 }
 
 @Injectable({ providedIn: 'root' })
 export class ProfileApiService {
   private http = inject(HttpClient);
   private apiUrl = `${environment.apiBaseUrl}/profile`;
+  private apiOrigin = environment.apiBaseUrl.replace(/\/api\/?$/, '');
 
   getProfile(): Observable<ProfileData> {
     return this.http.get<ProfileResponse>(this.apiUrl).pipe(map((response) => this.mapToProfileData(response)));
+  }
+
+  /**
+   * Upload profile picture file. Returns the URL path; then call updateProfile({ profilePictureUrl: response.url }).
+   */
+  uploadProfilePicture(file: File): Observable<{ url: string }> {
+    const formData = new FormData();
+    formData.set('file', file);
+    return this.http.post<{ url: string }>(`${this.apiUrl}/picture`, formData);
   }
 
   updateProfile(
@@ -63,30 +75,39 @@ export class ProfileApiService {
       phone: response.phone || '',
       address: response.address || '',
       role: response.role,
-      avatarUrl: response.profilePictureUrl,
+      avatarUrl: this.resolveProfilePictureUrl(response.profilePictureUrl),
     };
 
     // Add driver-specific data if available
-    if (response.role === 'DRIVER' && response.vehicle) {
-      const vehicleInfo: VehicleInfo = {
-        model: response.vehicle.model || 'Vehicle',
-        category: this.mapVehicleType(response.vehicle.vehicleTypeName),
-        licensePlate: response.vehicle.licensePlate || '',
-        seats: response.vehicle.numSeats,
-        features: {
-          babySeats: response.vehicle.babyFriendly,
-          petFriendly: response.vehicle.petFriendly,
-        },
-      };
-
-      return {
+    if (response.role === 'DRIVER') {
+      const driverProfile: ProfileData = {
         ...baseProfile,
-        vehicle: vehicleInfo,
-        activeHoursLast24h: undefined, // Not implemented in backend yet
+        activeHoursLast24h: response.activeHoursLast24h ?? undefined,
       };
+      if (response.vehicle) {
+        driverProfile.vehicle = {
+          model: response.vehicle.model || 'Vehicle',
+          category: this.mapVehicleType(response.vehicle.vehicleTypeName),
+          licensePlate: response.vehicle.licensePlate || '',
+          seats: response.vehicle.numSeats,
+          features: {
+            babySeats: response.vehicle.babyFriendly,
+            petFriendly: response.vehicle.petFriendly,
+          },
+        };
+      }
+      return driverProfile;
     }
 
     return baseProfile;
+  }
+
+  /** Resolve relative profile picture URL to absolute for display. */
+  private resolveProfilePictureUrl(url: string | null | undefined): string | null {
+    if (url == null || url === '') return null;
+    if (url.startsWith('http') || url.startsWith('data:')) return url;
+    const path = url.startsWith('/') ? url : '/' + url;
+    return this.apiOrigin + path;
   }
 
   private mapVehicleType(typeName: string): 'Standard' | 'Luxury' | 'Van' {

--- a/frontend/src/app/layout/components/navbar/navbar.component.html
+++ b/frontend/src/app/layout/components/navbar/navbar.component.html
@@ -1,67 +1,69 @@
 <aside class="sidebar">
-  <!-- Logo -->
-  <a routerLink="/" class="logo" aria-label="Drumigo Home">
-    <div class="logo-icon">
-      <img src="/images/logo/logo-blue-v2.svg" alt="Drumigo" />
-    </div>
-    <span class="logo-text">Drumigo</span>
-  </a>
-
-  <!-- Navigation Sections -->
-  @for (sectionKey of getSectionKeys(); track sectionKey) {
-    <nav class="nav-section">
-      <div class="nav-label">{{ sectionLabels[sectionKey] }}</div>
-      <div class="nav-items">
-        @for (item of groupedNavItems.get(sectionKey); track $index) {
-          @if (!item.disabled && item.path !== '#') {
-            <a [routerLink]="item.path" routerLinkActive="active" class="nav-item">
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                [innerHTML]="getIconSvg(item.icon)"
-              ></svg>
-              {{ item.label }}
-            </a>
-          } @else {
-            <span
-              class="nav-item nav-item--disabled"
-              [title]="item.disabled ? 'Not yet implemented – route reserved' : ''"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                [innerHTML]="getIconSvg(item.icon)"
-              ></svg>
-              {{ item.label }}
-            </span>
-          }
-        }
+  <div class="sidebar-scroll">
+    <!-- Logo -->
+    <a routerLink="/" class="logo" aria-label="Drumigo Home">
+      <div class="logo-icon">
+        <img src="/images/logo/logo-blue-v2.svg" alt="Drumigo" />
       </div>
-    </nav>
-  }
+      <span class="logo-text">Drumigo</span>
+    </a>
 
-  <!-- Spacer -->
-  <div class="nav-spacer"></div>
-
-  <!-- User Profile -->
-  <div class="user-profile">
-    @if (user.avatarUrl) {
-      <img [src]="user.avatarUrl" alt="{{ user.name }}" class="user-avatar-img" />
-    } @else {
-      <img src="images/default-avatar.svg" [alt]="user.name" class="user-avatar-img" />
+    <!-- Navigation Sections -->
+    @for (sectionKey of getSectionKeys(); track sectionKey) {
+      <nav class="nav-section">
+        <div class="nav-label">{{ sectionLabels[sectionKey] }}</div>
+        <div class="nav-items">
+          @for (item of groupedNavItems.get(sectionKey); track $index) {
+            @if (!item.disabled && item.path !== '#') {
+              <a [routerLink]="item.path" routerLinkActive="active" class="nav-item">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  [innerHTML]="getIconSvg(item.icon)"
+                ></svg>
+                {{ item.label }}
+              </a>
+            } @else {
+              <span
+                class="nav-item nav-item--disabled"
+                [title]="item.disabled ? 'Not yet implemented – route reserved' : ''"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  [innerHTML]="getIconSvg(item.icon)"
+                ></svg>
+                {{ item.label }}
+              </span>
+            }
+          }
+        </div>
+      </nav>
     }
-    <div class="user-info">
-      <div class="user-name">{{ user.name }}</div>
-      <div class="user-role">{{ user.role }}</div>
-    </div>
+  </div>
+
+  <!-- User block: clickable to go to profile; logout button separate -->
+  @let user = currentUserService.user();
+  <div class="user-profile">
+    <a routerLink="/profile" class="user-profile-link" aria-label="Go to profile">
+      @if (user.avatarUrl) {
+        <img [src]="user.avatarUrl" alt="{{ user.name }}" class="user-avatar-img" />
+      } @else {
+        <img src="images/default-avatar.svg" [alt]="user.name" class="user-avatar-img" />
+      }
+      <div class="user-info">
+        <div class="user-name">{{ user.name }}</div>
+        <div class="user-role">{{ user.role }}</div>
+      </div>
+    </a>
     <button type="button" class="logout-btn" (click)="logout()" aria-label="Log out">
       Log out
     </button>

--- a/frontend/src/app/layout/components/navbar/navbar.component.scss
+++ b/frontend/src/app/layout/components/navbar/navbar.component.scss
@@ -12,6 +12,12 @@
   z-index: 1000;
 }
 
+.sidebar-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .logo {
   display: flex;
   align-items: center;
@@ -104,18 +110,29 @@
   }
 }
 
-.nav-spacer {
-  flex: 1;
-}
-
 .user-profile {
+  flex-shrink: 0;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
+  flex-direction: column;
+  gap: 8px;
   padding: 12px;
   border-radius: var(--radius-sm);
   background: var(--bg-warm);
+}
+
+.user-profile-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0;
+  text-decoration: none;
+  color: inherit;
+  border-radius: var(--radius-sm);
+  transition: background 0.2s;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
 }
 
 .user-avatar {
@@ -169,15 +186,15 @@
   padding: 8px 12px;
   font-size: 13px;
   font-weight: 500;
-  color: var(--text-medium);
-  background: transparent;
-  border: 1px solid var(--border);
+  color: var(--danger);
+  background: var(--danger-light);
+  border: 1px solid var(--danger);
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.2s;
 
   &:hover {
-    background: rgba(0, 0, 0, 0.05);
-    color: var(--text-dark);
+    background: var(--danger);
+    color: var(--white);
   }
 }

--- a/frontend/src/app/layout/components/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/components/navbar/navbar.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, inject } from '@angular/core';
+import { Component, OnInit, inject, effect } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { NAVIGATION_CONFIG, SECTION_LABELS, NavItem } from '../../config/navbar.config';
 import { AuthService } from '../../../shared/services/auth.service';
+import { CurrentUserService } from '../../services/current-user.service';
 
 export type UserType = 'passenger' | 'driver' | 'admin';
 
@@ -21,32 +22,32 @@ export interface UserProfile {
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
-export class NavbarComponent implements OnInit, OnChanges {
-  @Input() user!: UserProfile;
-
+export class NavbarComponent implements OnInit {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
+  readonly currentUserService = inject(CurrentUserService);
 
   navItems: NavItem[] = [];
   groupedNavItems: Map<string, NavItem[]> = new Map();
   sectionLabels = SECTION_LABELS;
 
+  constructor() {
+    effect(() => {
+      this.currentUserService.user();
+      this.applyUserType();
+    });
+  }
+
   ngOnInit(): void {
     this.applyUserType();
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['user'] && !changes['user'].firstChange) {
-      this.applyUserType();
-    }
-  }
-
   private applyUserType(): void {
-    if (!this.user?.type) {
-      console.error('User type is required for navbar');
+    const user = this.currentUserService.user();
+    if (!user?.type) {
       return;
     }
-    this.navItems = NAVIGATION_CONFIG[this.user.type] || [];
+    this.navItems = NAVIGATION_CONFIG[user.type] || [];
     this.groupNavItems();
   }
 
@@ -90,7 +91,9 @@ export class NavbarComponent implements OnInit, OnChanges {
   }
 
   getSectionKeys(): string[] {
-    return Array.from(this.groupedNavItems.keys());
+    return Array.from(this.groupedNavItems.keys()).filter(
+      (key) => (this.groupedNavItems.get(key)?.length ?? 0) > 0,
+    );
   }
 
   logout(): void {

--- a/frontend/src/app/layout/config/navbar.config.ts
+++ b/frontend/src/app/layout/config/navbar.config.ts
@@ -21,7 +21,6 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Ride History', icon: 'file-text', path: '/ride-history', section: 'main' },
 
     // Account Section
-    { label: 'Profile', icon: 'user', path: '/profile', section: 'account' },
     { label: 'Support', icon: 'message-circle', path: '/support', section: 'account', disabled: true },
   ],
 
@@ -31,7 +30,6 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Ride History', icon: 'file-text', path: '/driver/ride-history', section: 'main' },
 
     // Account Section
-    { label: 'Profile', icon: 'user', path: '/profile', section: 'account' },
     { label: 'Support', icon: 'message-circle', path: '/support', section: 'account', disabled: true },
   ],
 
@@ -52,8 +50,7 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Reports', icon: 'bar-chart', path: '/admin/reports', section: 'management', disabled: true },
     { label: 'All Notifications', icon: 'bell', path: '/admin/notifications', section: 'management', disabled: true },
 
-    // Account Section
-    { label: 'Profile', icon: 'user', path: '/profile', section: 'account' },
+    // Account Section (profile is reached by clicking the user block at bottom)
   ],
 };
 

--- a/frontend/src/app/layout/layout.component.html
+++ b/frontend/src/app/layout/layout.component.html
@@ -1,5 +1,5 @@
 <div class="app-container">
-  <app-navbar [user]="user"></app-navbar>
+  <app-navbar />
   <main class="main-content">
     <router-outlet></router-outlet>
   </main>

--- a/frontend/src/app/layout/layout.component.ts
+++ b/frontend/src/app/layout/layout.component.ts
@@ -1,11 +1,12 @@
-import { Component, OnDestroy, OnInit, inject, ChangeDetectorRef } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
-import { NavbarComponent, UserProfile } from './components/navbar/navbar.component';
+import { NavbarComponent } from './components/navbar/navbar.component';
 import { ProfileApiService } from '../features/profile/services/profile-api.service';
 import { AuthService } from '../shared/services/auth.service';
 import { DriverLocationPingService } from '../shared/services/driver-location-ping.service';
+import { CurrentUserService } from './services/current-user.service';
 
 @Component({
   selector: 'app-layout',
@@ -15,19 +16,11 @@ import { DriverLocationPingService } from '../shared/services/driver-location-pi
   styleUrls: ['./layout.component.scss'],
 })
 export class LayoutComponent implements OnInit, OnDestroy {
-
   private profileService = inject(ProfileApiService);
   private readonly authService = inject(AuthService);
   private readonly driverLocationPingService = inject(DriverLocationPingService);
-  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly currentUserService = inject(CurrentUserService);
   private readonly destroy$ = new Subject<void>();
-
-  user: UserProfile = {
-    name: 'User',
-    initials: 'US',
-    role: 'Passenger',
-    type: 'passenger',
-  };
 
   ngOnInit(): void {
     this.loadUserFromToken();
@@ -49,67 +42,21 @@ export class LayoutComponent implements OnInit, OnDestroy {
     const role = this.authService.getRole();
 
     if (userId && role) {
-      const roleData = this.mapRole(role);
-      // Set role/type immediately from token so navbar shows correct items (driver vs passenger) before profile loads
-      this.user = {
-        ...this.user,
-        role: roleData.label,
-        type: roleData.type,
-      };
+      this.currentUserService.setRoleFromToken(role, email ?? undefined);
       this.profileService.getProfile().subscribe({
         next: (profile) => {
-          const fullName = `${profile.firstName} ${profile.lastName}`;
-          this.user = {
-            ...this.user,
-            name: fullName,
-            initials: this.getInitials(fullName),
-            avatarUrl: profile.avatarUrl,
-          };
-          this.cdr.detectChanges();
+          this.currentUserService.setFromProfile(profile);
         },
         error: (err) => {
           console.error('Failed to load profile:', err);
-          if (email) {
-            this.user = {
-              ...this.user,
-              name: email,
-              initials: this.getInitials(email),
-            };
-            this.cdr.detectChanges();
-          }
+          this.currentUserService.updateAvatar(null);
         },
       });
       return;
     }
 
-    if (email && role && this.user.name === 'User') {
-      const roleData = this.mapRole(role);
-      this.user = {
-        name: email,
-        initials: this.getInitials(email),
-        role: roleData.label,
-        type: roleData.type,
-      };
+    if (email && role) {
+      this.currentUserService.setRoleFromToken(role, email);
     }
-  }
-
-  private mapRole(role: 'DRIVER' | 'PASSENGER' | 'ADMIN'): { label: string; type: UserProfile['type'] } {
-    const r = (role ?? '').toUpperCase();
-    if (r === 'DRIVER') {
-      return { label: 'Driver', type: 'driver' };
-    }
-    if (r === 'ADMIN') {
-      return { label: 'Admin', type: 'admin' };
-    }
-    return { label: 'Passenger', type: 'passenger' };
-  }
-
-  private getInitials(name: string): string {
-    return name
-      .split(' ')
-      .map((n) => n[0])
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
   }
 }

--- a/frontend/src/app/layout/services/current-user.service.ts
+++ b/frontend/src/app/layout/services/current-user.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, signal } from '@angular/core';
+import { UserProfile } from '../components/navbar/navbar.component';
+import { ProfileData } from '../../features/profile/models/profile.model';
+
+const DEFAULT_USER: UserProfile = {
+  name: 'User',
+  initials: 'US',
+  role: 'Passenger',
+  type: 'passenger',
+  avatarUrl: null,
+};
+
+@Injectable({ providedIn: 'root' })
+export class CurrentUserService {
+  private readonly userState = signal<UserProfile>({ ...DEFAULT_USER });
+
+  readonly user = this.userState.asReadonly();
+
+  /**
+   * Set role/type from token so navbar shows correct items before profile loads.
+   * Called by layout when we have userId and role but before profile is loaded.
+   */
+  setRoleFromToken(role: 'DRIVER' | 'PASSENGER' | 'ADMIN', email?: string): void {
+    const roleData = this.mapRole(role);
+    this.userState.update((prev) => ({
+      ...prev,
+      role: roleData.label,
+      type: roleData.type,
+      ...(email && { name: email, initials: this.getInitials(email) }),
+    }));
+  }
+
+  /**
+   * Set full user from profile (after profile API load).
+   */
+  setFromProfile(profile: ProfileData): void {
+    const fullName = `${profile.firstName} ${profile.lastName}`.trim();
+    const roleData = this.mapRole(profile.role);
+    this.userState.set({
+      name: fullName || 'User',
+      initials: this.getInitials(fullName || 'User'),
+      role: roleData.label,
+      type: roleData.type,
+      avatarUrl: profile.avatarUrl ?? null,
+    });
+  }
+
+  /**
+   * Update only the avatar URL (e.g. after profile picture update).
+   */
+  updateAvatar(url: string | null): void {
+    this.userState.update((prev) => ({ ...prev, avatarUrl: url }));
+  }
+
+  /**
+   * Reset to default (e.g. on logout). Optional; layout may unmount on logout.
+   */
+  reset(): void {
+    this.userState.set({ ...DEFAULT_USER });
+  }
+
+  private mapRole(role: string): { label: string; type: UserProfile['type'] } {
+    const r = (role ?? '').toUpperCase();
+    if (r === 'DRIVER') return { label: 'Driver', type: 'driver' };
+    if (r === 'ADMIN') return { label: 'Admin', type: 'admin' };
+    return { label: 'Passenger', type: 'passenger' };
+  }
+
+  private getInitials(name: string): string {
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || 'US';
+  }
+}


### PR DESCRIPTION
close #208 

This pull request introduces backend and frontend support for uploading and displaying user profile pictures, as well as exposes driver active hours in the last 24 hours. The backend now accepts multipart profile picture uploads, saves them to disk, and returns a URL for the client to update the profile. The frontend integrates this flow, updating the profile picture and active hours display. Security and resource handling are updated to allow access to uploaded profile images.

**Profile Picture Upload & Display**

* Backend: Added `/api/profile/picture` endpoint to accept multipart profile picture uploads, validate file type and size, save to disk, and return a relative URL for profile updates. (`ProfileController.java`, `ProfileService.java`) [[1]](diffhunk://#diff-24d3c942fd75e0f44db04270b9da4afb2f0dfc0a79807f5d7a3ed65c314bac24R39-R55) [[2]](diffhunk://#diff-705d99b10a15427bcc3e9e2383f8e90a781584dc27767ee4bb651a0316f1b322R129-R204)
* Frontend: Integrated upload flow—when a user selects a photo, the file is uploaded, then the profile is updated with the returned URL. The image is displayed in the navbar and profile page. (`profile-page.component.ts`, `profile-api.service.ts`, `navbar.component.html`, `navbar.component.scss`) [[1]](diffhunk://#diff-f2939dbaa16291b8897dc1670a5d8fc2cd1e372b99fa2f7423d90494a87f721fR153-R185) [[2]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eR33-R55) [[3]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eL66-R88) [[4]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR51-R56) [[5]](diffhunk://#diff-15e8bbef34846b265cc891b1742d95aae7758b1cccbd952f83db0036585342adR15-R20)
* Backend/Frontend: Profile picture URLs are now resolved to absolute URLs for display, handling both relative and absolute paths. (`profile-api.service.ts`)

**Driver Active Hours**

* Backend: Added calculation of hours driven in the last 24h for drivers, returned in profile responses. (`ProfileService.java`)
* Frontend: Updated driver profile page to display active hours, defaulting to 0/8 if not present. (`profile-page.component.html`, `profile-api.service.ts`) [[1]](diffhunk://#diff-f1eb1bc796aa65a1347afecbe7dd8069c8a2d0f556e60ab3d0f36e6b32d60db9L184-R185) [[2]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eR33-R55)

**Security & Resource Handling**

* Security: Permitted access to `/api/uploads/profile/**` for profile image retrieval. (`SecurityConfig.java`)
* Resource Handler: Configured static resource handler for profile uploads directory, supporting file serving. (`WebConfig.java`) [[1]](diffhunk://#diff-460d64c3828ebf35bd1e488d934a53c9155349425b05d75cfa187b944ca70986R3-R16) [[2]](diffhunk://#diff-460d64c3828ebf35bd1e488d934a53c9155349425b05d75cfa187b944ca70986R26-R36)
* Configuration: Added properties for uploads directory and multipart size limits. (`application.properties`)

**Other UI Improvements**

* Navbar: User avatar and name are now clickable and navigate to the profile page; layout improved for scrollable sidebar. (`navbar.component.html`, `navbar.component.scss`) [[1]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR51-R56) [[2]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR66) [[3]](diffhunk://#diff-15e8bbef34846b265cc891b1742d95aae7758b1cccbd952f83db0036585342adR15-R20)

---

**References:**  
[[1]](diffhunk://#diff-24d3c942fd75e0f44db04270b9da4afb2f0dfc0a79807f5d7a3ed65c314bac24R39-R55) [[2]](diffhunk://#diff-705d99b10a15427bcc3e9e2383f8e90a781584dc27767ee4bb651a0316f1b322R129-R204) [[3]](diffhunk://#diff-f2939dbaa16291b8897dc1670a5d8fc2cd1e372b99fa2f7423d90494a87f721fR153-R185) [[4]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eR33-R55) [[5]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eL66-R88) [[6]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR51-R56) [[7]](diffhunk://#diff-15e8bbef34846b265cc891b1742d95aae7758b1cccbd952f83db0036585342adR15-R20) [[8]](diffhunk://#diff-83e5e6880008a69ef9af0be23325921eedfc6661e48bc6cee3dd504bd224ef2eL81-R112) [[9]](diffhunk://#diff-705d99b10a15427bcc3e9e2383f8e90a781584dc27767ee4bb651a0316f1b322R86-R87) [[10]](diffhunk://#diff-f1eb1bc796aa65a1347afecbe7dd8069c8a2d0f556e60ab3d0f36e6b32d60db9L184-R185) [[11]](diffhunk://#diff-90c5dcf746db5accdfe870c150eb538962a54a6f760076244bea90e1ca312f48L62-R63) [[12]](diffhunk://#diff-460d64c3828ebf35bd1e488d934a53c9155349425b05d75cfa187b944ca70986R3-R16) [[13]](diffhunk://#diff-460d64c3828ebf35bd1e488d934a53c9155349425b05d75cfa187b944ca70986R26-R36) [[14]](diffhunk://#diff-7647070c49e1c4e96fd2fb77ae1a686d616675c21dedb658199caea2da596feaR36-R42) [[15]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR66)