### PR TITLE
[FE 57] feat: implement support integration

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/controller/MessageController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/MessageController.java
@@ -1,6 +1,7 @@
 package com.ftn.drumigo.controller;
 
 import com.ftn.drumigo.domain.Message;
+import com.ftn.drumigo.dto.SupportConversationSummaryResponse;
 import com.ftn.drumigo.dto.SupportMessageCreateRequest;
 import com.ftn.drumigo.dto.SupportMessageResponse;
 import com.ftn.drumigo.mapper.MessageMapper;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,18 +27,54 @@ public class MessageController {
     private final MessageMapper messageMapper;
     
     @PostMapping("/messages")
+    @PreAuthorize("hasRole('PASSENGER') or hasRole('DRIVER') or hasRole('ADMIN')")
     public ResponseEntity<SupportMessageResponse> createSupportMessage(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody SupportMessageCreateRequest request) {
-        Message message = messageService.createSupportMessage(userDetails.getUserId(), request);
+        Message message = messageService.createSupportMessage(
+            userDetails.getUserId(),
+            userDetails.getRole(),
+            request
+        );
         return ResponseEntity.status(HttpStatus.CREATED).body(messageMapper.toResponse(message));
     }
-    
+
+    @GetMapping("/my-chat")
+    @PreAuthorize("hasRole('PASSENGER') or hasRole('DRIVER')")
+    public ResponseEntity<List<SupportMessageResponse>> getMySupportChat(
+        @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<Message> messages = messageService.getMySupportChat(userDetails.getUserId());
+        List<SupportMessageResponse> responses = messages.stream()
+            .map(messageMapper::toResponse)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/conversations")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<SupportConversationSummaryResponse>> getSupportConversations() {
+        return ResponseEntity.ok(messageService.getSupportConversationsForAdmin());
+    }
+
+    @GetMapping("/conversations/{userId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<SupportMessageResponse>> getSupportConversationByUserId(
+        @PathVariable Long userId
+    ) {
+        List<Message> messages = messageService.getSupportConversationForAdmin(userId);
+        List<SupportMessageResponse> responses = messages.stream()
+            .map(messageMapper::toResponse)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(responses);
+    }
+
     @GetMapping("/chats/{otherUserId}")
-    public ResponseEntity<List<SupportMessageResponse>> getChatHistory(
-            @PathVariable Long otherUserId,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<Message> messages = messageService.getChatHistory(userDetails.getUserId(), otherUserId);
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<SupportMessageResponse>> getChatHistoryAlias(
+        @PathVariable Long otherUserId
+    ) {
+        List<Message> messages = messageService.getSupportConversationForAdmin(otherUserId);
         List<SupportMessageResponse> responses = messages.stream()
             .map(messageMapper::toResponse)
             .collect(Collectors.toList());

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/SupportConversationSummaryResponse.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/SupportConversationSummaryResponse.java
@@ -1,0 +1,13 @@
+package com.ftn.drumigo.dto;
+
+import java.time.Instant;
+
+public record SupportConversationSummaryResponse(
+    Long userId,
+    String userName,
+    String userSurname,
+    String lastMessage,
+    Instant lastMessageAt,
+    Long lastSenderId,
+    String lastSenderRole
+) {}

--- a/drumigo/src/main/java/com/ftn/drumigo/dto/SupportMessageCreateRequest.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/dto/SupportMessageCreateRequest.java
@@ -1,10 +1,8 @@
 package com.ftn.drumigo.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record SupportMessageCreateRequest(
-    @NotNull(message = "Receiver ID is required")
     Long receiverId,
     
     @NotBlank(message = "Content is required")

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/MessageRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/MessageRepository.java
@@ -2,6 +2,7 @@ package com.ftn.drumigo.repository;
 
 import com.ftn.drumigo.domain.Message;
 import com.ftn.drumigo.domain.users.User;
+import com.ftn.drumigo.domain.enums.UserRole;
 import com.ftn.drumigo.domain.enums.MessageType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,5 +17,32 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     List<Message> findChatBetweenUsers(@Param("user1") User user1, @Param("user2") User user2);
     
     List<Message> findByTypeAndReceiverOrderByCreatedAtDesc(MessageType type, User receiver);
+
+    @Query("""
+        SELECT m FROM Message m
+        WHERE m.type = :type
+          AND (
+            (m.sender = :user AND m.receiver.role = :adminRole)
+            OR
+            (m.receiver = :user AND m.sender.role = :adminRole)
+          )
+        ORDER BY m.createdAt ASC
+        """)
+    List<Message> findSupportThreadForUser(
+        @Param("user") User user,
+        @Param("type") MessageType type,
+        @Param("adminRole") UserRole adminRole
+    );
+
+    @Query("""
+        SELECT m FROM Message m
+        WHERE m.type = :type
+          AND (m.sender.role = :adminRole OR m.receiver.role = :adminRole)
+        ORDER BY m.createdAt DESC
+        """)
+    List<Message> findAllSupportMessagesWithAdminsOrderByCreatedAtDesc(
+        @Param("type") MessageType type,
+        @Param("adminRole") UserRole adminRole
+    );
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/repository/UserRepository.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.ftn.drumigo.repository;
 
+import com.ftn.drumigo.domain.enums.UserRole;
 import com.ftn.drumigo.domain.users.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    Optional<User> findFirstByRoleOrderByIdAsc(UserRole role);
 }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/EmailService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/EmailService.java
@@ -1,6 +1,4 @@
 package com.ftn.drumigo.service;
-
-import com.ftn.drumigo.exception.EmailSendException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +22,7 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
-    private void sendEmail(String email, String subject, String body) {
+    private boolean sendEmail(String email, String subject, String body) {
         try {
             SimpleMailMessage message = new SimpleMailMessage();
             message.setTo(email);
@@ -36,10 +34,12 @@ public class EmailService {
 
             mailSender.send(message);
             log.info("Email successfully sent to {} with subject '{}'", email, subject);
+            return true;
 
         } catch (Exception e) {
-            log.error("Failed to send email to {}: {}", email, e.getMessage(), e);
-            throw new EmailSendException("Failed to send email", e);
+            // Email delivery must never break core business flows. Persisted domain data remains intact.
+            log.warn("Failed to send email to {}: {}", email, e.getMessage());
+            return false;
         }
     }
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/MessageService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/MessageService.java
@@ -1,9 +1,12 @@
 package com.ftn.drumigo.service;
 
 import com.ftn.drumigo.domain.Message;
+import com.ftn.drumigo.domain.enums.UserRole;
 import com.ftn.drumigo.domain.users.User;
 import com.ftn.drumigo.domain.enums.MessageType;
+import com.ftn.drumigo.dto.SupportConversationSummaryResponse;
 import com.ftn.drumigo.dto.SupportMessageCreateRequest;
+import com.ftn.drumigo.exception.BadRequestException;
 import com.ftn.drumigo.exception.ResourceNotFoundException;
 import com.ftn.drumigo.repository.MessageRepository;
 import com.ftn.drumigo.repository.UserRepository;
@@ -11,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -21,31 +27,80 @@ public class MessageService {
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
     
-    /**
-     * Create a support message.
-     * Security: Sender ID is derived from authentication, not from client input.
-     *
-     * @param senderId the authenticated sender's ID (from JWT token)
-     * @param request the request containing receiverId and content
-     * @return the created message
-     * @throws ResourceNotFoundException if sender or receiver not found
-     */
-    public Message createSupportMessage(Long senderId, SupportMessageCreateRequest request) {
+    public Message createSupportMessage(Long senderId, String senderRole, SupportMessageCreateRequest request) {
         User sender = userRepository.findById(senderId)
             .orElseThrow(() -> new ResourceNotFoundException("Sender not found with id: " + senderId));
 
-        User receiver = userRepository.findById(request.receiverId())
-            .orElseThrow(() -> new ResourceNotFoundException("Receiver not found with id: " + request.receiverId()));
-        
-        Message message = new Message();
-        message.setSender(sender);
-        message.setReceiver(receiver);
-        message.setContent(request.content());
-        message.setType(MessageType.SUPPORT);
-        
-        return messageRepository.save(message);
+        UserRole role = sender.getRole();
+        if (role == UserRole.ADMIN) {
+            return createMessage(sender, resolveAdminReceiver(request), request.content());
+        }
+        if (role == UserRole.PASSENGER || role == UserRole.DRIVER) {
+            User adminReceiver = resolveDefaultAdmin();
+            return createMessage(sender, adminReceiver, request.content());
+        }
+
+        throw new BadRequestException("Unsupported role for support messaging: " + senderRole);
     }
-    
+
+    public List<Message> getMySupportChat(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        if (user.getRole() == UserRole.ADMIN) {
+            throw new BadRequestException("Admins should use conversation-specific support endpoints.");
+        }
+
+        return messageRepository.findSupportThreadForUser(user, MessageType.SUPPORT, UserRole.ADMIN);
+    }
+
+    public List<SupportConversationSummaryResponse> getSupportConversationsForAdmin() {
+        List<Message> messages = messageRepository.findAllSupportMessagesWithAdminsOrderByCreatedAtDesc(
+            MessageType.SUPPORT,
+            UserRole.ADMIN
+        );
+
+        Map<Long, SupportConversationSummaryResponse> summaries = new LinkedHashMap<>();
+        for (Message message : messages) {
+            User sender = message.getSender();
+            User receiver = message.getReceiver();
+            boolean senderIsAdmin = sender.getRole() == UserRole.ADMIN;
+            boolean receiverIsAdmin = receiver.getRole() == UserRole.ADMIN;
+
+            // Ignore malformed rows where both users are admin or both are non-admin.
+            if (senderIsAdmin == receiverIsAdmin) {
+                continue;
+            }
+
+            User conversationUser = senderIsAdmin ? receiver : sender;
+            summaries.putIfAbsent(
+                conversationUser.getId(),
+                new SupportConversationSummaryResponse(
+                    conversationUser.getId(),
+                    conversationUser.getName(),
+                    conversationUser.getSurname(),
+                    message.getContent(),
+                    message.getCreatedAt(),
+                    sender.getId(),
+                    sender.getRole().name()
+                )
+            );
+        }
+
+        return new ArrayList<>(summaries.values());
+    }
+
+    public List<Message> getSupportConversationForAdmin(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
+
+        if (user.getRole() == UserRole.ADMIN) {
+            throw new BadRequestException("Admin-to-admin support conversations are not allowed.");
+        }
+
+        return messageRepository.findSupportThreadForUser(user, MessageType.SUPPORT, UserRole.ADMIN);
+    }
+
     public List<Message> getChatHistory(Long userId1, Long userId2) {
         User user1 = userRepository.findById(userId1)
             .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId1));
@@ -55,5 +110,33 @@ public class MessageService {
         
         return messageRepository.findChatBetweenUsers(user1, user2);
     }
+
+    private Message createMessage(User sender, User receiver, String content) {
+        Message message = new Message();
+        message.setSender(sender);
+        message.setReceiver(receiver);
+        message.setContent(content);
+        message.setType(MessageType.SUPPORT);
+        return messageRepository.save(message);
+    }
+
+    private User resolveAdminReceiver(SupportMessageCreateRequest request) {
+        if (request.receiverId() == null) {
+            throw new BadRequestException("Receiver ID is required for admin support messages.");
+        }
+
+        User receiver = userRepository.findById(request.receiverId())
+            .orElseThrow(() -> new ResourceNotFoundException("Receiver not found with id: " + request.receiverId()));
+        if (receiver.getRole() == UserRole.ADMIN) {
+            throw new BadRequestException("Admin cannot send support messages to another admin.");
+        }
+        return receiver;
+    }
+
+    private User resolveDefaultAdmin() {
+        return userRepository.findFirstByRoleOrderByIdAsc(UserRole.ADMIN)
+            .orElseThrow(() -> new BadRequestException("No admin is available for support."));
+    }
+        
 }
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -123,11 +123,12 @@ export const routes: Routes = [
       },
       {
         path: 'support',
+        canActivate: [roleGuard],
+        data: { roles: ['PASSENGER', 'DRIVER'] },
         loadComponent: () =>
-          import('./shared/components/placeholder-feature/placeholder-feature.component').then(
-            (m) => m.PlaceholderFeatureComponent,
+          import('./features/support/support-page/support-page.component').then(
+            (m) => m.SupportPageComponent,
           ),
-        data: { featureName: 'Support', specRef: '2.11' },
       },
       // Driver only
       {
@@ -184,10 +185,9 @@ export const routes: Routes = [
           {
             path: 'support',
             loadComponent: () =>
-              import('./shared/components/placeholder-feature/placeholder-feature.component').then(
-                (m) => m.PlaceholderFeatureComponent,
+              import('./features/support/admin-support-page/admin-support-page.component').then(
+                (m) => m.AdminSupportPageComponent,
               ),
-            data: { featureName: 'Live Support / Chat', specRef: '2.11' },
           },
           {
             path: 'drivers',

--- a/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
+++ b/frontend/src/app/features/ride-tracking/ride-tracking.component.ts
@@ -800,8 +800,8 @@ export class RideTrackingComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onContactSupport(): void {
-    console.log('Contact support clicked');
-    // In real app: Open support chat or initiate call
+    this.closePanicModal();
+    this.router.navigate(['/support']);
   }
 
   onCancelRideFromPanic(): void {

--- a/frontend/src/app/features/support/admin-support-page/admin-support-page.component.html
+++ b/frontend/src/app/features/support/admin-support-page/admin-support-page.component.html
@@ -1,0 +1,75 @@
+<section class="support-admin-page">
+  <header class="support-header">
+    <h1>Live Support / Chat</h1>
+    <p>Handle incoming support conversations from drivers and passengers.</p>
+  </header>
+
+  <div class="layout">
+    <aside class="conversations">
+      <h2>Conversations</h2>
+
+      @if (isLoadingConversations) {
+        <div class="state-card">Loading conversations...</div>
+      } @else if (conversations.length === 0) {
+        <div class="state-card">No support conversations yet.</div>
+      } @else {
+        @for (conversation of conversations; track trackConversation($index, conversation)) {
+          <button
+            type="button"
+            class="conversation-item"
+            [class.conversation-item--active]="conversation.userId === selectedUserId"
+            (click)="selectConversation(conversation.userId)"
+          >
+            <div class="conversation-item__header">
+              <span>{{ conversation.userName }} {{ conversation.userSurname }}</span>
+              <span>{{ formatTime(conversation.lastMessageAt) }}</span>
+            </div>
+            <p>{{ conversation.lastMessage }}</p>
+          </button>
+        }
+      }
+    </aside>
+
+    <section class="chat-panel">
+      @if (!selectedConversation) {
+        <div class="state-card">Select a conversation to start replying.</div>
+      } @else {
+        <div class="chat-title">
+          Chat with {{ selectedConversation.userName }} {{ selectedConversation.userSurname }}
+        </div>
+
+        @if (isLoadingMessages) {
+          <div class="state-card">Loading messages...</div>
+        } @else {
+          <div class="messages">
+            @for (message of messages; track trackMessage($index, message)) {
+              <article class="message" [class.message--mine]="isOwnMessage(message)">
+                <div class="message__meta">
+                  <span>{{ message.senderName }} {{ message.senderSurname }}</span>
+                  <span>{{ formatTime(message.createdAt) }}</span>
+                </div>
+                <p class="message__content">{{ message.content }}</p>
+              </article>
+            }
+          </div>
+        }
+
+        <div class="composer">
+          <textarea
+            [(ngModel)]="draftMessage"
+            rows="3"
+            [disabled]="isSending"
+            placeholder="Type a support reply..."
+          ></textarea>
+          <button type="button" [disabled]="isSending || !draftMessage.trim()" (click)="sendMessage()">
+            {{ isSending ? 'Sending...' : 'Send Reply' }}
+          </button>
+        </div>
+      }
+    </section>
+  </div>
+
+  @if (errorMessage) {
+    <p class="error">{{ errorMessage }}</p>
+  }
+</section>

--- a/frontend/src/app/features/support/admin-support-page/admin-support-page.component.html
+++ b/frontend/src/app/features/support/admin-support-page/admin-support-page.component.html
@@ -13,20 +13,22 @@
       } @else if (conversations.length === 0) {
         <div class="state-card">No support conversations yet.</div>
       } @else {
-        @for (conversation of conversations; track trackConversation($index, conversation)) {
-          <button
-            type="button"
-            class="conversation-item"
-            [class.conversation-item--active]="conversation.userId === selectedUserId"
-            (click)="selectConversation(conversation.userId)"
-          >
-            <div class="conversation-item__header">
-              <span>{{ conversation.userName }} {{ conversation.userSurname }}</span>
-              <span>{{ formatTime(conversation.lastMessageAt) }}</span>
-            </div>
-            <p>{{ conversation.lastMessage }}</p>
-          </button>
-        }
+        <div class="conversation-list">
+          @for (conversation of conversations; track trackConversation($index, conversation)) {
+            <button
+              type="button"
+              class="conversation-item"
+              [class.conversation-item--active]="conversation.userId === selectedUserId"
+              (click)="selectConversation(conversation.userId)"
+            >
+              <div class="conversation-item__header">
+                <span>{{ conversation.userName }} {{ conversation.userSurname }}</span>
+                <span>{{ formatTime(conversation.lastMessageAt) }}</span>
+              </div>
+              <p>{{ conversation.lastMessage }}</p>
+            </button>
+          }
+        </div>
       }
     </aside>
 

--- a/frontend/src/app/features/support/admin-support-page/admin-support-page.component.scss
+++ b/frontend/src/app/features/support/admin-support-page/admin-support-page.component.scss
@@ -1,0 +1,161 @@
+.support-admin-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: calc(100vh - 3rem);
+}
+
+.support-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.support-header p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.layout {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 0.75rem;
+}
+
+.conversations,
+.chat-panel {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+}
+
+.conversations {
+  min-height: 0;
+  overflow: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.conversations h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.conversation-item {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  background: #f9fafb;
+  padding: 0.55rem 0.6rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.conversation-item--active {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.conversation-item__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: #6b7280;
+}
+
+.conversation-item p {
+  margin: 0.35rem 0 0;
+  color: #111827;
+}
+
+.chat-panel {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.chat-title {
+  font-weight: 600;
+}
+
+.messages {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  max-width: 75%;
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: #f3f4f6;
+  align-self: flex-start;
+}
+
+.message--mine {
+  background: #dbeafe;
+  align-self: flex-end;
+}
+
+.message__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.message__content {
+  margin: 0.3rem 0 0;
+  white-space: pre-wrap;
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.composer textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.6rem;
+  resize: vertical;
+  padding: 0.65rem;
+  font: inherit;
+}
+
+.composer button {
+  align-self: flex-end;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #2563eb;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.composer button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.state-card {
+  border: 1px dashed #d1d5db;
+  border-radius: 0.6rem;
+  padding: 0.9rem;
+  color: #6b7280;
+}
+
+.error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}

--- a/frontend/src/app/features/support/admin-support-page/admin-support-page.component.scss
+++ b/frontend/src/app/features/support/admin-support-page/admin-support-page.component.scss
@@ -1,161 +1,346 @@
 .support-admin-page {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  height: calc(100vh - 3rem);
+  gap: 1.25rem;
+  flex: 1;
+  min-height: 0;
+  padding: 0 0.25rem 0 0;
 }
 
-.support-header h1 {
-  margin: 0;
-  font-size: 1.5rem;
-}
+.support-header {
+  flex-shrink: 0;
+  padding-top: 0.25rem;
 
-.support-header p {
-  margin: 0.25rem 0 0;
-  color: #6b7280;
+  h1 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--text-dark);
+    margin: 0;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    font-size: 0.9375rem;
+    color: var(--text-light);
+    font-weight: 400;
+  }
 }
 
 .layout {
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: 320px 1fr;
-  gap: 0.75rem;
-}
-
-.conversations,
-.chat-panel {
-  border: 1px solid #e5e7eb;
-  border-radius: 0.75rem;
-  background: #ffffff;
+  grid-template-columns: 280px 1fr;
+  gap: 1rem;
 }
 
 .conversations {
   min-height: 0;
-  overflow: auto;
-  padding: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .conversations h2 {
   margin: 0;
-  font-size: 1rem;
+  padding: 1rem 1.25rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-light);
+  background: var(--white);
+  border-bottom: 1px solid var(--border);
+}
+
+.conversations .state-card {
+  margin: 1rem 1.25rem;
+}
+
+.conversation-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.5rem 0.75rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
 }
 
 .conversation-item {
-  border: 1px solid #e5e7eb;
-  border-radius: 0.6rem;
-  background: #f9fafb;
-  padding: 0.55rem 0.6rem;
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
   text-align: left;
+  font-family: 'DM Sans', sans-serif;
+  background: var(--bg-warm);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.conversation-item:hover {
+  background: rgba(91, 76, 219, 0.04);
+  border-color: var(--border);
 }
 
 .conversation-item--active {
-  border-color: #2563eb;
-  background: #eff6ff;
+  background: rgba(91, 76, 219, 0.08);
+  border-color: rgba(91, 76, 219, 0.25);
 }
 
 .conversation-item__header {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: 0.5rem;
-  font-size: 0.78rem;
-  color: #6b7280;
+  margin-bottom: 0.35rem;
+}
+
+.conversation-item__header span:first-child {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-dark);
+}
+
+.conversation-item__header span:last-child {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-light);
+  flex-shrink: 0;
 }
 
 .conversation-item p {
-  margin: 0.35rem 0 0;
-  color: #111827;
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-medium);
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .chat-panel {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .chat-title {
+  flex-shrink: 0;
+  padding: 1rem 1.25rem;
+  font-family: 'Outfit', sans-serif;
+  font-size: 1rem;
   font-weight: 600;
+  color: var(--text-dark);
+  background: var(--white);
+  border-bottom: 1px solid var(--border);
+}
+
+.chat-panel .state-card {
+  margin: 1.25rem;
 }
 
 .messages {
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 1.25rem 1.25rem 1rem;
+  background: var(--bg-cream);
 }
 
 .message {
-  max-width: 75%;
-  border-radius: 0.75rem;
-  padding: 0.6rem 0.75rem;
-  background: #f3f4f6;
+  max-width: 78%;
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
   align-self: flex-start;
+  border: 1px solid var(--border);
+  background: var(--white);
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+    background: var(--primary);
+    opacity: 0.35;
+  }
 }
 
 .message--mine {
-  background: #dbeafe;
   align-self: flex-end;
+  background: rgba(91, 76, 219, 0.06);
+  border-color: rgba(91, 76, 219, 0.2);
+
+  &::before {
+    left: auto;
+    right: 0;
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    opacity: 0.5;
+  }
 }
 
 .message__meta {
   display: flex;
   justify-content: space-between;
-  gap: 0.6rem;
-  font-size: 0.75rem;
-  color: #6b7280;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.35rem;
+}
+
+.message__meta span:first-child {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-light);
+}
+
+.message--mine .message__meta span:first-child {
+  color: var(--primary);
+}
+
+.message__meta span:last-child {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: var(--text-light);
 }
 
 .message__content {
-  margin: 0.3rem 0 0;
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--text-dark);
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .composer {
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 1.25rem;
+  background: var(--white);
+  border-top: 1px solid var(--border);
 }
 
 .composer textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 0.6rem;
-  resize: vertical;
-  padding: 0.65rem;
-  font: inherit;
+  width: 100%;
+  min-height: 72px;
+  padding: 0.875rem 1rem;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.9375rem;
+  color: var(--text-dark);
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  resize: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &::placeholder {
+    color: var(--text-light);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(91, 76, 219, 0.08);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
 }
 
 .composer button {
   align-self: flex-end;
-  border: 0;
-  border-radius: 0.5rem;
-  background: #2563eb;
-  color: #fff;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.25rem;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--white);
+  background: var(--primary);
+  border: none;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-}
+  transition: background 0.2s ease;
 
-.composer button:disabled {
-  background: #9ca3af;
-  cursor: not-allowed;
+  &:hover:not(:disabled) {
+    background: var(--primary-dark);
+  }
+
+  &:disabled {
+    background: var(--text-light);
+    cursor: not-allowed;
+  }
 }
 
 .state-card {
-  border: 1px dashed #d1d5db;
-  border-radius: 0.6rem;
-  padding: 0.9rem;
-  color: #6b7280;
+  padding: 1.25rem;
+  font-size: 0.9375rem;
+  color: var(--text-light);
+  background: var(--bg-warm);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  text-align: center;
 }
 
 .error {
   margin: 0;
-  color: #b91c1c;
-  font-size: 0.9rem;
+  padding: 0 1.25rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--danger);
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    min-height: 400px;
+  }
+
+  .support-header h1 {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .message {
+    max-width: 92%;
+  }
+
+  .messages {
+    padding: 1rem;
+  }
+
+  .composer {
+    padding: 0.75rem 1rem 1rem;
+  }
+
+  .chat-title {
+    padding: 0.75rem 1rem;
+    font-size: 0.9375rem;
+  }
 }

--- a/frontend/src/app/features/support/admin-support-page/admin-support-page.component.ts
+++ b/frontend/src/app/features/support/admin-support-page/admin-support-page.component.ts
@@ -1,0 +1,220 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { finalize, timeout } from 'rxjs';
+import { AuthService } from '../../../shared/services/auth.service';
+import { SupportConversationSummary, SupportMessage } from '../models/support.model';
+import { SupportApiService } from '../services/support-api.service';
+
+@Component({
+  selector: 'app-admin-support-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './admin-support-page.component.html',
+  styleUrl: './admin-support-page.component.scss',
+})
+export class AdminSupportPageComponent implements OnInit, OnDestroy {
+  private readonly supportApi = inject(SupportApiService);
+  private readonly authService = inject(AuthService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private pollingTimer: ReturnType<typeof setInterval> | null = null;
+
+  conversations: SupportConversationSummary[] = [];
+  selectedUserId: number | null = null;
+  messages: SupportMessage[] = [];
+  draftMessage = '';
+
+  isLoadingConversations = true;
+  isLoadingMessages = false;
+  isSending = false;
+  errorMessage: string | null = null;
+
+  private readonly pollingIntervalMs = 2500;
+  private readonly requestTimeoutMs = 10000;
+  readonly currentUserId = this.authService.getUserId();
+
+  ngOnInit(): void {
+    this.loadConversations(true);
+    this.startPolling();
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  get selectedConversation(): SupportConversationSummary | null {
+    if (this.selectedUserId == null) {
+      return null;
+    }
+    return this.conversations.find((item) => item.userId === this.selectedUserId) ?? null;
+  }
+
+  selectConversation(userId: number): void {
+    if (this.selectedUserId === userId) {
+      return;
+    }
+    this.selectedUserId = userId;
+    this.loadMessages(true);
+  }
+
+  sendMessage(): void {
+    const content = this.draftMessage.trim();
+    if (!content || this.selectedUserId == null || this.isSending) {
+      return;
+    }
+
+    const optimisticId = -Date.now();
+    const selectedConv = this.selectedConversation;
+    const optimistic: SupportMessage = {
+      id: optimisticId,
+      senderId: this.currentUserId ?? 0,
+      senderName: '',
+      senderSurname: '',
+      receiverId: this.selectedUserId,
+      receiverName: selectedConv?.userName ?? '',
+      receiverSurname: selectedConv?.userSurname ?? '',
+      content,
+      createdAt: new Date().toISOString(),
+    };
+    this.messages = [...this.messages, optimistic];
+    this.draftMessage = '';
+    this.errorMessage = null;
+    this.isSending = true;
+
+    this.supportApi
+      .sendMessage(content, this.selectedUserId)
+      .pipe(
+        timeout(this.requestTimeoutMs),
+        finalize(() => {
+          this.isSending = false;
+        }),
+      )
+      .subscribe({
+        next: (createdMessage) => {
+          this.messages = [
+            ...this.messages.filter((m) => m.id !== optimisticId),
+            createdMessage,
+          ].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+          this.errorMessage = null;
+          this.loadConversations(false);
+        },
+        error: (error) => {
+          this.messages = this.messages.filter((m) => m.id !== optimisticId);
+          this.errorMessage = error?.error?.message || 'Unable to send support reply right now.';
+        },
+      });
+  }
+
+  isOwnMessage(message: SupportMessage): boolean {
+    return this.currentUserId != null && message.senderId === this.currentUserId;
+  }
+
+  formatTime(isoTime: string): string {
+    const date = new Date(isoTime);
+    return new Intl.DateTimeFormat('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: '2-digit',
+    }).format(date);
+  }
+
+  trackConversation(_: number, conversation: SupportConversationSummary): number {
+    return conversation.userId;
+  }
+
+  trackMessage(_: number, message: SupportMessage): number {
+    return message.id;
+  }
+
+  private startPolling(): void {
+    this.stopPolling();
+    this.pollingTimer = setInterval(() => {
+      this.loadConversations(false);
+      this.loadMessages(false);
+    }, this.pollingIntervalMs);
+  }
+
+  private stopPolling(): void {
+    if (this.pollingTimer) {
+      clearInterval(this.pollingTimer);
+      this.pollingTimer = null;
+    }
+  }
+
+  private loadConversations(showLoading: boolean): void {
+    if (showLoading) {
+      this.isLoadingConversations = true;
+    }
+
+    this.supportApi
+      .getConversations()
+      .pipe(
+        timeout(this.requestTimeoutMs),
+        finalize(() => {
+          this.isLoadingConversations = false;
+        }),
+      )
+      .subscribe({
+        next: (body) => {
+          const list = Array.isArray(body) ? body : [];
+          this.conversations = list;
+          this.isLoadingConversations = false;
+          this.errorMessage = null;
+
+          if (list.length === 0) {
+            this.selectedUserId = null;
+            this.messages = [];
+            this.cdr.markForCheck();
+            return;
+          }
+
+          const selectedStillExists =
+            this.selectedUserId != null &&
+            list.some((conversation) => conversation.userId === this.selectedUserId);
+          if (!selectedStillExists) {
+            this.selectedUserId = list[0].userId;
+            this.loadMessages(true);
+          }
+          this.cdr.markForCheck();
+        },
+        error: (error) => {
+          this.isLoadingConversations = false;
+          this.errorMessage = error?.error?.message || 'Unable to load support conversations.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private loadMessages(showLoading: boolean): void {
+    if (this.selectedUserId == null) {
+      return;
+    }
+    if (showLoading) {
+      this.isLoadingMessages = true;
+    }
+
+    this.supportApi
+      .getConversation(this.selectedUserId)
+      .pipe(
+        timeout(this.requestTimeoutMs),
+        finalize(() => {
+          this.isLoadingMessages = false;
+        }),
+      )
+      .subscribe({
+        next: (body) => {
+          const list = Array.isArray(body) ? body : [];
+          this.messages = list;
+          this.isLoadingMessages = false;
+          this.errorMessage = null;
+          this.cdr.markForCheck();
+        },
+        error: (error) => {
+          this.isLoadingMessages = false;
+          this.errorMessage = error?.error?.message || 'Unable to load selected conversation.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/frontend/src/app/features/support/models/support.model.ts
+++ b/frontend/src/app/features/support/models/support.model.ts
@@ -1,0 +1,21 @@
+export interface SupportMessage {
+  id: number;
+  senderId: number;
+  senderName: string;
+  senderSurname: string;
+  receiverId: number;
+  receiverName: string;
+  receiverSurname: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface SupportConversationSummary {
+  userId: number;
+  userName: string;
+  userSurname: string;
+  lastMessage: string;
+  lastMessageAt: string;
+  lastSenderId: number;
+  lastSenderRole: 'PASSENGER' | 'DRIVER' | 'ADMIN';
+}

--- a/frontend/src/app/features/support/services/support-api.service.ts
+++ b/frontend/src/app/features/support/services/support-api.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { SupportConversationSummary, SupportMessage } from '../models/support.model';
+
+@Injectable({ providedIn: 'root' })
+export class SupportApiService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = `${environment.apiBaseUrl}/support`;
+
+  getMyChat(): Observable<SupportMessage[]> {
+    return this.http.get<SupportMessage[]>(`${this.apiUrl}/my-chat`);
+  }
+
+  getConversations(): Observable<SupportConversationSummary[]> {
+    return this.http.get<SupportConversationSummary[]>(`${this.apiUrl}/conversations`);
+  }
+
+  getConversation(userId: number): Observable<SupportMessage[]> {
+    return this.http.get<SupportMessage[]>(`${this.apiUrl}/conversations/${userId}`);
+  }
+
+  sendMessage(content: string, receiverId?: number | null): Observable<SupportMessage> {
+    return this.http.post<SupportMessage>(`${this.apiUrl}/messages`, {
+      receiverId: receiverId ?? null,
+      content,
+    });
+  }
+}

--- a/frontend/src/app/features/support/support-page/support-page.component.html
+++ b/frontend/src/app/features/support/support-page/support-page.component.html
@@ -1,0 +1,50 @@
+<section class="support-page">
+  <header class="support-header">
+    <h1>Support</h1>
+    <p>Chat with our admin support team.</p>
+  </header>
+
+  <div class="chat-shell">
+    @if (isLoading && messages.length === 0) {
+      <div class="state-card">Loading support chat...</div>
+    }
+
+    <div class="messages">
+      @if (!isLoading && messages.length === 0) {
+        <div class="state-card">No messages yet. Start the conversation with support.</div>
+      }
+
+      @for (message of messages; track trackMessage($index, message)) {
+        <article class="message" [class.message--mine]="isOwnMessage(message)">
+          <div class="message__meta">
+            <span class="message__author">
+              @if (isOwnMessage(message)) {
+                {{ message.senderName }} {{ message.senderSurname }}
+              } @else {
+                Support
+              }
+            </span>
+            <span class="message__time">{{ formatTime(message.createdAt) }}</span>
+          </div>
+          <p class="message__content">{{ message.content }}</p>
+        </article>
+      }
+    </div>
+
+    <div class="composer">
+      <textarea
+        [(ngModel)]="draftMessage"
+        rows="3"
+        [disabled]="isSending"
+        placeholder="Type your message for support..."
+      ></textarea>
+      <button type="button" [disabled]="isSending || !draftMessage.trim()" (click)="sendMessage()">
+        {{ isSending ? 'Sending...' : 'Send' }}
+      </button>
+    </div>
+
+    @if (errorMessage) {
+      <p class="error">{{ errorMessage }}</p>
+    }
+  </div>
+</section>

--- a/frontend/src/app/features/support/support-page/support-page.component.html
+++ b/frontend/src/app/features/support/support-page/support-page.component.html
@@ -1,10 +1,11 @@
 <section class="support-page">
-  <header class="support-header">
-    <h1>Support</h1>
-    <p>Chat with our admin support team.</p>
-  </header>
+  <div class="support-page__inner">
+    <header class="support-header">
+      <h1>Support</h1>
+      <p>Chat with our admin support team.</p>
+    </header>
 
-  <div class="chat-shell">
+    <div class="chat-shell">
     @if (isLoading && messages.length === 0) {
       <div class="state-card">Loading support chat...</div>
     }
@@ -46,5 +47,6 @@
     @if (errorMessage) {
       <p class="error">{{ errorMessage }}</p>
     }
+  </div>
   </div>
 </section>

--- a/frontend/src/app/features/support/support-page/support-page.component.scss
+++ b/frontend/src/app/features/support/support-page/support-page.component.scss
@@ -1,0 +1,105 @@
+.support-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: calc(100vh - 3rem);
+}
+
+.support-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.support-header p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.chat-shell {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  gap: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  padding: 0.75rem;
+}
+
+.messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  max-width: 75%;
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: #f3f4f6;
+  align-self: flex-start;
+}
+
+.message--mine {
+  background: #dbeafe;
+  align-self: flex-end;
+}
+
+.message__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.message__content {
+  margin: 0.3rem 0 0;
+  white-space: pre-wrap;
+}
+
+.composer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.composer textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.6rem;
+  resize: vertical;
+  padding: 0.65rem;
+  font: inherit;
+}
+
+.composer button {
+  align-self: flex-end;
+  border: 0;
+  border-radius: 0.5rem;
+  background: #2563eb;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.composer button:disabled {
+  background: #9ca3af;
+  cursor: not-allowed;
+}
+
+.state-card {
+  border: 1px dashed #d1d5db;
+  border-radius: 0.6rem;
+  padding: 0.9rem;
+  color: #6b7280;
+}
+
+.error {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.9rem;
+}

--- a/frontend/src/app/features/support/support-page/support-page.component.scss
+++ b/frontend/src/app/features/support/support-page/support-page.component.scss
@@ -1,30 +1,79 @@
 .support-page {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  height: calc(100vh - 3rem);
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  padding: 0 0.5rem;
+  box-sizing: border-box;
 }
 
-.support-header h1 {
-  margin: 0;
-  font-size: 1.5rem;
+.support-page__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  max-width: 720px;
+  width: 100%;
+  max-height: min(calc(100vh - 4rem), 800px);
+  min-height: 0;
 }
 
-.support-header p {
-  margin: 0.25rem 0 0;
-  color: #6b7280;
+.support-header {
+  flex-shrink: 0;
+  padding-top: 0.25rem;
+
+  h1 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--text-dark);
+    margin: 0;
+    letter-spacing: -0.02em;
+  }
+
+  p {
+    margin: 0.35rem 0 0;
+    font-size: 0.9375rem;
+    color: var(--text-light);
+    font-weight: 400;
+  }
+}
+
+@media (max-width: 600px) {
+  .support-header h1 {
+    font-size: 1.5rem;
+  }
+
+  .support-page__inner {
+    max-height: min(calc(100vh - 3rem), 90vh);
+  }
+
+  .message {
+    max-width: 92%;
+  }
+
+  .messages {
+    padding: 1rem;
+  }
+
+  .composer {
+    padding: 0.75rem 1rem 1rem;
+  }
 }
 
 .chat-shell {
-  display: flex;
   flex: 1;
-  flex-direction: column;
   min-height: 0;
-  gap: 0.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.75rem;
-  background: #ffffff;
-  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  background: var(--white);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .messages {
@@ -33,73 +82,157 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 1.25rem 1.25rem 1rem;
+  background: var(--bg-cream);
 }
 
 .message {
-  max-width: 75%;
-  border-radius: 0.75rem;
-  padding: 0.6rem 0.75rem;
-  background: #f3f4f6;
+  max-width: 82%;
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
   align-self: flex-start;
+  border: 1px solid var(--border);
+  background: var(--white);
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    border-radius: var(--radius-md) 0 0 var(--radius-md);
+    background: var(--primary);
+    opacity: 0.35;
+  }
 }
 
 .message--mine {
-  background: #dbeafe;
   align-self: flex-end;
+  background: rgba(91, 76, 219, 0.06);
+  border-color: rgba(91, 76, 219, 0.2);
+
+  &::before {
+    left: auto;
+    right: 0;
+    border-radius: 0 var(--radius-md) var(--radius-md) 0;
+    opacity: 0.5;
+  }
 }
 
 .message__meta {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   gap: 0.75rem;
-  font-size: 0.75rem;
-  color: #6b7280;
+  margin-bottom: 0.35rem;
+}
+
+.message__author {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-light);
+}
+
+.message--mine .message__author {
+  color: var(--primary);
+}
+
+.message__time {
+  font-size: 0.6875rem;
+  color: var(--text-light);
+  font-weight: 500;
 }
 
 .message__content {
-  margin: 0.3rem 0 0;
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--text-dark);
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .composer {
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 1.25rem;
+  background: var(--white);
+  border-top: 1px solid var(--border);
 }
 
 .composer textarea {
-  border: 1px solid #d1d5db;
-  border-radius: 0.6rem;
-  resize: vertical;
-  padding: 0.65rem;
-  font: inherit;
+  width: 100%;
+  min-height: 72px;
+  padding: 0.875rem 1rem;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.9375rem;
+  color: var(--text-dark);
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  resize: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &::placeholder {
+    color: var(--text-light);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(91, 76, 219, 0.08);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
 }
 
 .composer button {
   align-self: flex-end;
-  border: 0;
-  border-radius: 0.5rem;
-  background: #2563eb;
-  color: #fff;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.25rem;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--white);
+  background: var(--primary);
+  border: none;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-}
+  transition: background 0.2s ease;
 
-.composer button:disabled {
-  background: #9ca3af;
-  cursor: not-allowed;
+  &:hover:not(:disabled) {
+    background: var(--primary-dark);
+  }
+
+  &:disabled {
+    background: var(--text-light);
+    cursor: not-allowed;
+  }
 }
 
 .state-card {
-  border: 1px dashed #d1d5db;
-  border-radius: 0.6rem;
-  padding: 0.9rem;
-  color: #6b7280;
+  padding: 1.25rem 1.25rem;
+  font-size: 0.9375rem;
+  color: var(--text-light);
+  background: var(--bg-warm);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  text-align: center;
 }
 
 .error {
   margin: 0;
-  color: #b91c1c;
-  font-size: 0.9rem;
+  padding: 0 1.25rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--danger);
 }

--- a/frontend/src/app/features/support/support-page/support-page.component.ts
+++ b/frontend/src/app/features/support/support-page/support-page.component.ts
@@ -1,0 +1,145 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { finalize, timeout } from 'rxjs';
+import { AuthService } from '../../../shared/services/auth.service';
+import { SupportMessage } from '../models/support.model';
+import { SupportApiService } from '../services/support-api.service';
+
+@Component({
+  selector: 'app-support-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './support-page.component.html',
+  styleUrl: './support-page.component.scss',
+})
+export class SupportPageComponent implements OnInit, OnDestroy {
+  private readonly supportApi = inject(SupportApiService);
+  private readonly authService = inject(AuthService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private pollingTimer: ReturnType<typeof setInterval> | null = null;
+
+  messages: SupportMessage[] = [];
+  draftMessage = '';
+  isLoading = true;
+  isSending = false;
+  errorMessage: string | null = null;
+
+  private readonly pollingIntervalMs = 2500;
+  private readonly requestTimeoutMs = 10000;
+  readonly currentUserId = this.authService.getUserId();
+
+  ngOnInit(): void {
+    this.loadMessages(true);
+    this.startPolling();
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  sendMessage(): void {
+    const content = this.draftMessage.trim();
+    if (!content || this.isSending) {
+      return;
+    }
+
+    const optimisticId = -Date.now();
+    const optimistic: SupportMessage = {
+      id: optimisticId,
+      senderId: this.currentUserId ?? 0,
+      senderName: '',
+      senderSurname: '',
+      receiverId: 0,
+      receiverName: '',
+      receiverSurname: '',
+      content,
+      createdAt: new Date().toISOString(),
+    };
+    this.messages = [...this.messages, optimistic];
+    this.draftMessage = '';
+    this.errorMessage = null;
+    this.isSending = true;
+
+    this.supportApi
+      .sendMessage(content)
+      .pipe(
+        timeout(this.requestTimeoutMs),
+        finalize(() => {
+          this.isSending = false;
+        }),
+      )
+      .subscribe({
+        next: (createdMessage) => {
+          this.messages = [
+            ...this.messages.filter((m) => m.id !== optimisticId),
+            createdMessage,
+          ].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+          this.errorMessage = null;
+        },
+        error: (error) => {
+          this.messages = this.messages.filter((m) => m.id !== optimisticId);
+          this.errorMessage = error?.error?.message || 'Unable to send support message right now.';
+        },
+      });
+  }
+
+  isOwnMessage(message: SupportMessage): boolean {
+    return this.currentUserId != null && message.senderId === this.currentUserId;
+  }
+
+  formatTime(isoTime: string): string {
+    const date = new Date(isoTime);
+    return new Intl.DateTimeFormat('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: '2-digit',
+    }).format(date);
+  }
+
+  trackMessage(_: number, message: SupportMessage): number {
+    return message.id;
+  }
+
+  private startPolling(): void {
+    this.stopPolling();
+    this.pollingTimer = setInterval(() => this.loadMessages(false), this.pollingIntervalMs);
+  }
+
+  private stopPolling(): void {
+    if (this.pollingTimer) {
+      clearInterval(this.pollingTimer);
+      this.pollingTimer = null;
+    }
+  }
+
+  private loadMessages(showLoading: boolean): void {
+    if (showLoading) {
+      this.isLoading = true;
+    }
+
+    this.supportApi
+      .getMyChat()
+      .pipe(
+        timeout(this.requestTimeoutMs),
+        finalize(() => {
+          this.isLoading = false;
+        }),
+      )
+      .subscribe({
+        next: (body) => {
+          const list = Array.isArray(body) ? body : [];
+          this.messages = list;
+          this.isLoading = false;
+          this.errorMessage = null;
+          this.cdr.markForCheck();
+        },
+        error: (error) => {
+          this.isLoading = false;
+          this.errorMessage = error?.error?.message || 'Unable to load support messages.';
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/frontend/src/app/layout/config/navbar.config.ts
+++ b/frontend/src/app/layout/config/navbar.config.ts
@@ -21,7 +21,7 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Ride History', icon: 'file-text', path: '/ride-history', section: 'main' },
 
     // Account Section
-    { label: 'Support', icon: 'message-circle', path: '/support', section: 'account', disabled: true },
+    { label: 'Support', icon: 'message-circle', path: '/support', section: 'account' },
   ],
 
   driver: [
@@ -30,7 +30,7 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Ride History', icon: 'file-text', path: '/driver/ride-history', section: 'main' },
 
     // Account Section
-    { label: 'Support', icon: 'message-circle', path: '/support', section: 'account', disabled: true },
+    { label: 'Support', icon: 'message-circle', path: '/support', section: 'account' },
   ],
 
   admin: [
@@ -41,7 +41,7 @@ export const NAVIGATION_CONFIG: NavigationConfig = {
     { label: 'Active Rides', icon: 'map-pin', path: '/admin/active-rides', section: 'monitoring', disabled: true },
     { label: 'Ride History', icon: 'file-text', path: '/admin/ride-history', section: 'monitoring' },
     { label: 'Panic Notifications', icon: 'alert-triangle', path: '/admin/panic', section: 'monitoring', disabled: true },
-    { label: 'Live Support / Chat', icon: 'message-circle', path: '/admin/support', section: 'monitoring', disabled: true },
+    { label: 'Live Support / Chat', icon: 'message-circle', path: '/admin/support', section: 'monitoring' },
 
     // Management Section
     { label: 'Register Driver', icon: 'truck', path: '/register-driver', section: 'management' },

--- a/frontend/src/app/layout/layout.component.scss
+++ b/frontend/src/app/layout/layout.component.scss
@@ -5,4 +5,14 @@
 .main-content {
   margin-left: 260px;
   min-height: 100vh;
+  padding: 1.5rem 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  box-sizing: border-box;
+
+  @media (max-width: 900px) {
+    margin-left: 0;
+    padding: 1rem;
+  }
 }


### PR DESCRIPTION
This pull request introduces a complete backend and frontend implementation for a live support chat feature between users (passengers/drivers) and admins. It adds new endpoints, security rules, data models, and frontend pages to enable and manage support conversations.

**Backend (Java Spring) changes:**

*Support messaging endpoints and logic:*

- Added new endpoints to `MessageController` for creating support messages, retrieving user-specific chats, and allowing admins to view and reply to all support conversations. Role-based access is enforced for each endpoint.
- Enhanced `MessageService` to support conversation threading, admin and user flows, and summary retrieval for admin dashboards. This includes new methods for creating messages based on user roles, fetching conversation summaries, and validating participants. [[1]](diffhunk://#diff-34167f887e61d423e1ecf6eadf91339841a48f2d8cda5a8226fc4f8046519c4fL24-R101) [[2]](diffhunk://#diff-34167f887e61d423e1ecf6eadf91339841a48f2d8cda5a8226fc4f8046519c4fR113-R140)
- Introduced `SupportConversationSummaryResponse` DTO to represent summarized conversation data for admin views.

*Repository and validation changes:*

- Added custom queries in `MessageRepository` to efficiently fetch support threads and all admin-related messages.
- Extended `UserRepository` to allow finding the first admin user, used for routing support messages.
- Updated `SupportMessageCreateRequest` to make `receiverId` optional for non-admins, as admins are auto-assigned as receivers for user-initiated support messages.

*Email sending robustness:*

- Modified `EmailService` to ensure email delivery failures do not break business logic; errors are logged as warnings and the method returns a boolean instead of throwing exceptions. [[1]](diffhunk://#diff-0ce30b3e9b3141f52946442dc6dbe9d24d674699ad5267918c21c430411791afL27-R25) [[2]](diffhunk://#diff-0ce30b3e9b3141f52946442dc6dbe9d24d674699ad5267918c21c430411791afR37-R42)

**Frontend (Angular) changes:**

*Support chat user experience:*

- Added `SupportPageComponent` for users and `AdminSupportPageComponent` for admins, with dedicated routes and role guards. These components provide real-time chat UIs and conversation management for support. [[1]](diffhunk://#diff-68288cf867d196c535d1178cbdf7f8f821776fe9b541b18e6fa66528ef8a38b8R126-L130) [[2]](diffhunk://#diff-68288cf867d196c535d1178cbdf7f8f821776fe9b541b18e6fa66528ef8a38b8L187-L190) [[3]](diffhunk://#diff-4774a5b8edf4f0f6827a8e8f62081391ee2a09c09dd7a155621aa47ccc5758e4R1-R77)
- Updated the ride tracking flow to allow users to navigate directly to the support chat from the panic modal.

---

**Most important changes:**

**Backend: Support messaging features**
- Added endpoints and service logic for support chat between users and admins, including conversation threading, role-based access, and admin dashboard summaries in `MessageController` and `MessageService`. [[1]](diffhunk://#diff-40d9f6265cdcb147ba909fb7fff4cc37f2b2b248d7625bc09d4be7260d838ae8R30-R77) [[2]](diffhunk://#diff-34167f887e61d423e1ecf6eadf91339841a48f2d8cda5a8226fc4f8046519c4fL24-R101) [[3]](diffhunk://#diff-34167f887e61d423e1ecf6eadf91339841a48f2d8cda5a8226fc4f8046519c4fR113-R140)
- Introduced `SupportConversationSummaryResponse` DTO for admin support conversation summaries.

**Backend: Data access and validation**
- Implemented custom queries in `MessageRepository` and a helper in `UserRepository` to efficiently fetch support threads and route messages. [[1]](diffhunk://#diff-42032ecba9d154e3f0c2ab72599a8a3bbc05406c36290b46f95254ca4035d5e2R20-R46) [[2]](diffhunk://#diff-37f64eb7c87af641783c7329e6be971e261b1ddb1369dfde5244eb1e40c81095R14)
- Updated `SupportMessageCreateRequest` to make `receiverId` optional for non-admins.

**Backend: Email service robustness**
- Made email sending non-blocking for business flows, logging failures as warnings instead of throwing exceptions in `EmailService`. [[1]](diffhunk://#diff-0ce30b3e9b3141f52946442dc6dbe9d24d674699ad5267918c21c430411791afL27-R25) [[2]](diffhunk://#diff-0ce30b3e9b3141f52946442dc6dbe9d24d674699ad5267918c21c430411791afR37-R42)

**Frontend: Support chat UI**
- Added user and admin support chat pages with real-time conversation and message UIs, and updated routes and guards for access control. [[1]](diffhunk://#diff-68288cf867d196c535d1178cbdf7f8f821776fe9b541b18e6fa66528ef8a38b8R126-L130) [[2]](diffhunk://#diff-68288cf867d196c535d1178cbdf7f8f821776fe9b541b18e6fa66528ef8a38b8L187-L190) [[3]](diffhunk://#diff-4774a5b8edf4f0f6827a8e8f62081391ee2a09c09dd7a155621aa47ccc5758e4R1-R77)

**Frontend: Ride tracking integration**
- Enabled direct navigation from the panic modal to the support chat for immediate assistance.