### PR TITLE
[MOB 21] fix: correct mapbox dependency

### DIFF
--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -11,8 +11,13 @@ val secretsProperties = Properties().apply {
     }
 }
 
-val mapboxAccessToken = secretsProperties.getProperty("MAPBOX_ACCESS_TOKEN") ?: "MAPBOX_API_KEY"
-val apiBaseUrl = secretsProperties.getProperty("API_BASE_URL") ?: "http://localhost:8080/api"
+val mapboxAccessToken = (
+    secretsProperties.getProperty("MAPBOX_ACCESS_TOKEN")
+        ?: secretsProperties.getProperty("MAPBOX_PUBLIC_TOKEN")
+        ?: secretsProperties.getProperty("MAPBOX_SECRET_KEY")
+        ?: "MAPBOX_API_KEY"
+).trim()
+val apiBaseUrl = (secretsProperties.getProperty("API_BASE_URL") ?: "http://localhost:8080/api").trim()
 
 android {
     namespace = "com.drumigo.mobile"
@@ -32,7 +37,7 @@ android {
         if (secretsFile.exists()) {
             secretsFile.inputStream().use { secretsProps.load(it) }
         }
-        val apiBaseUrl = secretsProps.getProperty("API_BASE_URL", "").trim()
+        val apiBaseUrl = secretsProps.getProperty("API_BASE_URL", "http://localhost:8080/api").trim()
 
         buildConfigField("String", "MAPBOX_ACCESS_TOKEN", "\"${mapboxAccessToken}\"")
         buildConfigField("String", "API_BASE_URL", "\"${apiBaseUrl}\"")
@@ -77,7 +82,6 @@ dependencies {
 
     // Maps (Mapbox)
     implementation(libs.mapbox.maps)
-    implementation(libs.mapbox.annotation)
     implementation(libs.play.services.location)
 
     // Testing

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/map/ActiveVehiclesMapFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/map/ActiveVehiclesMapFragment.java
@@ -30,7 +30,9 @@ import com.mapbox.maps.CameraOptions;
 import com.mapbox.maps.MapView;
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor;
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin;
+import com.mapbox.maps.plugin.annotation.AnnotationsUtils;
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManagerKt;
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions;
 
 import java.util.ArrayList;
@@ -245,8 +247,8 @@ public class ActiveVehiclesMapFragment extends Fragment {
         if (mapView == null || pointAnnotationManager != null) {
             return;
         }
-        AnnotationPlugin annotationPlugin = mapView.getAnnotations();
-        pointAnnotationManager = annotationPlugin.createPointAnnotationManager();
+        AnnotationPlugin annotationPlugin = AnnotationsUtils.getAnnotations(mapView);
+        pointAnnotationManager = PointAnnotationManagerKt.createPointAnnotationManager(annotationPlugin, null);
         pointAnnotationManager.addClickListener(annotation -> {
             if (binding == null) {
                 return false;

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
@@ -35,9 +35,12 @@ import com.mapbox.geojson.Point;
 import com.mapbox.maps.CameraOptions;
 import com.mapbox.maps.MapView;
 import com.mapbox.maps.plugin.annotation.AnnotationPlugin;
+import com.mapbox.maps.plugin.annotation.AnnotationsUtils;
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManagerKt;
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions;
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManager;
+import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationManagerKt;
 import com.mapbox.maps.plugin.annotation.generated.PolylineAnnotationOptions;
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor;
 
@@ -474,12 +477,12 @@ public class RideTrackingFragment extends Fragment {
         if (mapView == null) {
             return;
         }
-        AnnotationPlugin annotationPlugin = mapView.getAnnotations();
+        AnnotationPlugin annotationPlugin = AnnotationsUtils.getAnnotations(mapView);
         if (pointAnnotationManager == null) {
-            pointAnnotationManager = annotationPlugin.createPointAnnotationManager();
+            pointAnnotationManager = PointAnnotationManagerKt.createPointAnnotationManager(annotationPlugin, null);
         }
         if (polylineAnnotationManager == null) {
-            polylineAnnotationManager = annotationPlugin.createPolylineAnnotationManager();
+            polylineAnnotationManager = PolylineAnnotationManagerKt.createPolylineAnnotationManager(annotationPlugin, null);
         }
     }
 

--- a/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
+++ b/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
@@ -20,7 +20,7 @@
             android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/back"
             android:src="@drawable/ic_arrow_back"
-            android:tint="@color/text_dark" />
+            app:tint="@color/text_dark" />
 
         <LinearLayout
             android:layout_width="0dp"

--- a/mobile/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/app/src/main/res/navigation/nav_graph.xml
@@ -20,7 +20,7 @@
         <argument
             android:name="rideId"
             app:argType="long"
-            android:defaultValue="0" />
+            android:defaultValue="0L" />
     </fragment>
 
     <fragment

--- a/mobile/settings.gradle.kts
+++ b/mobile/settings.gradle.kts
@@ -1,3 +1,18 @@
+import java.util.Properties
+
+val secretsProperties = Properties().apply {
+    val secretsFile = file("secrets.properties")
+    if (secretsFile.exists()) {
+        secretsFile.inputStream().use { load(it) }
+    }
+}
+
+val mapboxDownloadsToken = (
+    secretsProperties.getProperty("MAPBOX_DOWNLOADS_TOKEN")
+        ?: secretsProperties.getProperty("MAPBOX_SECRET_KEY")
+        ?: System.getenv("MAPBOX_DOWNLOADS_TOKEN")
+).orEmpty().trim()
+
 pluginManagement {
     repositories {
         google {
@@ -16,6 +31,15 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://api.mapbox.com/downloads/v2/releases/maven") {
+            credentials {
+                username = "mapbox"
+                password = mapboxDownloadsToken
+            }
+            authentication {
+                create<BasicAuthentication>("basic")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #144 

This pull request makes several improvements to the configuration and usage of Mapbox and API secrets, updates dependency management for Mapbox libraries, and includes minor fixes to code and resource files. The changes enhance flexibility in secret handling, update Mapbox annotation usage to match newer APIs, and improve build reliability.

**Secrets and Configuration Management:**

* Updated secret retrieval logic in `mobile/app/build.gradle.kts` to support multiple possible environment variable names for Mapbox tokens, and ensured all secrets are trimmed of whitespace. Also, provided a default value for `API_BASE_URL` if not set.
* Added logic in `mobile/settings.gradle.kts` to load a Mapbox downloads token from several possible sources and configured the Mapbox Maven repository to use this token for authentication. [[1]](diffhunk://#diff-ec6fff8a6e0ef795b1b00aa9bfe89bca6cab31dceba9a3e169a02a2fbfa14874R1-R15) [[2]](diffhunk://#diff-ec6fff8a6e0ef795b1b00aa9bfe89bca6cab31dceba9a3e169a02a2fbfa14874R34-R42)

**Dependency and Annotation Plugin Updates:**

* Removed the deprecated `mapbox.annotation` dependency and updated Java code in `ActiveVehiclesMapFragment` and `RideTrackingFragment` to use the new `AnnotationsUtils` and `PointAnnotationManagerKt`/`PolylineAnnotationManagerKt` APIs for creating annotation managers. [[1]](diffhunk://#diff-88ee5eac977700af450da72480d952c654086c7b635a3e3a07f0fb2485c5cf2bL80) [[2]](diffhunk://#diff-4c942526d43949ae1f0f3c3fb9c2cb5c0725d8b58b9abfeb1342b0e8193141faR33-R35) [[3]](diffhunk://#diff-4c942526d43949ae1f0f3c3fb9c2cb5c0725d8b58b9abfeb1342b0e8193141faL248-R251) [[4]](diffhunk://#diff-0d3d6136d8688a905944479ef18bee2a718c8b03f50a0bc38fa435b91c494d7bR38-R43) [[5]](diffhunk://#diff-0d3d6136d8688a905944479ef18bee2a718c8b03f50a0bc38fa435b91c494d7bL477-R485)

**Resource and Navigation Fixes:**

* Fixed a resource attribute in `fragment_ride_tracking.xml` by switching from `android:tint` to `app:tint` for compatibility.
* Updated the default value for the `rideId` navigation argument in `nav_graph.xml` to use a long literal (`0L`) for type correctness.