### PR TITLE
[FE 59] Sandwich navbar for small screens

### DIFF
--- a/frontend/src/app/layout/components/navbar/navbar.component.html
+++ b/frontend/src/app/layout/components/navbar/navbar.component.html
@@ -1,4 +1,30 @@
+<!-- Desktop: fixed sidebar (hidden on small screens via CSS) -->
 <aside class="sidebar">
+  <ng-container *ngTemplateOutlet="sidebarContent" />
+</aside>
+
+<!-- Mobile: floating hamburger, top-left -->
+<button
+  type="button"
+  class="hamburger"
+  (click)="toggleDrawer()"
+  [attr.aria-expanded]="drawerOpen"
+  aria-label="Open menu"
+>
+  <span class="hamburger-line"></span>
+  <span class="hamburger-line"></span>
+  <span class="hamburger-line"></span>
+</button>
+
+<!-- Mobile: drawer overlay + panel (same content as sidebar) -->
+@if (drawerOpen) {
+  <div class="drawer-backdrop" (click)="closeDrawer()" aria-hidden="true"></div>
+  <div class="drawer-panel" role="dialog" aria-label="Navigation menu">
+    <ng-container *ngTemplateOutlet="sidebarContent" />
+  </div>
+}
+
+<ng-template #sidebarContent>
   <div class="sidebar-scroll">
     <!-- Logo -->
     <a routerLink="/" class="logo" aria-label="Drumigo Home">
@@ -68,4 +94,4 @@
       Log out
     </button>
   </div>
-</aside>
+</ng-template>

--- a/frontend/src/app/layout/components/navbar/navbar.component.scss
+++ b/frontend/src/app/layout/components/navbar/navbar.component.scss
@@ -1,5 +1,8 @@
+$sidebar-width: 260px;
+$breakpoint-mobile: 900px;
+
 .sidebar {
-  width: 260px;
+  width: $sidebar-width;
   background: var(--white);
   border-right: 1px solid var(--border);
   padding: 24px 16px;
@@ -10,6 +13,92 @@
   left: 0;
   height: 100vh;
   z-index: 1000;
+
+  @media (max-width: $breakpoint-mobile) {
+    display: none;
+  }
+}
+
+/* Floating hamburger: visible only on small screens */
+.hamburger {
+  display: none;
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 1002;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.35);
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  transition: background 0.2s;
+  backdrop-filter: blur(4px);
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.55);
+  }
+
+  @media (max-width: $breakpoint-mobile) {
+    display: flex;
+  }
+}
+
+.hamburger-line {
+  width: 20px;
+  height: 2px;
+  background: var(--text-dark);
+  border-radius: 1px;
+}
+
+/* Drawer overlay and panel (mobile) */
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1001;
+  background: rgba(0, 0, 0, 0.4);
+  animation: drawerBackdropIn 0.2s ease-out;
+}
+
+.drawer-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: $sidebar-width;
+  height: 100vh;
+  z-index: 1002;
+  background: var(--white);
+  border-right: 1px solid var(--border);
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.15);
+  animation: drawerPanelIn 0.25s ease-out;
+}
+
+@keyframes drawerBackdropIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes drawerPanelIn {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }
 
 .sidebar-scroll {

--- a/frontend/src/app/layout/components/navbar/navbar.component.ts
+++ b/frontend/src/app/layout/components/navbar/navbar.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, inject, effect } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { Router, RouterLink, RouterLinkActive } from '@angular/router';
+import { Component, OnInit, OnDestroy, inject, effect } from '@angular/core';
+import { CommonModule, NgTemplateOutlet } from '@angular/common';
+import { Router, RouterLink, RouterLinkActive, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
 import { NAVIGATION_CONFIG, SECTION_LABELS, NavItem } from '../../config/navbar.config';
 import { AuthService } from '../../../shared/services/auth.service';
 import { CurrentUserService } from '../../services/current-user.service';
@@ -18,11 +19,11 @@ export interface UserProfile {
 @Component({
   selector: 'app-navbar',
   standalone: true,
-  imports: [CommonModule, RouterLink, RouterLinkActive],
+  imports: [CommonModule, RouterLink, RouterLinkActive, NgTemplateOutlet],
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
 })
-export class NavbarComponent implements OnInit {
+export class NavbarComponent implements OnInit, OnDestroy {
   private readonly authService = inject(AuthService);
   private readonly router = inject(Router);
   readonly currentUserService = inject(CurrentUserService);
@@ -31,15 +32,38 @@ export class NavbarComponent implements OnInit {
   groupedNavItems: Map<string, NavItem[]> = new Map();
   sectionLabels = SECTION_LABELS;
 
+  /** Drawer open state for mobile menu (hamburger). */
+  drawerOpen = false;
+
+  private readonly boundEscape = (e: KeyboardEvent) => {
+    if (e.key === 'Escape' && this.drawerOpen) this.closeDrawer();
+  };
+
   constructor() {
     effect(() => {
       this.currentUserService.user();
       this.applyUserType();
     });
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(() => this.closeDrawer());
   }
 
   ngOnInit(): void {
     this.applyUserType();
+    window.addEventListener('keydown', this.boundEscape);
+  }
+
+  ngOnDestroy(): void {
+    window.removeEventListener('keydown', this.boundEscape);
+  }
+
+  toggleDrawer(): void {
+    this.drawerOpen = !this.drawerOpen;
+  }
+
+  closeDrawer(): void {
+    this.drawerOpen = false;
   }
 
   private applyUserType(): void {


### PR DESCRIPTION
This pull request implements a responsive navigation sidebar for both desktop and mobile devices. The sidebar is now always visible on desktop, while on mobile devices, a floating hamburger button toggles a slide-in drawer menu. The implementation includes accessibility improvements and ensures the menu closes on navigation or Escape key press.

**Responsive navigation and mobile drawer:**

* Refactored `navbar.component.html` to render the sidebar as a fixed element on desktop, and as a drawer panel with a floating hamburger button on mobile; sidebar content is shared via an Angular template (`sidebarContent`). [[1]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbR1-R27) [[2]](diffhunk://#diff-5a23bdba2bcf6c2b415670fcb122e0a2a311a771924ea9767c057eac09f236dbL71-R97)
* Added SCSS styles for responsive behavior: sidebar is hidden on mobile, hamburger button appears only on mobile, and drawer panel/backdrop are styled and animated for mobile. [[1]](diffhunk://#diff-15e8bbef34846b265cc891b1742d95aae7758b1cccbd952f83db0036585342adR1-R5) [[2]](diffhunk://#diff-15e8bbef34846b265cc891b1742d95aae7758b1cccbd952f83db0036585342adR16-R101)

**Component logic and accessibility:**

* Updated `NavbarComponent` to manage drawer open state, handle hamburger button actions, close the drawer on navigation or Escape key, and clean up event listeners on destroy. Also added necessary Angular imports for template outlet. [[1]](diffhunk://#diff-119c7a8fdee7ee8af29f9521b5848c2418ca921b376855e4f9318f25f6eb35afL1-R4) [[2]](diffhunk://#diff-119c7a8fdee7ee8af29f9521b5848c2418ca921b376855e4f9318f25f6eb35afL21-R26) [[3]](diffhunk://#diff-119c7a8fdee7ee8af29f9521b5848c2418ca921b376855e4f9318f25f6eb35afR35-R66)