### PR TITLE
[MOB 25] feat: add shake gesture to toggle ride history sorting

### DIFF
--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
@@ -1,6 +1,10 @@
 package com.drumigo.mobile.ui.history;
 
 import android.app.DatePickerDialog;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
@@ -56,6 +60,8 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
     private static final int DEFAULT_PAGE = 0;
     private static final int DEFAULT_PAGE_SIZE = 100;
     private static final String DEFAULT_SORT = "requestedAt,desc";
+    private static final float SHAKE_THRESHOLD_GRAVITY = 2.3F;
+    private static final long SHAKE_SLOP_TIME_MS = 800L;
 
     private RecyclerView recyclerView;
     private RideHistoryAdapter adapter;
@@ -73,6 +79,10 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
     private PassengerApiService passengerApiService;
     private AdminApiService adminApiService;
     private SessionManager sessionManager;
+    private SensorManager sensorManager;
+    private Sensor accelerometer;
+    private long lastShakeAtMs = 0L;
+    private boolean shakeSortDescending = true;
 
     private String currentRole = ROLE_DRIVER;
     private final List<Ride> fetchedRides = new ArrayList<>();
@@ -85,6 +95,33 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
         AMOUNT_ASC,
         STATUS_ASC
     }
+
+    private final SensorEventListener shakeListener = new SensorEventListener() {
+        @Override
+        public void onSensorChanged(SensorEvent event) {
+            if (event == null || event.values == null || event.values.length < 3) {
+                return;
+            }
+            float gX = event.values[0] / SensorManager.GRAVITY_EARTH;
+            float gY = event.values[1] / SensorManager.GRAVITY_EARTH;
+            float gZ = event.values[2] / SensorManager.GRAVITY_EARTH;
+            float gForce = (float) Math.sqrt(gX * gX + gY * gY + gZ * gZ);
+            if (gForce < SHAKE_THRESHOLD_GRAVITY) {
+                return;
+            }
+
+            long now = System.currentTimeMillis();
+            if (now - lastShakeAtMs < SHAKE_SLOP_TIME_MS) {
+                return;
+            }
+            lastShakeAtMs = now;
+            toggleDateSortByShake();
+        }
+
+        @Override
+        public void onAccuracyChanged(Sensor sensor, int accuracy) {
+        }
+    };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -110,6 +147,11 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
                 return;
             }
 
+            sensorManager = (SensorManager) getSystemService(SENSOR_SERVICE);
+            if (sensorManager != null) {
+                accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
+            }
+
             currentRole = resolveCurrentRole();
             driverApiService = ApiClient.getDriverApiService();
             passengerApiService = ApiClient.getPassengerApiService();
@@ -120,6 +162,26 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
             Log.e(TAG, "Error while opening ride history", e);
             Toast.makeText(this, "Unable to open ride history", Toast.LENGTH_LONG).show();
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (sensorManager != null && accelerometer != null) {
+            sensorManager.registerListener(
+                shakeListener,
+                accelerometer,
+                SensorManager.SENSOR_DELAY_UI
+            );
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        if (sensorManager != null) {
+            sensorManager.unregisterListener(shakeListener);
+        }
+        super.onPause();
     }
 
     private void setupToolbar() {
@@ -466,6 +528,20 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
         if (resultsCountText != null) {
             resultsCountText.setText(getString(R.string.ride_history_results_count, sorted.size()));
         }
+    }
+
+    private void toggleDateSortByShake() {
+        shakeSortDescending = !shakeSortDescending;
+        selectedSort = shakeSortDescending ? SortOption.NEWEST_FIRST : SortOption.OLDEST_FIRST;
+        if (sortSpinner != null) {
+            sortSpinner.setSelection(shakeSortDescending ? 0 : 1);
+        }
+        renderSortedResults();
+        Toast.makeText(
+            this,
+            shakeSortDescending ? getString(R.string.ride_history_sort_newest) : getString(R.string.ride_history_sort_oldest),
+            Toast.LENGTH_SHORT
+        ).show();
     }
 
     private Comparator<Ride> buildComparator(SortOption option) {


### PR DESCRIPTION
Closes #245 

This pull request introduces a new feature to the `RideHistoryActivity` that allows users to toggle the ride history date sort order by shaking their device. The implementation uses the device's accelerometer to detect shake gestures and updates the sort order accordingly. The most important changes are grouped below:

**Shake-to-Sort Feature Implementation:**

* Added accelerometer sensor management and a `SensorEventListener` (`shakeListener`) to detect shake gestures in `RideHistoryActivity`. When a shake is detected above a gravity threshold, the sort order for ride history is toggled. [[1]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R4-R7) [[2]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R82-R85) [[3]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R99-R125)
* Registered and unregistered the shake listener in the activity lifecycle (`onResume` and `onPause`) to ensure proper sensor usage. [[1]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R150-R154) [[2]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R167-R186)

**Sort Order Toggle Logic:**

* Added the `toggleDateSortByShake()` method, which flips the sort order between newest and oldest, updates the UI spinner, refreshes the results, and displays a toast notification to the user. [[1]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R63-R64) [[2]](diffhunk://#diff-a055ae25f3afd06e9d0c996def2b635dcb790b8eb4134bef03628e22c3df19e2R533-R546)