### PR TITLE
[BE 47] feat: store profile picture in internal file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,10 +366,13 @@ The backend exposes a RESTful API at `http://localhost:8080/api`. Key endpoints:
 
 For detailed API documentation, explore the controller classes in `drumigo/src/main/java/com/ftn/drumigo/controller/`.
 
+**Profile pictures:** Only URLs are stored in the database (`profile_picture_url`). Image files live under `uploads/profile/` (or `uploads/profile/temp/` for pre-registration uploads). For registration flows (passenger or driver), upload first via `POST /api/auth/profile-picture` (multipart `file`, no auth), then send the returned `url` in the registration payload as `profilePictureUrl`. For logged-in profile updates, use `POST /api/profile/picture` and then `PUT /api/profile` with the returned URL.
+
 ## 🚧 Known Limitations & Future Work
 
 ### Not Yet Implemented
 
+- **Mobile passenger registration** does not upload profile pictures yet (backend expects `profilePictureUrl` from `POST /api/auth/profile-picture`; web app uses this flow).
 - Real-time WebSocket connections (ride updates are polling-based or refresh-based)
 - Multi-passenger ride splitting
 - Scheduled rides (future booking)

--- a/drumigo/src/main/java/com/ftn/drumigo/controller/AuthController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/AuthController.java
@@ -4,18 +4,26 @@ import com.ftn.drumigo.dto.auth.request.LoginRequest;
 import com.ftn.drumigo.dto.auth.response.LoginResponse;
 import com.ftn.drumigo.security.CustomUserDetails;
 import com.ftn.drumigo.service.AuthService;
+import com.ftn.drumigo.service.ProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-    
+
     private final AuthService authService;
+    private final ProfileService profileService;
     
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
@@ -41,6 +49,22 @@ public class AuthController {
             @RequestBody String newPassword) {
         authService.resetPassword(token, newPassword);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Upload a temporary profile picture for registration (no auth required).
+     * Returns the URL to send as profilePictureUrl when registering.
+     */
+    @PostMapping(value = "/profile-picture", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> uploadProfilePictureForRegistration(@RequestParam("file") MultipartFile file) {
+        try {
+            String url = profileService.saveTempProfilePicture(file);
+            return ResponseEntity.ok(Map.of("url", url));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "Failed to save picture"));
+        }
     }
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/auth/request/PassengerRegisterRequest.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/auth/request/PassengerRegisterRequest.java
@@ -28,6 +28,6 @@ public record PassengerRegisterRequest(
         @NotBlank(message = "Phone number is required")
         String phoneNumber,
 
-        String profilePicture
+        String profilePictureUrl
 ) {}
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/PassengerService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/PassengerService.java
@@ -72,8 +72,8 @@ public class PassengerService {
         passenger.setUpdatedAt(Instant.now());
         passenger.setPasswordHash(PasswordUtil.hashPassword(password)); // Hash password
 
-        if (request.profilePicture() != null && !request.profilePicture().isBlank()) {
-            passenger.setProfilePictureUrl(request.profilePicture());
+        if (request.profilePictureUrl() != null && !request.profilePictureUrl().isBlank()) {
+            passenger.setProfilePictureUrl(request.profilePictureUrl());
         }
 
         passenger = passengerRepository.save(passenger);

--- a/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java
@@ -29,6 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -156,6 +157,38 @@ public class ProfileService {
         file.transferTo(target);
 
         return "/api/uploads/profile/" + filename;
+    }
+
+    /**
+     * Save a temporary profile picture (e.g. for registration before user exists).
+     * File is stored under profile-dir/temp/ with a UUID filename.
+     * Caller should store the returned URL in the user's profilePictureUrl when creating the user.
+     */
+    @Transactional
+    public String saveTempProfilePicture(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("Profile picture file is required");
+        }
+        if (file.getSize() > MAX_PICTURE_SIZE_BYTES) {
+            throw new IllegalArgumentException("Profile picture must be at most 5MB");
+        }
+        String contentType = file.getContentType();
+        if (contentType != null && !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("Profile picture must be JPEG, PNG, GIF, or WebP");
+        }
+
+        Path dir = Path.of(profileUploadDir).resolve("temp").toAbsolutePath().normalize();
+        Files.createDirectories(dir);
+
+        String extension = getExtensionFromContentTypeOrFilename(contentType, file.getOriginalFilename());
+        String filename = UUID.randomUUID() + extension;
+        Path target = dir.resolve(filename).normalize();
+        if (!target.startsWith(dir)) {
+            throw new IllegalArgumentException("Invalid file path");
+        }
+        file.transferTo(target);
+
+        return "/api/uploads/profile/temp/" + filename;
     }
 
     private static String getExtensionFromContentTypeOrFilename(String contentType, String originalFilename) {

--- a/frontend/src/app/features/admin/driver-registration/driver-registration.component.spec.ts
+++ b/frontend/src/app/features/admin/driver-registration/driver-registration.component.spec.ts
@@ -12,11 +12,12 @@ describe('DriverRegistrationComponent', () => {
   beforeEach(async () => {
     driverRegistrationService = jasmine.createSpyObj<DriverRegistrationService>(
       'DriverRegistrationService',
-      ['registerDriver', 'mapCategoryToTypeId'],
+      ['registerDriver', 'mapCategoryToTypeId', 'uploadProfilePicture'],
     );
 
     driverRegistrationService.mapCategoryToTypeId.and.returnValue(2);
     driverRegistrationService.registerDriver.and.returnValue(of({ id: 1 } as any));
+    driverRegistrationService.uploadProfilePicture.and.returnValue(of({ url: '/api/uploads/profile/temp/test.jpg' }));
 
     await TestBed.configureTestingModule({
       imports: [DriverRegistrationComponent],

--- a/frontend/src/app/features/admin/driver-registration/driver-registration.component.ts
+++ b/frontend/src/app/features/admin/driver-registration/driver-registration.component.ts
@@ -59,8 +59,6 @@ export class DriverRegistrationComponent implements OnInit {
   isSubmitting = false;
 
   selectedPhotoFile: File | null = null;
-  /** Base64 data URL of selected profile picture, set when user selects a photo */
-  selectedPhotoDataUrl: string | null = null;
 
   vehicleCategories: VehicleCategory[] = ['Standard', 'Luxury', 'Van'];
 
@@ -102,11 +100,6 @@ export class DriverRegistrationComponent implements OnInit {
   onPhotoSelected(file: File): void {
     this.selectedPhotoFile = file;
     console.log('Driver photo selected (auto-cropped to 1:1):', file.name, file.size, 'bytes');
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      this.selectedPhotoDataUrl = (e.target?.result as string) ?? null;
-    };
-    reader.readAsDataURL(file);
   }
 
   nextStep(): void {
@@ -160,45 +153,59 @@ export class DriverRegistrationComponent implements OnInit {
 
     this.isSubmitting = true;
 
-    // Prepare the data
     const driverData: DriverFormData = this.driverForm.value;
     const vehicleData: VehicleFormData = this.vehicleForm.value;
 
-    const registrationRequest = {
+    const buildRequest = (profilePictureUrl: string | null) => ({
       name: driverData.firstName,
       surname: driverData.lastName,
       email: driverData.email,
       phone: driverData.countryCode + driverData.phone,
       address: driverData.address,
-      profilePictureUrl: this.selectedPhotoDataUrl ?? null,
+      profilePictureUrl,
       vehicleTypeId: this.driverRegistrationService.mapCategoryToTypeId(vehicleData.category),
       vehicleModel: vehicleData.model,
       vehicleLicensePlate: vehicleData.licensePlate.toUpperCase(),
       vehicleNumSeats: vehicleData.seats,
       vehicleBabyFriendly: vehicleData.babySeats,
       vehiclePetFriendly: vehicleData.petFriendly,
+    });
+
+    const doRegister = (registrationRequest: ReturnType<typeof buildRequest>) => {
+      this.driverRegistrationService
+        .registerDriver(registrationRequest)
+        .pipe(
+          finalize(() => {
+            this.isSubmitting = false;
+          }),
+        )
+        .subscribe({
+          next: (response) => {
+            console.log('Driver registered successfully:', response);
+            this.toastService.success('Driver created. Activation email sent.');
+            this.addAnotherDriver();
+          },
+          error: (error) => {
+            console.error('Error registering driver:', error);
+            alert(error.error?.message || 'Failed to register driver. Please try again.');
+          },
+        });
     };
 
-    this.driverRegistrationService
-      .registerDriver(registrationRequest)
-      // Always stop the spinner, even if an interceptor completes the stream without next/error.
-      .pipe(
-        finalize(() => {
-          this.isSubmitting = false;
-        }),
-      )
-      .subscribe({
-      next: (response) => {
-        console.log('Driver registered successfully:', response);
-        // UX: immediately reset the form to allow registering the next driver.
-        // Admin should not get "stuck" on a separate success screen.
-        this.toastService.success('Driver created. Activation email sent.');
-        this.addAnotherDriver();
+    const file = this.selectedPhotoFile;
+    if (!file) {
+      doRegister(buildRequest(null));
+      return;
+    }
+
+    this.driverRegistrationService.uploadProfilePicture(file).subscribe({
+      next: (res) => {
+        doRegister(buildRequest(res.url));
       },
-      error: (error) => {
-        console.error('Error registering driver:', error);
-        // TODO: Show error message to user
-        alert(error.error?.message || 'Failed to register driver. Please try again.');
+      error: (err) => {
+        this.isSubmitting = false;
+        console.error('Profile picture upload failed:', err);
+        doRegister(buildRequest(null));
       },
     });
   }
@@ -209,7 +216,6 @@ export class DriverRegistrationComponent implements OnInit {
     this.driverSubmitted = false;
     this.vehicleSubmitted = false;
     this.selectedPhotoFile = null;
-    this.selectedPhotoDataUrl = null;
     this.driverForm.reset({
       countryCode: '+381',
     });

--- a/frontend/src/app/features/admin/services/driver-registration.service.ts
+++ b/frontend/src/app/features/admin/services/driver-registration.service.ts
@@ -38,8 +38,15 @@ export interface DriverRegistrationResponse {
 })
 export class DriverRegistrationService {
   private apiUrl = `${environment.apiBaseUrl}/drivers`;
+  private authUrl = `${environment.apiBaseUrl}/auth`;
 
   constructor(private http: HttpClient) {}
+
+  uploadProfilePicture(file: File): Observable<{ url: string }> {
+    const formData = new FormData();
+    formData.set('file', file);
+    return this.http.post<{ url: string }>(`${this.authUrl}/profile-picture`, formData);
+  }
 
   registerDriver(request: DriverRegistrationRequest): Observable<DriverRegistrationResponse> {
     // Guard against indefinite spinner if backend gets stuck.

--- a/frontend/src/app/features/auth/register/register.component.spec.ts
+++ b/frontend/src/app/features/auth/register/register.component.spec.ts
@@ -12,8 +12,9 @@ describe('RegisterComponent', () => {
   let registerService: jasmine.SpyObj<RegisterService>;
 
   beforeEach(async () => {
-    registerService = jasmine.createSpyObj<RegisterService>('RegisterService', ['register']);
+    registerService = jasmine.createSpyObj<RegisterService>('RegisterService', ['register', 'uploadProfilePicture']);
     registerService.register.and.returnValue(of({ id: 1 }));
+    registerService.uploadProfilePicture.and.returnValue(of({ url: '/api/uploads/profile/temp/test.jpg' }));
 
     await TestBed.configureTestingModule({
       imports: [RegisterComponent],
@@ -40,15 +41,6 @@ describe('RegisterComponent', () => {
 
   it('should send user registration payload and navigate to login', () => {
     const navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
-    const dataUrl = 'data:image/png;base64,dGVzdA==';
-    spyOn(FileReader.prototype, 'readAsDataURL').and.callFake(function (this: FileReader) {
-      const reader = this;
-      setTimeout(() => {
-        Object.defineProperty(reader, 'result', { value: dataUrl, configurable: true });
-        (reader as any).onload?.({ target: reader } as ProgressEvent<FileReader>);
-      }, 0);
-    });
-
     const photo = new File(['avatar'], 'avatar.png', { type: 'image/png' });
     component.onPhotoSelected(photo);
     component.registerForm.patchValue({
@@ -65,24 +57,19 @@ describe('RegisterComponent', () => {
 
     component.onSubmit();
 
-    // Payload is sent in FileReader onload (async). Wait for it.
-    return fixture.whenStable().then(() => {
-      return new Promise<void>((resolve) => setTimeout(resolve, 50));
-    }).then(() => {
-      expect(registerService.register).toHaveBeenCalledWith(
-        jasmine.objectContaining({
-          firstName: 'Milos',
-          lastName: 'Milosevic',
-          email: 'milos@example.com',
-          phoneNumber: '+381641112223',
-          address: 'Narodnog Fronta 10',
-          password: 'Password1',
-          confirmPassword: 'Password1',
-        }),
-      );
-      const payload = registerService.register.calls.mostRecent()?.args[0];
-      expect(payload?.profilePicture).toBe(dataUrl);
-      expect(navigateSpy).toHaveBeenCalledWith(['/login']);
-    });
+    expect(registerService.uploadProfilePicture).toHaveBeenCalledWith(photo);
+    expect(registerService.register).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        firstName: 'Milos',
+        lastName: 'Milosevic',
+        email: 'milos@example.com',
+        phoneNumber: '+381641112223',
+        address: 'Narodnog Fronta 10',
+        password: 'Password1',
+        confirmPassword: 'Password1',
+        profilePictureUrl: '/api/uploads/profile/temp/test.jpg',
+      }),
+    );
+    expect(navigateSpy).toHaveBeenCalledWith(['/login']);
   });
 });

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -108,7 +108,7 @@ export class RegisterComponent implements OnInit {
     }
 
     const formValue = this.registerForm.value;
-    const basePayload: Omit<PassengerRegisterRequest, 'profilePicture'> = {
+    const basePayload: Omit<PassengerRegisterRequest, 'profilePictureUrl'> = {
       firstName: formValue.firstName,
       lastName: formValue.lastName,
       email: formValue.email,
@@ -120,15 +120,18 @@ export class RegisterComponent implements OnInit {
 
     const file = this.selectedPhotoFile;
     if (!file) {
-      this.submitWithPayload({ ...basePayload, profilePicture: undefined });
+      this.submitWithPayload({ ...basePayload, profilePictureUrl: undefined });
       return;
     }
 
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      const dataUrl = e.target?.result as string;
-      this.submitWithPayload({ ...basePayload, profilePicture: dataUrl });
-    };
-    reader.readAsDataURL(file);
+    this.registerService.uploadProfilePicture(file).subscribe({
+      next: (res) => {
+        this.submitWithPayload({ ...basePayload, profilePictureUrl: res.url });
+      },
+      error: (err) => {
+        console.error('Profile picture upload failed:', err);
+        this.submitWithPayload({ ...basePayload, profilePictureUrl: undefined });
+      },
+    });
   }
 }

--- a/frontend/src/app/features/auth/services/register.service.ts
+++ b/frontend/src/app/features/auth/services/register.service.ts
@@ -11,7 +11,7 @@ export interface PassengerRegisterRequest {
   lastName: string;
   address: string;
   phoneNumber: string;
-  profilePicture?: string;
+  profilePictureUrl?: string;
 }
 
 @Injectable({
@@ -19,10 +19,17 @@ export interface PassengerRegisterRequest {
 })
 export class RegisterService {
   private apiUrl = `${environment.apiBaseUrl}/passengers`;
+  private authUrl = `${environment.apiBaseUrl}/auth`;
 
   constructor(private http: HttpClient) {}
 
-  register(passenger: PassengerRegisterRequest): Observable<any> {
+  register(passenger: PassengerRegisterRequest): Observable<unknown> {
     return this.http.post(this.apiUrl, passenger);
+  }
+
+  uploadProfilePicture(file: File): Observable<{ url: string }> {
+    const formData = new FormData();
+    formData.set('file', file);
+    return this.http.post<{ url: string }>(`${this.authUrl}/profile-picture`, formData);
   }
 }

--- a/frontend/src/app/features/profile/profile-page/profile-page.component.ts
+++ b/frontend/src/app/features/profile/profile-page/profile-page.component.ts
@@ -168,7 +168,12 @@ export class ProfilePageComponent implements OnInit {
             .subscribe({
               next: (updatedProfile) => {
                 this.profile.set(updatedProfile);
-                this.currentUserService.setFromProfile(updatedProfile);
+                // Cache-bust avatar URL so navbar img refetches (same path overwritten on server)
+                const profileWithBuster =
+                  updatedProfile?.avatarUrl != null
+                    ? { ...updatedProfile, avatarUrl: `${updatedProfile.avatarUrl}?t=${Date.now()}` }
+                    : updatedProfile;
+                this.currentUserService.setFromProfile(profileWithBuster ?? updatedProfile);
                 this.showSuccess('Profile photo updated successfully');
               },
               error: (err) => {


### PR DESCRIPTION
Implements #215

This pull request implements a unified backend and frontend flow for uploading and storing user profile pictures, both during registration (for passengers and drivers) and for profile updates. The changes introduce a new backend endpoint for temporary profile picture uploads, refactor the API and DTOs to use `profilePictureUrl` instead of embedding image data, and update the frontend registration flows to upload images to the backend and send the returned URL.

Key changes include:

**Backend: Profile Picture Upload API and Data Model**

- Added a new unauthenticated endpoint `POST /api/auth/profile-picture` that allows uploading a temporary profile picture during registration. The image is saved under `uploads/profile/temp/` and a URL is returned for use in registration payloads. (`drumigo/src/main/java/com/ftn/drumigo/controller/AuthController.java`, `drumigo/src/main/java/com/ftn/drumigo/service/ProfileService.java`) [[1]](diffhunk://#diff-580ea67e66f55ad9a14b3cb6459c9d13879cf029356b2efaf1e81b38d0cb8096R53-R68) [[2]](diffhunk://#diff-705d99b10a15427bcc3e9e2383f8e90a781584dc27767ee4bb651a0316f1b322R162-R193)
- Updated the `PassengerRegisterRequest` DTO and registration logic to use `profilePictureUrl` instead of embedding image data, and ensured the backend stores only the URL in the database. (`drumigo/src/main/java/com/ftn/drumigo/dto/auth/request/PassengerRegisterRequest.java`, `drumigo/src/main/java/com/ftn/drumigo/service/PassengerService.java`) [[1]](diffhunk://#diff-f04e085c35f300ac9ee45ac0d8bb77dfe54ed54018fb8edb4ad657b23590ef20L31-R31) [[2]](diffhunk://#diff-a80770782e7fa253da8962ea118e3be313be4a08056c5c3e477126679a30b8d0L75-R76)
- Documented the new profile picture upload flow in the `README.md`.

**Frontend: Registration and Profile Update Flows**

- Refactored both passenger and driver registration flows to upload the selected profile photo to the backend with a new `uploadProfilePicture` service method, then send the returned URL in the registration payload. Removed all usage of base64-encoded image data in payloads. (`frontend/src/app/features/auth/register/register.component.ts`, `frontend/src/app/features/admin/driver-registration/driver-registration.component.ts`, `frontend/src/app/features/auth/services/register.service.ts`, `frontend/src/app/features/admin/services/driver-registration.service.ts`) [[1]](diffhunk://#diff-7122abae4436681fef7b6057a0a5557dee229ab4f80162c27130ffe5494123b2L123-R135) [[2]](diffhunk://#diff-afb595b37c11344f0df8585be6f703765846d0259b6d3971c3e6a5ec465f45dbL163-L184) [[3]](diffhunk://#diff-c99a7320bc2db653bf44c4a2cd2305f621add63c1efbd00aab25188cce825619L14-R34) [[4]](diffhunk://#diff-46b5648a8522ed0d73eb891d85347d1155f6131dd63efc7d37475b2b6fdbef9cR41-R50)
- Updated related unit tests to mock and verify the new upload flow and payload structure. (`frontend/src/app/features/auth/register/register.component.spec.ts`, `frontend/src/app/features/admin/driver-registration/driver-registration.component.spec.ts`) [[1]](diffhunk://#diff-b1ff443ea56ff9a494f76ab4a5d660b3caa163cf486dea646a669ba48c0cf46dL15-R17) [[2]](diffhunk://#diff-34e7c331e1220ec1c05b571074c83ffaf9625f0074da3c12ec03b45fb92d1f17L15-R20)

**Frontend: Profile Page Improvements**

- Improved avatar image cache-busting on profile updates to ensure the UI reflects the new image immediately. (`frontend/src/app/features/profile/profile-page/profile-page.component.ts`) 