### PR TITLE
[MOB 13] Ride tracking

### DIFF
--- a/drumigo/src/main/java/com/ftn/drumigo/controller/RideController.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/controller/RideController.java
@@ -11,6 +11,7 @@ import com.ftn.drumigo.dto.ReviewResponse;
 import com.ftn.drumigo.dto.ActiveRideIdResponse;
 import com.ftn.drumigo.dto.RideCreateRequest;
 import com.ftn.drumigo.dto.RideDetailsResponse;
+import com.ftn.drumigo.dto.VehicleLocationUpdateRequest;
 import com.ftn.drumigo.dto.RideInconsistencyCreateRequest;
 import com.ftn.drumigo.dto.RideInconsistencyResponse;
 import com.ftn.drumigo.dto.RideTrackingResponse;
@@ -144,6 +145,20 @@ public class RideController {
      * Start simulated vehicle movement for this ride (demo/E2E).
      * Ride must be ACTIVE with driver and at least 2 waypoints.
      */
+    /**
+     * Sync the displayed (e.g. capped) vehicle position back to the backend so backend and client stay aligned.
+     * Allowed for the ride's driver or any passenger. Call after computing display position so next poll returns it.
+     */
+    @PutMapping("/{id}/tracking-position")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<Void> updateTrackingPosition(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody VehicleLocationUpdateRequest request) {
+        rideService.updateTrackingPosition(id, userDetails.getUserId(), userDetails.getRole(), request);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/{id}/tracking-demo/start")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> startTrackingDemo(@PathVariable Long id) {

--- a/drumigo/src/main/java/com/ftn/drumigo/service/FavoriteRouteService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/FavoriteRouteService.java
@@ -22,7 +22,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -80,11 +83,24 @@ public class FavoriteRouteService {
         return favoriteRoute;
     }
     
+    /**
+     * Returns favorite routes for the passenger, at most one per source ride (by sourceRideId).
+     * Duplicates from the same starred ride are collapsed to a single entry (keeps latest by id).
+     */
     public List<FavoriteRoute> getByPassenger(Long passengerId) {
         Passenger passenger = passengerRepository.findById(passengerId)
             .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with id: " + passengerId));
-        
-        return favoriteRouteRepository.findByPassenger(passenger);
+
+        List<FavoriteRoute> all = favoriteRouteRepository.findByPassenger(passenger);
+        Map<Long, FavoriteRoute> uniqueBySourceRide = all.stream()
+            .collect(Collectors.toMap(
+                fr -> fr.getSourceRideId() != null ? fr.getSourceRideId() : -fr.getId(),
+                fr -> fr,
+                (a, b) -> a.getId() > b.getId() ? a : b
+            ));
+        return uniqueBySourceRide.values().stream()
+            .sorted(Comparator.comparing(FavoriteRoute::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())).reversed())
+            .collect(Collectors.toList());
     }
     
     public void delete(Long favoriteRouteId) {

--- a/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
@@ -57,7 +57,7 @@ public class RideService {
     private final MapService mapService;
     private final AssignmentNotificationService assignmentNotificationService;
     private static final String NO_ACTIVE_DRIVERS_MESSAGE = "There are currently no active drivers.";
-    private static final long TEN_MINUTES_IN_SECONDS = Duration.ofMinutes(10).getSeconds();
+    private static final String NO_AVAILABLE_DRIVERS_MESSAGE = "No drivers available. All drivers are currently busy.";
     private static final long DEFAULT_RIDE_DURATION_SECONDS = Duration.ofMinutes(15).getSeconds();
     private static final List<RideStatus> ASSIGNMENT_BLOCKING_STATUSES = List.of(RideStatus.ACTIVE, RideStatus.ACCEPTED);
 
@@ -585,6 +585,10 @@ public class RideService {
         return DriverAssignmentResult.assigned(reservedDriver);
     }
 
+    /**
+     * Assign a driver for an immediate ride. Only drivers who are not currently on a ride
+     * (inactive / free) are considered. If none are available, returns a clear "no drivers available" message.
+     */
     private DriverAssignmentResult assignImmediateRideDriver(List<DriverAssignmentCandidate> eligibleCandidates) {
         List<DriverAssignmentCandidate> freeCandidates = eligibleCandidates.stream()
             .filter(candidate -> !candidate.currentlyOccupied())
@@ -602,33 +606,7 @@ public class RideService {
             return DriverAssignmentResult.assigned(nearestFreeDriver);
         }
 
-        if (eligibleCandidates.stream().allMatch(
-                candidate -> candidate.reservationConflict()
-                    || (candidate.currentlyOccupied() && candidate.hasFutureScheduledRide())
-        )) {
-            return DriverAssignmentResult.rejected(NO_ACTIVE_DRIVERS_MESSAGE);
-        }
-
-        List<DriverAssignmentCandidate> fallbackCandidates = eligibleCandidates.stream()
-            .filter(DriverAssignmentCandidate::currentlyOccupied)
-            .filter(candidate -> !candidate.reservationConflict())
-            .filter(candidate -> !candidate.hasFutureScheduledRide())
-            .filter(candidate -> candidate.remainingToFinishSec() <= TEN_MINUTES_IN_SECONDS)
-            .toList();
-
-        if (fallbackCandidates.isEmpty()) {
-            return DriverAssignmentResult.rejected(NO_ACTIVE_DRIVERS_MESSAGE);
-        }
-
-        Driver fallbackDriver = fallbackCandidates.stream()
-            .min(Comparator
-                .comparingLong(DriverAssignmentCandidate::remainingToFinishSec)
-                .thenComparingDouble(DriverAssignmentCandidate::pickupDistanceKm)
-                .thenComparing(candidate -> candidate.driver().getId()))
-            .orElseThrow()
-            .driver();
-
-        return DriverAssignmentResult.assigned(fallbackDriver);
+        return DriverAssignmentResult.rejected(NO_AVAILABLE_DRIVERS_MESSAGE);
     }
 
     private boolean isVehicleEligibleForRide(Ride ride, VehicleType vehicleType, Vehicle vehicle) {

--- a/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/RideService.java
@@ -9,6 +9,7 @@ import com.ftn.drumigo.domain.users.Driver;
 import com.ftn.drumigo.domain.users.Passenger;
 import com.ftn.drumigo.domain.users.User;
 import com.ftn.drumigo.dto.RideCreateRequest;
+import com.ftn.drumigo.dto.VehicleLocationUpdateRequest;
 import com.ftn.drumigo.dto.ride.request.RideStopRequest;
 import com.ftn.drumigo.dto.ride.request.RideCancelByDriverRequest;
 import com.ftn.drumigo.event.RideFinishedEvent;
@@ -166,6 +167,39 @@ public class RideService {
         inconsistency.setNote(note);
         
         return rideInconsistencyRepository.save(inconsistency);
+    }
+
+    /**
+     * Update the ride's vehicle current location to the given position (e.g. display/capped position from client).
+     * Keeps backend in sync with what the client shows so next poll returns the same position.
+     * Allowed for the ride's driver or any passenger (ordering or linked).
+     */
+    public void updateTrackingPosition(Long rideId, Long userId, String role, VehicleLocationUpdateRequest request) {
+        Ride ride = getById(rideId);
+        if (ride.getVehicle() == null) {
+            throw new BadRequestException("Ride has no assigned vehicle");
+        }
+        boolean isDriver = ride.getDriver() != null && ride.getDriver().getId().equals(userId);
+        if (isDriver) {
+            ride.getVehicle().setCurrentLat(request.lat());
+            ride.getVehicle().setCurrentLng(request.lng());
+            vehicleRepository.save(ride.getVehicle());
+            return;
+        }
+        if ("PASSENGER".equals(role)) {
+            Passenger passenger = passengerRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("Passenger not found with ID: " + userId));
+            boolean isOrdering = ride.getOrderingPassenger() != null && ride.getOrderingPassenger().getId().equals(passenger.getId());
+            boolean isLinked = ridePassengerRepository.findByRide(ride).stream()
+                .anyMatch(rp -> rp.getPassengerEmail().equals(passenger.getEmail()));
+            if (isOrdering || isLinked) {
+                ride.getVehicle().setCurrentLat(request.lat());
+                ride.getVehicle().setCurrentLng(request.lng());
+                vehicleRepository.save(ride.getVehicle());
+                return;
+            }
+        }
+        throw new BadRequestException("You are not authorized to update tracking position for this ride");
     }
     
     public List<RideInconsistency> getRideInconsistencies(Long rideId) {
@@ -535,7 +569,9 @@ public class RideService {
             );
             Instant availableAt = estimateDriverAvailableAt(driverAssignments, now);
             long remainingToFinishSec = estimateRemainingToFinishSec(availableAt, now);
-            boolean currentlyOccupied = remainingToFinishSec > 0;
+            // Driver is occupied if time estimate says so, or they have any ACTIVE ride (never assign a second ride to a driver who is currently on one)
+            boolean currentlyOccupied = remainingToFinishSec > 0
+                || driverAssignments.stream().anyMatch(r -> r.getStatus() == RideStatus.ACTIVE);
             Instant assignmentStart = resolveAssignmentStart(ride, availableAt, now);
             boolean reservationConflict = hasReservationConflict(driverAssignments, ride, assignmentStart, now);
 

--- a/drumigo/src/main/java/com/ftn/drumigo/service/RideTrackingSimulationService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/RideTrackingSimulationService.java
@@ -31,7 +31,8 @@ public class RideTrackingSimulationService {
     private static final int TICK_INTERVAL_MS = 3000;
     private static final double DEFAULT_SIM_DURATION_SEC = 120.0;
     private static final double MIN_METERS_PER_TICK = 5.0;
-    private static final double MAX_METERS_PER_TICK = 120.0;
+    /** Cap movement per tick so backend position never jumps more than mobile's display cap (40m); keeps backend and shown position aligned. */
+    private static final double MAX_METERS_PER_TICK = 40.0;
     private static final double EARTH_RADIUS_M = 6_371_000.0;
 
     private final RideService rideService;
@@ -115,9 +116,20 @@ public class RideTrackingSimulationService {
             return;
         }
 
+        double baseDistanceMeters = state.distanceTraveledMeters();
+        if (ride.getVehicle() != null && ride.getVehicle().getCurrentLat() != null && ride.getVehicle().getCurrentLng() != null) {
+            double fromVehicle = distanceAlongRouteFromPosition(
+                ride.getVehicle().getCurrentLat().doubleValue(),
+                ride.getVehicle().getCurrentLng().doubleValue(),
+                state.routePoints(),
+                state.cumulativeDistancesMeters()
+            );
+            baseDistanceMeters = Math.max(baseDistanceMeters, fromVehicle);
+        }
+
         double nextDistanceMeters = Math.min(
             state.totalDistanceMeters(),
-            state.distanceTraveledMeters() + state.metersPerTick()
+            baseDistanceMeters + state.metersPerTick()
         );
         RoutePoint nextPoint = resolvePointAtDistance(state.routePoints(), state.cumulativeDistancesMeters(), nextDistanceMeters);
         updateVehicleLocation(ride, BigDecimal.valueOf(nextPoint.lat()), BigDecimal.valueOf(nextPoint.lng()));
@@ -129,6 +141,46 @@ public class RideTrackingSimulationService {
         }
 
         simulatedRides.put(rideId, state.withDistanceTraveled(nextDistanceMeters));
+    }
+
+    private double distanceAlongRouteFromPosition(double lat, double lng, List<RoutePoint> points, List<Double> cumulativeDistances) {
+        if (points == null || points.size() < 2 || cumulativeDistances == null || cumulativeDistances.size() < 2) {
+            return 0.0;
+        }
+        double minDistSq = Double.POSITIVE_INFINITY;
+        double closestDistance = 0.0;
+        double refLatRad = Math.toRadians(lat);
+        double cosLat = Math.cos(refLatRad);
+        if (Math.abs(cosLat) < 1e-9) cosLat = 1e-9;
+        for (int i = 0; i < points.size() - 1; i++) {
+            RoutePoint a = points.get(i);
+            RoutePoint b = points.get(i + 1);
+            double ax = Math.toRadians(a.lng()) * EARTH_RADIUS_M * cosLat;
+            double ay = Math.toRadians(a.lat()) * EARTH_RADIUS_M;
+            double bx = Math.toRadians(b.lng()) * EARTH_RADIUS_M * cosLat;
+            double by = Math.toRadians(b.lat()) * EARTH_RADIUS_M;
+            double px = Math.toRadians(lng) * EARTH_RADIUS_M * cosLat;
+            double py = Math.toRadians(lat) * EARTH_RADIUS_M;
+            double abx = bx - ax;
+            double aby = by - ay;
+            double apx = px - ax;
+            double apy = py - ay;
+            double abLenSq = abx * abx + aby * aby;
+            double t = abLenSq <= 0 ? 0 : (apx * abx + apy * aby) / abLenSq;
+            double clampedT = Math.max(0.0, Math.min(1.0, t));
+            double projX = ax + abx * clampedT;
+            double projY = ay + aby * clampedT;
+            double dx = px - projX;
+            double dy = py - projY;
+            double distSq = dx * dx + dy * dy;
+            if (distSq < minDistSq) {
+                minDistSq = distSq;
+                double segStart = cumulativeDistances.get(i);
+                double segEnd = cumulativeDistances.get(i + 1);
+                closestDistance = segStart + (segEnd - segStart) * clampedT;
+            }
+        }
+        return closestDistance;
     }
 
     private void updateVehicleLocation(Ride ride, BigDecimal lat, BigDecimal lng) {

--- a/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
+++ b/drumigo/src/main/java/com/ftn/drumigo/service/VehicleService.java
@@ -139,6 +139,16 @@ public class VehicleService {
         return persistLocation(vehicle, request);
     }
 
+    /**
+     * Update a vehicle's current location. Caller is responsible for authorization (e.g. ride tracking sync).
+     */
+    public Vehicle updateLocationForRide(Vehicle vehicle, VehicleLocationUpdateRequest request) {
+        if (vehicle == null) {
+            throw new ResourceNotFoundException("Vehicle is null");
+        }
+        return persistLocation(vehicle, request);
+    }
+
     private Vehicle persistLocation(Vehicle vehicle, VehicleLocationUpdateRequest request) {
         vehicle.setCurrentLat(request.lat());
         vehicle.setCurrentLng(request.lng());

--- a/mobile/app/build.gradle.kts
+++ b/mobile/app/build.gradle.kts
@@ -91,3 +91,7 @@ dependencies {
     androidTestImplementation(libs.ext.junit)
     androidTestImplementation(libs.espresso.core)
 }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:deprecation")
+}

--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Drumigo"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
         <!-- Main Activity - Single Activity Architecture -->

--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -320,7 +320,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         setDrawerItemState(menu, R.id.nav_order_ride, true, true);
         setDrawerItemState(menu, R.id.nav_ride_tracking, true, true);
         setDrawerItemState(menu, R.id.nav_ride_history, true, true);
-        setDrawerItemState(menu, R.id.nav_favorite_routes, true, false);
         setDrawerItemState(menu, R.id.nav_profile, true, true);
         setDrawerItemState(menu, R.id.nav_support, true, false);
         setDrawerItemState(menu, R.id.nav_logout, true, true);
@@ -352,7 +351,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             R.id.nav_order_ride,
             R.id.nav_ride_tracking,
             R.id.nav_ride_history,
-            R.id.nav_favorite_routes,
             R.id.nav_dashboard,
             R.id.nav_active_rides_admin,
             R.id.nav_panic_notifications,

--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -473,7 +473,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         if (itemId == R.id.nav_home) {
             navController.navigate(R.id.landingFragment);
         } else if (itemId == R.id.nav_order_ride) {
-            navController.navigate(R.id.activeVehiclesMapFragment);
+            navController.navigate(R.id.landingFragment);
         } else if (itemId == R.id.nav_login) {
             navController.navigate(R.id.loginFragment);
         } else if (itemId == R.id.nav_registration) {

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxApiClient.java
@@ -19,6 +19,10 @@ public class MapboxApiClient {
         return getRetrofit().create(MapboxGeocodingService.class);
     }
 
+    public static MapboxSearchBoxService getSearchBoxService() {
+        return getRetrofit().create(MapboxSearchBoxService.class);
+    }
+
     private static Retrofit getRetrofit() {
         if (retrofit == null) {
             retrofit = new Retrofit.Builder()

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxSearchBoxService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/MapboxSearchBoxService.java
@@ -1,0 +1,23 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.mapbox.MapboxSearchBoxSuggestResponse;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * Mapbox Search Box API for address autocomplete (same as frontend).
+ * https://docs.mapbox.com/api/search/search-box/#suggest
+ */
+public interface MapboxSearchBoxService {
+
+    @GET("search/searchbox/v1/suggest")
+    Call<MapboxSearchBoxSuggestResponse> suggest(
+        @Query("q") String query,
+        @Query("access_token") String accessToken,
+        @Query("session_token") String sessionToken,
+        @Query("limit") int limit,
+        @Query("proximity") String proximity
+    );
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/PassengerApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/PassengerApiService.java
@@ -1,10 +1,15 @@
 package com.drumigo.mobile.data.api;
 
+import com.drumigo.mobile.data.model.favorite.FavoriteRouteResponse;
 import com.drumigo.mobile.data.model.history.PageResponse;
 import com.drumigo.mobile.data.model.history.PassengerRideHistoryItemResponse;
 
+import java.util.List;
+
 import retrofit2.Call;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
@@ -18,5 +23,20 @@ public interface PassengerApiService {
         @Query("page") int page,
         @Query("size") int size,
         @Query("sort") String sort
+    );
+
+    @GET("passengers/{passengerId}/favorite-routes")
+    Call<List<FavoriteRouteResponse>> getFavoriteRoutes(@Path("passengerId") long passengerId);
+
+    @POST("passengers/{passengerId}/favorite-routes/from-ride/{rideId}")
+    Call<FavoriteRouteResponse> createFavoriteRouteFromRide(
+        @Path("passengerId") long passengerId,
+        @Path("rideId") long rideId
+    );
+
+    @DELETE("passengers/{passengerId}/favorite-routes/by-ride/{rideId}")
+    Call<Void> deleteFavoriteRouteByRide(
+        @Path("passengerId") long passengerId,
+        @Path("rideId") long rideId
     );
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
@@ -4,7 +4,10 @@ import com.drumigo.mobile.data.model.estimate.EstimateRequest;
 import com.drumigo.mobile.data.model.estimate.EstimateResponse;
 import com.drumigo.mobile.data.model.ride.ActiveRideIdResponse;
 import com.drumigo.mobile.data.model.ride.RideCancelByDriverRequest;
+import com.drumigo.mobile.data.model.ride.RideCreateRequest;
 import com.drumigo.mobile.data.model.ride.RideDetailsResponse;
+import com.drumigo.mobile.data.model.ride.RideInconsistencyCreateRequest;
+import com.drumigo.mobile.data.model.ride.RideInconsistencyResponse;
 import com.drumigo.mobile.data.model.ride.RideResponse;
 import com.drumigo.mobile.data.model.ride.RideStopRequest;
 import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
@@ -12,11 +15,11 @@ import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
 import java.util.List;
 
 import retrofit2.Call;
-import retrofit2.http.PUT;
+import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Path;
-import retrofit2.http.Body;
 
 public interface RideApiService {
 
@@ -32,6 +35,9 @@ public interface RideApiService {
     @GET("rides/me/active")
     Call<ActiveRideIdResponse> getMyActiveRide();
 
+    @POST("rides")
+    Call<RideResponse> createRide(@Body RideCreateRequest request);
+
     @POST("rides/estimate")
     Call<EstimateResponse> estimateRide(@Body EstimateRequest request);
 
@@ -46,4 +52,19 @@ public interface RideApiService {
 
     @PUT("rides/{id}/stop")
     Call<RideResponse> stopRide(@Path("id") long rideId, @Body RideStopRequest request);
+
+    @PUT("rides/{id}/start")
+    Call<RideResponse> startRide(@Path("id") long rideId);
+
+    @PUT("rides/{id}/end")
+    Call<RideResponse> endRide(@Path("id") long rideId);
+
+    @POST("rides/{id}/inconsistencies")
+    Call<RideInconsistencyResponse> reportInconsistency(
+        @Path("id") long rideId,
+        @Body RideInconsistencyCreateRequest request
+    );
+
+    @GET("rides/{id}/inconsistencies")
+    Call<List<RideInconsistencyResponse>> getInconsistencies(@Path("id") long rideId);
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/RideApiService.java
@@ -10,6 +10,7 @@ import com.drumigo.mobile.data.model.ride.RideInconsistencyCreateRequest;
 import com.drumigo.mobile.data.model.ride.RideInconsistencyResponse;
 import com.drumigo.mobile.data.model.ride.RideResponse;
 import com.drumigo.mobile.data.model.ride.RideStopRequest;
+import com.drumigo.mobile.data.model.ride.RideTrackingPositionRequest;
 import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
 
 import java.util.List;
@@ -25,6 +26,9 @@ public interface RideApiService {
 
     @GET("rides/{id}")
     Call<RideTrackingResponse> getRideTracking(@Path("id") long rideId);
+
+    @PUT("rides/{id}/tracking-position")
+    Call<Void> updateTrackingPosition(@Path("id") long rideId, @Body RideTrackingPositionRequest position);
 
     @GET("rides/{id}/details")
     Call<RideDetailsResponse> getRideDetails(@Path("id") long rideId);

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/Ride.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/Ride.java
@@ -14,6 +14,8 @@ public class Ride {
     private boolean hasPanic;
     private long sortTimestampEpochMs;
     private double amountValue;
+    private boolean favorite;
+    private Long favoriteRouteId;
 
     public Ride(Long id, String date, String time, String origin, String destination,
                 String[] passengerInitials, int passengerCount, String status,
@@ -46,6 +48,8 @@ public class Ride {
     public boolean hasPanic() { return hasPanic; }
     public long getSortTimestampEpochMs() { return sortTimestampEpochMs; }
     public double getAmountValue() { return amountValue; }
+    public boolean isFavorite() { return favorite; }
+    public Long getFavoriteRouteId() { return favoriteRouteId; }
 
     public void setId(Long id) { this.id = id; }
     public void setDate(String date) { this.date = date; }
@@ -60,4 +64,6 @@ public class Ride {
     public void setHasPanic(boolean hasPanic) { this.hasPanic = hasPanic; }
     public void setSortTimestampEpochMs(long sortTimestampEpochMs) { this.sortTimestampEpochMs = sortTimestampEpochMs; }
     public void setAmountValue(double amountValue) { this.amountValue = amountValue; }
+    public void setFavorite(boolean favorite) { this.favorite = favorite; }
+    public void setFavoriteRouteId(Long favoriteRouteId) { this.favoriteRouteId = favoriteRouteId; }
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/favorite/FavoriteRouteResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/favorite/FavoriteRouteResponse.java
@@ -1,0 +1,17 @@
+package com.drumigo.mobile.data.model.favorite;
+
+import java.util.List;
+
+/**
+ * Favorite route for order-ride picker. Matches backend FavoriteRouteResponse.
+ */
+public class FavoriteRouteResponse {
+    public Long id;
+    public Long passengerId;
+    public Long vehicleTypeId;
+    public String vehicleTypeName;
+    public Boolean babyTransport;
+    public Boolean petTransport;
+    public List<FavoriteRouteWaypointResponse> waypoints;
+    public String createdAt;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/favorite/FavoriteRouteWaypointResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/favorite/FavoriteRouteWaypointResponse.java
@@ -1,0 +1,14 @@
+package com.drumigo.mobile.data.model.favorite;
+
+/**
+ * Waypoint of a favorite route. Matches backend FavoriteRouteResponse.WaypointResponse.
+ * lat/lng may come as numbers from JSON; use Double for Gson.
+ */
+public class FavoriteRouteWaypointResponse {
+    public Long id;
+    public Long locationId;
+    public String address;
+    public Double lat;
+    public Double lng;
+    public Integer order;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PassengerRideHistoryItemResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/history/PassengerRideHistoryItemResponse.java
@@ -13,4 +13,6 @@ public class PassengerRideHistoryItemResponse {
     public Boolean canceled;
     public String canceledBy;
     public Boolean hasPanic;
+    public Boolean isFavorite;
+    public Long favoriteRouteId;
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/mapbox/MapboxSearchBoxSuggestResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/mapbox/MapboxSearchBoxSuggestResponse.java
@@ -1,0 +1,19 @@
+package com.drumigo.mobile.data.model.mapbox;
+
+import java.util.List;
+
+/**
+ * Response from Mapbox Search Box API suggest endpoint.
+ * https://api.mapbox.com/search/searchbox/v1/suggest
+ */
+public class MapboxSearchBoxSuggestResponse {
+
+    public List<Suggestion> suggestions;
+
+    public static class Suggestion {
+        public String full_address;
+        public String name;
+        public String address;
+        public String place_formatted;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideCreateRequest.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideCreateRequest.java
@@ -1,0 +1,38 @@
+package com.drumigo.mobile.data.model.ride;
+
+import java.util.List;
+
+/**
+ * Request body for POST /api/rides (create ride).
+ * Matches backend RideCreateRequest.
+ */
+public class RideCreateRequest {
+
+    public List<WaypointRequest> waypoints;
+    public String vehicleType;
+    public Boolean babyTransport;
+    public Boolean petTransport;
+    public List<String> linkedPassengerEmails;
+    /** ISO-8601 instant or null for immediate ride */
+    public String scheduledFor;
+
+    public RideCreateRequest() {
+    }
+
+    public static class WaypointRequest {
+        public String address;
+        public Double lat;
+        public Double lng;
+        public Integer order;
+
+        public WaypointRequest() {
+        }
+
+        public WaypointRequest(String address, Double lat, Double lng, Integer order) {
+            this.address = address;
+            this.lat = lat;
+            this.lng = lng;
+            this.order = order;
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideDetailsResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideDetailsResponse.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 public class RideDetailsResponse {
     public RideInfo ride;
+    /** Top-level waypoints (pickup -> waypoint 1 -> ... -> destination). Backend sends this; use when ride.waypoints is null/empty. */
+    public List<WaypointInfo> waypoints;
     public DriverInfo driver;
     public List<PassengerInfo> passengers;
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideInconsistencyCreateRequest.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideInconsistencyCreateRequest.java
@@ -1,0 +1,16 @@
+package com.drumigo.mobile.data.model.ride;
+
+/**
+ * Request body for POST /rides/{id}/inconsistencies.
+ * Note must be 10–1000 characters.
+ */
+public class RideInconsistencyCreateRequest {
+    public String note;
+
+    public RideInconsistencyCreateRequest() {
+    }
+
+    public RideInconsistencyCreateRequest(String note) {
+        this.note = note;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideInconsistencyResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideInconsistencyResponse.java
@@ -1,0 +1,15 @@
+package com.drumigo.mobile.data.model.ride;
+
+/**
+ * Response from POST /rides/{id}/inconsistencies or GET /rides/{id}/inconsistencies.
+ */
+public class RideInconsistencyResponse {
+    public Long id;
+    public Long rideId;
+    public Long passengerId;
+    public String passengerName;
+    public String passengerSurname;
+    public String note;
+    /** ISO-8601 date string from backend */
+    public String createdAt;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideTrackingPositionRequest.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RideTrackingPositionRequest.java
@@ -1,0 +1,15 @@
+package com.drumigo.mobile.data.model.ride;
+
+/**
+ * Request body for PUT /rides/{id}/tracking-position.
+ * Sends the displayed (e.g. capped) position so backend stays in sync with the client.
+ */
+public class RideTrackingPositionRequest {
+    public final double lat;
+    public final double lng;
+
+    public RideTrackingPositionRequest(double lat, double lng) {
+        this.lat = lat;
+        this.lng = lng;
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RoutePoint.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/ride/RoutePoint.java
@@ -4,10 +4,19 @@ public class RoutePoint {
     public double lat;
     public double lng;
     public int order;
+    /** Optional address for display (e.g. in checkpoints). */
+    public String address;
 
     public RoutePoint(double lat, double lng, int order) {
         this.lat = lat;
         this.lng = lng;
         this.order = order;
+    }
+
+    public RoutePoint(double lat, double lng, int order, String address) {
+        this.lat = lat;
+        this.lng = lng;
+        this.order = order;
+        this.address = address;
     }
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/auth/LoginFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/auth/LoginFragment.java
@@ -109,7 +109,7 @@ public class LoginFragment extends Fragment {
                     } else if ("ADMIN".equals(role)) {
                         Navigation.findNavController(binding.getRoot()).navigate(R.id.profileFragment);
                     } else {
-                        Navigation.findNavController(binding.getRoot()).navigate(R.id.activeVehiclesMapFragment);
+                        Navigation.findNavController(binding.getRoot()).navigate(R.id.landingFragment);
                     }
                 } else {
                     String errorMsg = getLoginErrorMessage(response.code(), response.message());

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/PassengerRideHistoryMapper.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/PassengerRideHistoryMapper.java
@@ -54,6 +54,8 @@ public final class PassengerRideHistoryMapper {
         );
         ride.setSortTimestampEpochMs(start != null ? start.toInstant().toEpochMilli() : 0L);
         ride.setAmountValue(item.totalCost == null ? 0.0d : item.totalCost);
+        ride.setFavorite(item.isFavorite != null && item.isFavorite);
+        ride.setFavoriteRouteId(item.favoriteRouteId);
         return ride;
     }
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
@@ -23,6 +23,7 @@ import com.drumigo.mobile.data.api.ApiClient;
 import com.drumigo.mobile.data.api.DriverApiService;
 import com.drumigo.mobile.data.api.PassengerApiService;
 import com.drumigo.mobile.data.model.Ride;
+import com.drumigo.mobile.data.model.favorite.FavoriteRouteResponse;
 import com.drumigo.mobile.data.model.history.DriverRideHistoryItemResponse;
 import com.drumigo.mobile.data.model.history.PageResponse;
 import com.drumigo.mobile.data.model.history.PassengerRideHistoryItemResponse;
@@ -46,7 +47,8 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-public class RideHistoryActivity extends AppCompatActivity implements RideHistoryAdapter.OnRideClickListener {
+public class RideHistoryActivity extends AppCompatActivity
+    implements RideHistoryAdapter.OnRideClickListener, RideHistoryAdapter.OnFavoriteToggleListener {
 
     private static final String TAG = "RideHistoryActivity";
     private static final String ROLE_DRIVER = "DRIVER";
@@ -99,9 +101,6 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
 
             setupToolbar();
             initializeViews();
-            setupRecyclerView();
-            setupDatePickers();
-            setupSortControl();
 
             sessionManager = SessionManager.getInstance(this);
             if (!sessionManager.isAuthenticated()) {
@@ -109,11 +108,14 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
                 finish();
                 return;
             }
-
             currentRole = resolveCurrentRole();
             driverApiService = ApiClient.getDriverApiService();
             passengerApiService = ApiClient.getPassengerApiService();
             adminApiService = ApiClient.getAdminApiService();
+
+            setupRecyclerView();
+            setupDatePickers();
+            setupSortControl();
 
             loadRideHistory();
         } catch (Exception e) {
@@ -156,7 +158,14 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
     }
 
     private void setupRecyclerView() {
-        adapter = new RideHistoryAdapter(new ArrayList<>(), this, this);
+        boolean showFavorite = ROLE_PASSENGER.equals(currentRole);
+        adapter = new RideHistoryAdapter(
+            new ArrayList<>(),
+            this,
+            this,
+            showFavorite,
+            showFavorite ? this : null
+        );
         if (recyclerView != null) {
             recyclerView.setLayoutManager(new LinearLayoutManager(this));
             recyclerView.setAdapter(adapter);
@@ -552,6 +561,75 @@ public class RideHistoryActivity extends AppCompatActivity implements RideHistor
             return;
         }
         RideHistoryDetailsBottomSheet.show(this, ride);
+    }
+
+    @Override
+    public void onFavoriteToggled(Ride ride) {
+        if (ride == null || passengerApiService == null || sessionManager == null) {
+            return;
+        }
+        long passengerId = sessionManager.getUserId();
+        if (passengerId <= 0) {
+            Toast.makeText(this, R.string.favorite_error, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        Long rideId = ride.getId();
+        if (rideId == null) {
+            return;
+        }
+        if (ride.isFavorite()) {
+            passengerApiService.deleteFavoriteRouteByRide(passengerId, rideId).enqueue(new Callback<Void>() {
+                @Override
+                public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
+                    if (response.isSuccessful()) {
+                        updateRideFavoriteState(ride.getId(), false, null);
+                        Toast.makeText(RideHistoryActivity.this, R.string.favorite_removed, Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(RideHistoryActivity.this, R.string.favorite_error, Toast.LENGTH_SHORT).show();
+                    }
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
+                    Toast.makeText(RideHistoryActivity.this, R.string.favorite_error, Toast.LENGTH_SHORT).show();
+                }
+            });
+        } else {
+            passengerApiService.createFavoriteRouteFromRide(passengerId, rideId).enqueue(new Callback<FavoriteRouteResponse>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<FavoriteRouteResponse> call,
+                    @NonNull Response<FavoriteRouteResponse> response
+                ) {
+                    if (response.isSuccessful() && response.body() != null) {
+                        updateRideFavoriteState(ride.getId(), true, response.body().id);
+                        Toast.makeText(RideHistoryActivity.this, R.string.favorite_added, Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(RideHistoryActivity.this, R.string.favorite_error, Toast.LENGTH_SHORT).show();
+                    }
+                }
+
+                @Override
+                public void onFailure(
+                    @NonNull Call<FavoriteRouteResponse> call,
+                    @NonNull Throwable t
+                ) {
+                    Toast.makeText(RideHistoryActivity.this, R.string.favorite_error, Toast.LENGTH_SHORT).show();
+                }
+            });
+        }
+    }
+
+    private void updateRideFavoriteState(Long rideId, boolean favorite, Long favoriteRouteId) {
+        for (int i = 0; i < fetchedRides.size(); i++) {
+            Ride r = fetchedRides.get(i);
+            if (r != null && rideId.equals(r.getId())) {
+                r.setFavorite(favorite);
+                r.setFavoriteRouteId(favoriteRouteId);
+                adapter.updateRides(new ArrayList<>(fetchedRides));
+                break;
+            }
+        }
     }
 
     @Override

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
@@ -3,8 +3,10 @@ package com.drumigo.mobile.ui.history;
 import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.graphics.PorterDuff;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -26,14 +28,23 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         void onRideSelected(Ride ride);
     }
 
+    public interface OnFavoriteToggleListener {
+        void onFavoriteToggled(Ride ride);
+    }
+
     private List<Ride> rides;
     private final Context context;
     private final OnRideClickListener onRideClickListener;
+    private final boolean showFavoriteButton;
+    private final OnFavoriteToggleListener onFavoriteToggleListener;
 
-    public RideHistoryAdapter(List<Ride> rides, Context context, OnRideClickListener onRideClickListener) {
+    public RideHistoryAdapter(List<Ride> rides, Context context, OnRideClickListener onRideClickListener,
+                              boolean showFavoriteButton, OnFavoriteToggleListener onFavoriteToggleListener) {
         this.rides = rides == null ? Collections.emptyList() : rides;
         this.context = context;
         this.onRideClickListener = onRideClickListener;
+        this.showFavoriteButton = showFavoriteButton;
+        this.onFavoriteToggleListener = onFavoriteToggleListener;
     }
 
     @NonNull
@@ -60,11 +71,31 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         bindPassengerSection(holder, ride);
         bindStatusSection(holder, ride);
         bindBottomSummary(holder, ride);
+        bindFavoriteStar(holder, ride);
 
         holder.itemView.setOnClickListener(v -> {
             if (onRideClickListener != null) {
                 onRideClickListener.onRideSelected(ride);
             }
+        });
+    }
+
+    private void bindFavoriteStar(RideViewHolder holder, Ride ride) {
+        holder.favoriteStar.setVisibility(showFavoriteButton ? View.VISIBLE : View.GONE);
+        if (!showFavoriteButton) {
+            return;
+        }
+        holder.favoriteStar.setImageResource(ride.isFavorite() ? R.drawable.ic_star : R.drawable.ic_star_outline);
+        int color = ride.isFavorite()
+            ? ContextCompat.getColor(context, R.color.star_filled)
+            : ContextCompat.getColor(context, R.color.text_light);
+        holder.favoriteStar.setColorFilter(color, PorterDuff.Mode.SRC_IN);
+        holder.favoriteStar.setOnClickListener(v -> {
+            v.setClickable(false);
+            if (onFavoriteToggleListener != null) {
+                onFavoriteToggleListener.onFavoriteToggled(ride);
+            }
+            v.setClickable(true);
         });
     }
 
@@ -138,6 +169,7 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         TextView fromText;
         TextView toText;
         TextView passengerCountText;
+        ImageButton favoriteStar;
         View statusBadge;
         ImageView statusIcon;
         TextView statusText;
@@ -153,6 +185,7 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
             fromText = itemView.findViewById(R.id.fromText);
             toText = itemView.findViewById(R.id.toText);
             passengerCountText = itemView.findViewById(R.id.passengerCountText);
+            favoriteStar = itemView.findViewById(R.id.favoriteStar);
             statusBadge = itemView.findViewById(R.id.statusBadge);
             statusIcon = itemView.findViewById(R.id.statusIcon);
             statusText = itemView.findViewById(R.id.statusText);

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryRouteMapDialog.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryRouteMapDialog.java
@@ -25,10 +25,13 @@ import androidx.lifecycle.ViewTreeLifecycleOwner;
 
 import com.drumigo.mobile.BuildConfig;
 import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.api.ApiClient;
 import com.drumigo.mobile.data.api.MapboxApiClient;
 import com.drumigo.mobile.data.api.MapboxDirectionsService;
 import com.drumigo.mobile.data.api.MapboxGeocodingService;
+import com.drumigo.mobile.data.api.RideApiService;
 import com.drumigo.mobile.data.model.Ride;
+import com.drumigo.mobile.data.model.ride.RideDetailsResponse;
 import com.drumigo.mobile.data.model.mapbox.MapboxDirectionsResponse;
 import com.drumigo.mobile.data.model.mapbox.MapboxGeocodingResponse;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -52,6 +55,8 @@ import com.mapbox.maps.plugin.scalebar.ScaleBarUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import retrofit2.Call;
@@ -71,6 +76,7 @@ final class RideHistoryRouteMapDialog {
     private final Ride ride;
     private final MapboxGeocodingService geocodingService;
     private final MapboxDirectionsService directionsService;
+    private final RideApiService rideApiService;
 
     private BottomSheetDialog dialog;
     private MapView mapView;
@@ -89,6 +95,7 @@ final class RideHistoryRouteMapDialog {
         this.ride = ride;
         this.geocodingService = MapboxApiClient.getGeocodingService();
         this.directionsService = MapboxApiClient.getDirectionsService();
+        this.rideApiService = ApiClient.getRideApiService();
     }
 
     static void show(@NonNull Context context, @NonNull Ride ride) {
@@ -190,6 +197,72 @@ final class RideHistoryRouteMapDialog {
         if (dismissed) {
             return;
         }
+        Long rideId = ride.getId();
+        if (rideId != null && rideApiService != null) {
+            rideApiService.getRideDetails(rideId).enqueue(new Callback<RideDetailsResponse>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<RideDetailsResponse> call,
+                    @NonNull Response<RideDetailsResponse> response
+                ) {
+                    if (dismissed) return;
+                    if (response.isSuccessful() && response.body() != null) {
+                        RideDetailsResponse body = response.body();
+                        List<RideDetailsResponse.WaypointInfo> waypoints = getOrderedWaypoints(body);
+                        if (waypoints != null && waypoints.size() >= 2) {
+                            boolean allHaveLatLng = true;
+                            for (RideDetailsResponse.WaypointInfo wp : waypoints) {
+                                if (wp.lat == null || wp.lng == null) {
+                                    allHaveLatLng = false;
+                                    break;
+                                }
+                            }
+                            if (allHaveLatLng) {
+                                List<GeocodedLocation> points = new ArrayList<>();
+                                for (RideDetailsResponse.WaypointInfo wp : waypoints) {
+                                    String addr = wp.address != null ? wp.address : "";
+                                    points.add(new GeocodedLocation(wp.lat, wp.lng, addr));
+                                }
+                                requestRouteFromWaypoints(points);
+                                return;
+                            }
+                        }
+                    }
+                    loadRouteFallbackOriginDestination();
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<RideDetailsResponse> call, @NonNull Throwable t) {
+                    if (!dismissed) loadRouteFallbackOriginDestination();
+                }
+            });
+        } else {
+            loadRouteFallbackOriginDestination();
+        }
+    }
+
+    /**
+     * Waypoints in order: pickup -> waypoint 1 -> waypoint 2 -> ... -> destination.
+     * Uses whichever of top-level waypoints or ride.waypoints has more elements, so we never
+     * show only pickup->first waypoint when the backend sends the full list in the other field.
+     */
+    private static List<RideDetailsResponse.WaypointInfo> getOrderedWaypoints(RideDetailsResponse body) {
+        if (body == null) return null;
+        List<RideDetailsResponse.WaypointInfo> fromTop = body.waypoints != null ? new ArrayList<>(body.waypoints) : null;
+        List<RideDetailsResponse.WaypointInfo> fromRide = (body.ride != null && body.ride.waypoints != null)
+            ? new ArrayList<>(body.ride.waypoints) : null;
+        int topSize = fromTop != null ? fromTop.size() : 0;
+        int rideSize = fromRide != null ? fromRide.size() : 0;
+        List<RideDetailsResponse.WaypointInfo> list = topSize >= rideSize && topSize > 0
+            ? fromTop
+            : (rideSize > 0 ? fromRide : null);
+        if (list == null || list.isEmpty()) return null;
+        Collections.sort(list, Comparator.comparingInt(wp -> wp.order == null ? 0 : wp.order));
+        return list;
+    }
+
+    private void loadRouteFallbackOriginDestination() {
+        if (dismissed) return;
         String originAddress = trimToEmpty(ride.getOrigin());
         String destinationAddress = trimToEmpty(ride.getDestination());
         if (originAddress.isEmpty() || destinationAddress.isEmpty()) {
@@ -277,6 +350,27 @@ final class RideHistoryRouteMapDialog {
         );
     }
 
+    private void requestRouteFromWaypoints(List<GeocodedLocation> points) {
+        if (points == null || points.size() < 2) {
+            loadRouteFallbackOriginDestination();
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < points.size(); i++) {
+            if (i > 0) sb.append(";");
+            GeocodedLocation p = points.get(i);
+            sb.append(p.longitude).append(",").append(p.latitude);
+        }
+        int requestToken = ++routeRequestToken;
+        requestDirectionsWithProfileWaypoints(
+            "driving-traffic",
+            sb.toString(),
+            requestToken,
+            true,
+            points
+        );
+    }
+
     private void requestDirectionsWithProfile(
         String profile,
         String coordinates,
@@ -344,6 +438,70 @@ final class RideHistoryRouteMapDialog {
         });
     }
 
+    private void requestDirectionsWithProfileWaypoints(
+        String profile,
+        String coordinates,
+        int requestToken,
+        boolean allowRetryWithDriving,
+        List<GeocodedLocation> routePoints
+    ) {
+        if (directionsService == null) {
+            showError(context.getString(R.string.ride_history_route_map_error));
+            return;
+        }
+        directionsService.getDirections(
+            profile,
+            coordinates,
+            "geojson",
+            "full",
+            BuildConfig.MAPBOX_ACCESS_TOKEN
+        ).enqueue(new Callback<MapboxDirectionsResponse>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<MapboxDirectionsResponse> call,
+                @NonNull Response<MapboxDirectionsResponse> response
+            ) {
+                if (dismissed || requestToken != routeRequestToken) {
+                    return;
+                }
+                List<List<Double>> coordinatesList = extractRouteCoordinates(response);
+                if (coordinatesList != null && coordinatesList.size() >= 2) {
+                    drawRouteWithWaypoints(coordinatesList, routePoints);
+                    return;
+                }
+                if (allowRetryWithDriving) {
+                    requestDirectionsWithProfileWaypoints(
+                        "driving",
+                        coordinates,
+                        requestToken,
+                        false,
+                        routePoints
+                    );
+                } else {
+                    showError(context.getString(R.string.ride_history_route_map_error));
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<MapboxDirectionsResponse> call, @NonNull Throwable t) {
+                if (dismissed || requestToken != routeRequestToken) {
+                    return;
+                }
+                if (allowRetryWithDriving) {
+                    requestDirectionsWithProfileWaypoints(
+                        "driving",
+                        coordinates,
+                        requestToken,
+                        false,
+                        routePoints
+                    );
+                } else {
+                    showError(context.getString(R.string.ride_history_route_map_error));
+                }
+            }
+        });
+    }
+
     @Nullable
     private List<List<Double>> extractRouteCoordinates(Response<MapboxDirectionsResponse> response) {
         if (response == null || !response.isSuccessful() || response.body() == null) {
@@ -388,6 +546,47 @@ final class RideHistoryRouteMapDialog {
         Point endPoint = Point.fromLngLat(destination.longitude, destination.latitude);
         addRouteLabel(startPoint, compactAddressLabel(origin.address), R.color.primary);
         addRouteLabel(endPoint, compactAddressLabel(destination.address), R.color.accent);
+
+        centerMapOnRoute(routePoints);
+        showMap();
+    }
+
+    private void drawRouteWithWaypoints(
+        @NonNull List<List<Double>> routeCoordinates,
+        @NonNull List<GeocodedLocation> orderedPoints
+    ) {
+        if (dismissed || mapView == null || orderedPoints.isEmpty()) {
+            return;
+        }
+        ensureAnnotationManagers();
+
+        GeocodedLocation first = orderedPoints.get(0);
+        List<Point> routePoints = buildRenderableRoutePoints(routeCoordinates, first);
+        if (routePoints.size() < 2 || polylineAnnotationManager == null || pointAnnotationManager == null) {
+            showError(context.getString(R.string.ride_history_route_map_error));
+            return;
+        }
+
+        polylineAnnotationManager.deleteAll();
+        pointAnnotationManager.deleteAll();
+
+        polylineAnnotationManager.create(new PolylineAnnotationOptions()
+            .withPoints(routePoints)
+            .withLineColor("#5B4CDB")
+            .withLineWidth(5.2));
+
+        for (int i = 0; i < orderedPoints.size(); i++) {
+            GeocodedLocation p = orderedPoints.get(i);
+            Point point = Point.fromLngLat(p.longitude, p.latitude);
+            String label = compactAddressLabel(p.address);
+            if (label.isEmpty() && orderedPoints.size() > 2) {
+                if (i == 0) label = context.getString(R.string.ride_tracking_checkpoint_pickup);
+                else if (i == orderedPoints.size() - 1) label = context.getString(R.string.ride_tracking_checkpoint_destination);
+                else label = context.getString(R.string.ride_tracking_checkpoint_waypoint_fallback, i);
+            }
+            int colorRes = (i == 0) ? R.color.primary : R.color.accent;
+            addRouteLabel(point, label.isEmpty() ? String.valueOf(i + 1) : label, colorRes);
+        }
 
         centerMapOnRoute(routePoints);
         showMap();

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/landing/LandingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/landing/LandingFragment.java
@@ -38,10 +38,13 @@ import com.drumigo.mobile.data.api.MapboxApiClient;
 import com.drumigo.mobile.data.api.MapboxDirectionsService;
 import com.drumigo.mobile.data.api.MapboxGeocodingService;
 import com.drumigo.mobile.data.api.MapboxSearchBoxService;
+import com.drumigo.mobile.data.api.PassengerApiService;
 import com.drumigo.mobile.data.api.RideApiService;
 import com.drumigo.mobile.data.api.VehicleApiService;
 import com.drumigo.mobile.data.model.VehicleResponse;
 import com.drumigo.mobile.data.model.estimate.EstimateRequest;
+import com.drumigo.mobile.data.model.favorite.FavoriteRouteResponse;
+import com.drumigo.mobile.data.model.favorite.FavoriteRouteWaypointResponse;
 import com.drumigo.mobile.data.model.estimate.EstimateResponse;
 import com.drumigo.mobile.data.model.estimate.LocationDto;
 import com.drumigo.mobile.data.model.ride.RideCreateRequest;
@@ -73,6 +76,7 @@ import com.mapbox.maps.plugin.scalebar.ScaleBarUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,6 +103,7 @@ public class LandingFragment extends Fragment {
     private MapView mapView;
     private VehicleApiService vehicleApiService;
     private RideApiService rideApiService;
+    private PassengerApiService passengerApiService;
     private MapboxGeocodingService geocodingService;
     private MapboxSearchBoxService searchBoxService;
     private SessionManager sessionManager;
@@ -130,6 +135,7 @@ public class LandingFragment extends Fragment {
     private final List<View> passengerRows = new ArrayList<>();
     private ArrayAdapter<String> pickupSuggestionsAdapter;
     private ArrayAdapter<String> destinationSuggestionsAdapter;
+    private ArrayAdapter<String> favoriteRouteDropdownAdapter;
     private int pickupAutocompleteToken = 0;
     private int destinationAutocompleteToken = 0;
     private int stopAutocompleteToken = 0;
@@ -139,6 +145,8 @@ public class LandingFragment extends Fragment {
 
     private List<VehicleResponse> activeVehicles = new ArrayList<>();
     private List<List<Double>> routeCoordinates = Collections.emptyList();
+    private final List<FavoriteRouteResponse> favoriteRoutes = new ArrayList<>();
+    private final List<FavoriteRouteResponse> favoriteRouteDropdownItems = new ArrayList<>();
 
     private final Handler pollingHandler = new Handler(Looper.getMainLooper());
     private final Handler autocompleteHandler = new Handler(Looper.getMainLooper());
@@ -163,6 +171,7 @@ public class LandingFragment extends Fragment {
         MapboxOptions.setAccessToken(BuildConfig.MAPBOX_ACCESS_TOKEN);
         vehicleApiService = ApiClient.getVehicleApiService();
         rideApiService = ApiClient.getRideApiService();
+        passengerApiService = ApiClient.getPassengerApiService();
         geocodingService = MapboxApiClient.getGeocodingService();
         searchBoxService = MapboxApiClient.getSearchBoxService();
         directionsService = MapboxApiClient.getDirectionsService();
@@ -188,6 +197,7 @@ public class LandingFragment extends Fragment {
 
         setupHeaderActions();
         setupEstimatePanel();
+        refreshFavoriteRoutesSection();
         // Open order/estimate panel by default so users always see where to order a ride
         binding.getRoot().post(() -> {
             if (binding != null && !estimatePanelOpen) {
@@ -203,6 +213,7 @@ public class LandingFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        refreshFavoriteRoutesSection();
         // Open order panel when fragment is visible (e.g. after login or "Order a Ride")
         if (binding != null && !estimatePanelOpen) {
             binding.getRoot().postDelayed(() -> {
@@ -273,6 +284,7 @@ public class LandingFragment extends Fragment {
         passengerRows.clear();
         pickupSuggestionsAdapter = null;
         destinationSuggestionsAdapter = null;
+        favoriteRouteDropdownAdapter = null;
         binding = null;
         super.onDestroyView();
     }
@@ -298,8 +310,14 @@ public class LandingFragment extends Fragment {
             android.R.layout.simple_list_item_1,
             new ArrayList<>()
         );
+        favoriteRouteDropdownAdapter = new ArrayAdapter<>(
+            requireContext(),
+            android.R.layout.simple_list_item_1,
+            new ArrayList<>()
+        );
         binding.pickupInput.setAdapter(pickupSuggestionsAdapter);
         binding.destinationInput.setAdapter(destinationSuggestionsAdapter);
+        binding.favoriteRouteDropdown.setAdapter(favoriteRouteDropdownAdapter);
         setupLocationAutocomplete();
 
         binding.vehicleTypeDropdown.setAdapter(vehicleTypeAdapter);
@@ -308,6 +326,9 @@ public class LandingFragment extends Fragment {
         }
         binding.vehicleTypeDropdown.setKeyListener(null);
         binding.vehicleTypeDropdown.setOnClickListener(v -> binding.vehicleTypeDropdown.showDropDown());
+        binding.favoriteRouteDropdown.setKeyListener(null);
+        binding.favoriteRouteDropdown.setOnClickListener(v -> binding.favoriteRouteDropdown.showDropDown());
+        binding.favoriteRouteDropdown.setOnItemClickListener((parent, view, position, id) -> onFavoriteRouteSelected(position));
 
         binding.btnEstimateLauncher.setOnClickListener(v -> openEstimatePanel());
         binding.btnCloseEstimatePanel.setOnClickListener(v -> closeEstimatePanel());
@@ -740,6 +761,26 @@ public class LandingFragment extends Fragment {
                 .setDuration(240L)
                 .start();
         });
+        refreshFavoriteRoutesSection();
+    }
+
+    private void refreshFavoriteRoutesSection() {
+        if (binding == null) {
+            return;
+        }
+        if (!isPassengerLoggedIn()) {
+            binding.favoriteRoutesSection.setVisibility(View.GONE);
+            return;
+        }
+        // Always show manual entry card immediately; favorites append once fetched.
+        binding.favoriteRoutesSection.setVisibility(View.VISIBLE);
+        populateFavoriteRoutesCards();
+        if (passengerApiService != null && sessionManager != null) {
+            long passengerId = sessionManager.getUserId();
+            if (passengerId > 0) {
+                fetchFavoriteRoutes(passengerId);
+            }
+        }
     }
 
     private void closeEstimatePanel() {
@@ -1496,7 +1537,8 @@ public class LandingFragment extends Fragment {
         if (role == null || role.trim().isEmpty()) {
             return false;
         }
-        return "PASSENGER".equals(role.trim().toUpperCase());
+        String normalized = role.trim().toUpperCase(java.util.Locale.ENGLISH);
+        return "PASSENGER".equals(normalized) || "ROLE_PASSENGER".equals(normalized);
     }
 
     private void createRideFromEstimate() {
@@ -2023,6 +2065,173 @@ public class LandingFragment extends Fragment {
             return;
         }
         Snackbar.make(binding.getRoot(), messageResId, Snackbar.LENGTH_SHORT).show();
+    }
+
+    private void fetchFavoriteRoutes(long passengerId) {
+        if (passengerApiService == null || binding == null) {
+            return;
+        }
+        favoriteRoutes.clear();
+        passengerApiService.getFavoriteRoutes(passengerId).enqueue(new Callback<List<FavoriteRouteResponse>>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<List<FavoriteRouteResponse>> call,
+                @NonNull Response<List<FavoriteRouteResponse>> response
+            ) {
+                if (binding == null) {
+                    return;
+                }
+                if (response.isSuccessful() && response.body() != null) {
+                    favoriteRoutes.clear();
+                    favoriteRoutes.addAll(deduplicateFavoriteRoutes(response.body()));
+                }
+                populateFavoriteRoutesCards();
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<List<FavoriteRouteResponse>> call, @NonNull Throwable t) {
+                if (binding != null) {
+                    populateFavoriteRoutesCards();
+                }
+            }
+        });
+    }
+
+    /** Keep first occurrence of each route (by pickup + destination). Stops duplicates from API. */
+    private List<FavoriteRouteResponse> deduplicateFavoriteRoutes(List<FavoriteRouteResponse> list) {
+        if (list == null) return new ArrayList<>();
+        List<FavoriteRouteResponse> out = new ArrayList<>();
+        java.util.Set<String> seen = new java.util.LinkedHashSet<>();
+        for (FavoriteRouteResponse fav : list) {
+            String key = getFavoriteRouteKey(fav);
+            if (key.isEmpty() || seen.add(key)) {
+                out.add(fav);
+            }
+        }
+        return out;
+    }
+
+    private String getFavoriteRouteKey(FavoriteRouteResponse fav) {
+        if (fav == null || fav.waypoints == null || fav.waypoints.isEmpty()) return "";
+        List<FavoriteRouteWaypointResponse> sorted = new ArrayList<>(fav.waypoints);
+        sorted.sort(Comparator.comparingInt(w -> w.order != null ? w.order : 0));
+        String first = sorted.get(0).address != null ? sorted.get(0).address.trim() : "";
+        String last = sorted.get(sorted.size() - 1).address != null ? sorted.get(sorted.size() - 1).address.trim() : "";
+        return first + "|" + last;
+    }
+
+    private void populateFavoriteRoutesCards() {
+        if (binding == null || favoriteRouteDropdownAdapter == null) {
+            return;
+        }
+        favoriteRouteDropdownItems.clear();
+        favoriteRouteDropdownItems.addAll(deduplicateFavoriteRoutes(favoriteRoutes));
+        List<String> labels = new ArrayList<>();
+        labels.add(getString(R.string.order_enter_address_manually));
+        for (FavoriteRouteResponse fav : favoriteRouteDropdownItems) {
+            labels.add(getFavoriteLabel(fav));
+        }
+        favoriteRouteDropdownAdapter.clear();
+        favoriteRouteDropdownAdapter.addAll(labels);
+        favoriteRouteDropdownAdapter.notifyDataSetChanged();
+        String current = binding.favoriteRouteDropdown.getText() == null
+            ? ""
+            : binding.favoriteRouteDropdown.getText().toString();
+        if (current.trim().isEmpty() || !labels.contains(current)) {
+            binding.favoriteRouteDropdown.setText(labels.get(0), false);
+        }
+        binding.favoriteRoutesSection.setVisibility(View.VISIBLE);
+    }
+
+    private void onFavoriteRouteSelected(int position) {
+        if (position <= 0) {
+            clearFormForManual();
+            return;
+        }
+        int favoriteIndex = position - 1;
+        if (favoriteIndex >= 0 && favoriteIndex < favoriteRouteDropdownItems.size()) {
+            applyFavoriteRoute(favoriteRouteDropdownItems.get(favoriteIndex));
+        }
+    }
+
+    private String getFavoriteLabel(FavoriteRouteResponse fav) {
+        if (fav == null || fav.waypoints == null || fav.waypoints.isEmpty()) {
+            return "";
+        }
+        List<FavoriteRouteWaypointResponse> sorted = new ArrayList<>(fav.waypoints);
+        sorted.sort(Comparator.comparingInt(w -> w.order != null ? w.order : 0));
+        String first = sorted.get(0).address != null ? sorted.get(0).address : "";
+        String last = sorted.get(sorted.size() - 1).address != null ? sorted.get(sorted.size() - 1).address : "";
+        if (first.length() > 35) first = first.substring(0, 32) + "...";
+        if (last.length() > 35) last = last.substring(0, 32) + "...";
+        return first + " → " + last;
+    }
+
+    private void applyFavoriteRoute(FavoriteRouteResponse fav) {
+        if (binding == null || fav == null || fav.waypoints == null || fav.waypoints.size() < 2) {
+            return;
+        }
+        List<FavoriteRouteWaypointResponse> sorted = new ArrayList<>(fav.waypoints);
+        sorted.sort(Comparator.comparingInt(w -> w.order != null ? w.order : 0));
+
+        binding.pickupInput.setText(sorted.get(0).address != null ? sorted.get(0).address : "");
+        binding.destinationInput.setText(sorted.get(sorted.size() - 1).address != null
+            ? sorted.get(sorted.size() - 1).address : "");
+
+        for (Runnable r : stopAutocompleteRunnables.values()) {
+            autocompleteHandler.removeCallbacks(r);
+        }
+        stopAutocompleteRunnables.clear();
+        stopRows.clear();
+        binding.stopsContainer.removeAllViews();
+        for (int i = 1; i < sorted.size() - 1; i++) {
+            addStopRow();
+            View row = stopRows.get(stopRows.size() - 1);
+            if (row instanceof LinearLayout && ((LinearLayout) row).getChildCount() > 0) {
+                android.view.View first = ((LinearLayout) row).getChildAt(0);
+                if (first instanceof AutoCompleteTextView) {
+                    ((AutoCompleteTextView) first).setText(sorted.get(i).address != null ? sorted.get(i).address : "");
+                }
+            }
+        }
+
+        String vehicleTypeName = fav.vehicleTypeName != null ? fav.vehicleTypeName.toUpperCase() : "STANDARD";
+        String[] typeValues = getResources().getStringArray(R.array.landing_vehicle_type_values);
+        String[] labels = getResources().getStringArray(R.array.landing_vehicle_type_labels);
+        for (int i = 0; i < typeValues.length && i < labels.length; i++) {
+            if (vehicleTypeName.equals(typeValues[i])) {
+                binding.vehicleTypeDropdown.setText(labels[i], false);
+                break;
+            }
+        }
+
+        binding.babyTransportCheckbox.setChecked(Boolean.TRUE.equals(fav.babyTransport));
+        binding.petTransportCheckbox.setChecked(Boolean.TRUE.equals(fav.petTransport));
+
+        lastGeocodedWaypoints.clear();
+        lastEstimateResponse = null;
+    }
+
+    private void clearFormForManual() {
+        if (binding == null) {
+            return;
+        }
+        binding.pickupInput.setText("");
+        binding.destinationInput.setText("");
+        for (Runnable r : stopAutocompleteRunnables.values()) {
+            autocompleteHandler.removeCallbacks(r);
+        }
+        stopAutocompleteRunnables.clear();
+        stopRows.clear();
+        binding.stopsContainer.removeAllViews();
+        String[] vehicleLabels = getResources().getStringArray(R.array.landing_vehicle_type_labels);
+        if (vehicleLabels.length > 0) {
+            binding.vehicleTypeDropdown.setText(vehicleLabels[0], false);
+        }
+        binding.babyTransportCheckbox.setChecked(false);
+        binding.petTransportCheckbox.setChecked(false);
+        lastGeocodedWaypoints.clear();
+        lastEstimateResponse = null;
     }
 
     private void navigateTo(int destinationId) {

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/landing/LandingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/landing/LandingFragment.java
@@ -20,6 +20,9 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
+import android.widget.EditText;
+import android.widget.LinearLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -34,15 +37,20 @@ import com.drumigo.mobile.data.api.ApiClient;
 import com.drumigo.mobile.data.api.MapboxApiClient;
 import com.drumigo.mobile.data.api.MapboxDirectionsService;
 import com.drumigo.mobile.data.api.MapboxGeocodingService;
+import com.drumigo.mobile.data.api.MapboxSearchBoxService;
 import com.drumigo.mobile.data.api.RideApiService;
 import com.drumigo.mobile.data.api.VehicleApiService;
 import com.drumigo.mobile.data.model.VehicleResponse;
 import com.drumigo.mobile.data.model.estimate.EstimateRequest;
 import com.drumigo.mobile.data.model.estimate.EstimateResponse;
 import com.drumigo.mobile.data.model.estimate.LocationDto;
+import com.drumigo.mobile.data.model.ride.RideCreateRequest;
+import com.drumigo.mobile.data.model.ride.RideResponse;
 import com.drumigo.mobile.data.model.mapbox.MapboxDirectionsResponse;
 import com.drumigo.mobile.data.model.mapbox.MapboxGeocodingResponse;
+import com.drumigo.mobile.data.model.mapbox.MapboxSearchBoxSuggestResponse;
 import com.drumigo.mobile.databinding.FragmentLandingBinding;
+import com.drumigo.mobile.session.SessionManager;
 import com.drumigo.mobile.ui.map.VehicleMarkerBitmapFactory;
 import com.google.android.material.snackbar.Snackbar;
 import com.mapbox.common.MapboxOptions;
@@ -65,7 +73,10 @@ import com.mapbox.maps.plugin.scalebar.ScaleBarUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -79,7 +90,7 @@ public class LandingFragment extends Fragment {
     private static final String MAPBOX_STYLE_URI = "mapbox://styles/mapbox/streets-v12";
     private static final long VEHICLE_POLLING_INTERVAL_MS = 10_000L;
     private static final long AUTOCOMPLETE_DEBOUNCE_MS = 320L;
-    private static final int AUTOCOMPLETE_MIN_QUERY_LENGTH = 3;
+    private static final int AUTOCOMPLETE_MIN_QUERY_LENGTH = 2;
     private static final int AUTOCOMPLETE_LIMIT = 6;
     private static final long ROUTE_CAMERA_ANIMATION_MS = 1600L;
     private static final List<Double> ROUTE_LABEL_ICON_OFFSET = Arrays.asList(0.0, -2.3);
@@ -89,7 +100,10 @@ public class LandingFragment extends Fragment {
     private VehicleApiService vehicleApiService;
     private RideApiService rideApiService;
     private MapboxGeocodingService geocodingService;
+    private MapboxSearchBoxService searchBoxService;
+    private SessionManager sessionManager;
     private MapboxDirectionsService directionsService;
+    private String mapboxSessionToken;
 
     private boolean mapReady = false;
     private PointAnnotationManager pointAnnotationManager;
@@ -106,10 +120,20 @@ public class LandingFragment extends Fragment {
     private float panelDragStartY = 0f;
     private LocationDto estimatedStartLocation;
     private LocationDto estimatedDestinationLocation;
+    /** Geocoded waypoints [pickup, stop1, ..., destination] from last successful estimate, for create ride. */
+    private List<LocationDto> lastGeocodedWaypoints = new ArrayList<>();
+    private EstimateResponse lastEstimateResponse;
+    private int currentOrderStep = 1;
+    private int nextStopId = 0;
+    private int nextPassengerId = 0;
+    private final List<View> stopRows = new ArrayList<>();
+    private final List<View> passengerRows = new ArrayList<>();
     private ArrayAdapter<String> pickupSuggestionsAdapter;
     private ArrayAdapter<String> destinationSuggestionsAdapter;
     private int pickupAutocompleteToken = 0;
     private int destinationAutocompleteToken = 0;
+    private int stopAutocompleteToken = 0;
+    private final Map<AutoCompleteTextView, Runnable> stopAutocompleteRunnables = new HashMap<>();
     private int routeRequestToken = 0;
     private ValueAnimator routeCameraAnimator;
 
@@ -140,7 +164,10 @@ public class LandingFragment extends Fragment {
         vehicleApiService = ApiClient.getVehicleApiService();
         rideApiService = ApiClient.getRideApiService();
         geocodingService = MapboxApiClient.getGeocodingService();
+        searchBoxService = MapboxApiClient.getSearchBoxService();
         directionsService = MapboxApiClient.getDirectionsService();
+        mapboxSessionToken = UUID.randomUUID().toString();
+        sessionManager = SessionManager.getInstance(requireContext());
     }
 
     @Nullable
@@ -161,7 +188,29 @@ public class LandingFragment extends Fragment {
 
         setupHeaderActions();
         setupEstimatePanel();
+        // Open order/estimate panel by default so users always see where to order a ride
+        binding.getRoot().post(() -> {
+            if (binding != null && !estimatePanelOpen) {
+                openEstimatePanel();
+            }
+        });
+        if (isPassengerLoggedIn()) {
+            binding.btnEstimateLauncher.setText(R.string.landing_order_ride_launcher);
+        }
         setupMap();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Open order panel when fragment is visible (e.g. after login or "Order a Ride")
+        if (binding != null && !estimatePanelOpen) {
+            binding.getRoot().postDelayed(() -> {
+                if (binding != null && !estimatePanelOpen) {
+                    openEstimatePanel();
+                }
+            }, 80);
+        }
     }
 
     @Override
@@ -214,6 +263,14 @@ public class LandingFragment extends Fragment {
         }
         estimatedStartLocation = null;
         estimatedDestinationLocation = null;
+        lastGeocodedWaypoints = new ArrayList<>();
+        lastEstimateResponse = null;
+        for (Runnable r : stopAutocompleteRunnables.values()) {
+            autocompleteHandler.removeCallbacks(r);
+        }
+        stopAutocompleteRunnables.clear();
+        stopRows.clear();
+        passengerRows.clear();
         pickupSuggestionsAdapter = null;
         destinationSuggestionsAdapter = null;
         binding = null;
@@ -221,7 +278,7 @@ public class LandingFragment extends Fragment {
     }
 
     private void setupHeaderActions() {
-        binding.btnBookRide.setOnClickListener(v -> navigateTo(R.id.registrationFragment));
+        // Order flow uses btnContinueOrRequest in setupEstimatePanel
     }
 
     private void setupEstimatePanel() {
@@ -252,9 +309,14 @@ public class LandingFragment extends Fragment {
         binding.vehicleTypeDropdown.setKeyListener(null);
         binding.vehicleTypeDropdown.setOnClickListener(v -> binding.vehicleTypeDropdown.showDropDown());
 
-        binding.btnEstimate.setOnClickListener(v -> calculateEstimate());
         binding.btnEstimateLauncher.setOnClickListener(v -> openEstimatePanel());
         binding.btnCloseEstimatePanel.setOnClickListener(v -> closeEstimatePanel());
+        binding.btnAddStop.setOnClickListener(v -> addStopRow());
+        binding.btnAddPassenger.setOnClickListener(v -> addPassengerRow());
+        binding.btnBack.setOnClickListener(v -> onOrderBack());
+        binding.btnContinueOrRequest.setOnClickListener(v -> onContinueOrRequest());
+        binding.scheduleNow.setOnClickListener(v -> binding.scheduleLaterFields.setVisibility(View.GONE));
+        binding.scheduleLater.setOnClickListener(v -> binding.scheduleLaterFields.setVisibility(View.VISIBLE));
         setupPanelSwipeToClose();
         initializeEstimatePanel();
         updateActiveVehicleCount();
@@ -341,6 +403,73 @@ public class LandingFragment extends Fragment {
         }
         int token = isPickup ? ++pickupAutocompleteToken : ++destinationAutocompleteToken;
         String encodedQuery = Uri.encode(query);
+        // Try Search Box API first (same as frontend), then fall back to Geocoding
+        if (searchBoxService != null) {
+            searchBoxService.suggest(
+                query,
+                BuildConfig.MAPBOX_ACCESS_TOKEN,
+                mapboxSessionToken,
+                AUTOCOMPLETE_LIMIT,
+                "19.82,45.25"
+            ).enqueue(new Callback<MapboxSearchBoxSuggestResponse>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<MapboxSearchBoxSuggestResponse> call,
+                    @NonNull Response<MapboxSearchBoxSuggestResponse> response
+                ) {
+                    if (binding == null || !isLatestAutocompleteToken(token, isPickup)) {
+                        return;
+                    }
+                    List<String> suggestions = parseSearchBoxSuggestions(response);
+                    if (!suggestions.isEmpty()) {
+                        updateSuggestionAdapter(isPickup, suggestions);
+                        return;
+                    }
+                    fallbackFetchAddressSuggestionsGeocoding(encodedQuery, token, isPickup);
+                }
+
+                @Override
+                public void onFailure(
+                    @NonNull Call<MapboxSearchBoxSuggestResponse> call,
+                    @NonNull Throwable t
+                ) {
+                    if (binding == null || !isLatestAutocompleteToken(token, isPickup)) {
+                        return;
+                    }
+                    fallbackFetchAddressSuggestionsGeocoding(encodedQuery, token, isPickup);
+                }
+            });
+        } else {
+            fallbackFetchAddressSuggestionsGeocoding(encodedQuery, token, isPickup);
+        }
+    }
+
+    private List<String> parseSearchBoxSuggestions(Response<MapboxSearchBoxSuggestResponse> response) {
+        List<String> out = new ArrayList<>();
+        if (!response.isSuccessful() || response.body() == null || response.body().suggestions == null) {
+            return out;
+        }
+        for (MapboxSearchBoxSuggestResponse.Suggestion s : response.body().suggestions) {
+            if (s == null) continue;
+            String address = s.full_address != null && !s.full_address.trim().isEmpty()
+                ? s.full_address
+                : (s.name != null && !s.name.trim().isEmpty()
+                    ? s.name
+                    : (s.address != null && s.place_formatted != null
+                        ? s.address + ", " + s.place_formatted
+                        : (s.address != null ? s.address : (s.place_formatted != null ? s.place_formatted : ""))));
+            if (!address.trim().isEmpty()) {
+                out.add(address.trim());
+            }
+        }
+        return out;
+    }
+
+    private void fallbackFetchAddressSuggestionsGeocoding(String encodedQuery, int token, boolean isPickup) {
+        if (geocodingService == null) {
+            updateSuggestionAdapter(isPickup, new ArrayList<>());
+            return;
+        }
         geocodingService.searchAddressSuggestions(
             encodedQuery,
             true,
@@ -415,6 +544,116 @@ public class LandingFragment extends Fragment {
         }
     }
 
+    /**
+     * Fetch address suggestions for a stop row. Uses same Search Box + Geocoding fallback as pickup/destination.
+     */
+    private void fetchAddressSuggestions(String query, ArrayAdapter<String> adapter, AutoCompleteTextView view) {
+        if (adapter == null || view == null || geocodingService == null) {
+            return;
+        }
+        if (query.length() < AUTOCOMPLETE_MIN_QUERY_LENGTH) {
+            updateStopSuggestionAdapter(adapter, view, new ArrayList<>());
+            return;
+        }
+        int token = ++stopAutocompleteToken;
+        if (searchBoxService != null) {
+            searchBoxService.suggest(
+                query,
+                BuildConfig.MAPBOX_ACCESS_TOKEN,
+                mapboxSessionToken,
+                AUTOCOMPLETE_LIMIT,
+                "19.82,45.25"
+            ).enqueue(new Callback<MapboxSearchBoxSuggestResponse>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<MapboxSearchBoxSuggestResponse> call,
+                    @NonNull Response<MapboxSearchBoxSuggestResponse> response
+                ) {
+                    if (!isLatestStopAutocompleteToken(token)) return;
+                    List<String> suggestions = parseSearchBoxSuggestions(response);
+                    if (!suggestions.isEmpty()) {
+                        updateStopSuggestionAdapter(adapter, view, suggestions);
+                        return;
+                    }
+                    fallbackFetchAddressSuggestionsForStop(Uri.encode(query), token, adapter, view);
+                }
+
+                @Override
+                public void onFailure(
+                    @NonNull Call<MapboxSearchBoxSuggestResponse> call,
+                    @NonNull Throwable t
+                ) {
+                    if (!isLatestStopAutocompleteToken(token)) return;
+                    fallbackFetchAddressSuggestionsForStop(Uri.encode(query), token, adapter, view);
+                }
+            });
+        } else {
+            fallbackFetchAddressSuggestionsForStop(Uri.encode(query), token, adapter, view);
+        }
+    }
+
+    private boolean isLatestStopAutocompleteToken(int token) {
+        return token == stopAutocompleteToken;
+    }
+
+    private void updateStopSuggestionAdapter(
+        ArrayAdapter<String> adapter,
+        AutoCompleteTextView view,
+        List<String> suggestions
+    ) {
+        if (adapter == null || view == null) return;
+        adapter.clear();
+        adapter.addAll(suggestions);
+        adapter.notifyDataSetChanged();
+        if (suggestions.isEmpty()) {
+            view.dismissDropDown();
+        } else if (view.hasFocus()) {
+            view.showDropDown();
+        }
+    }
+
+    private void fallbackFetchAddressSuggestionsForStop(
+        String encodedQuery,
+        int token,
+        ArrayAdapter<String> adapter,
+        AutoCompleteTextView view
+    ) {
+        if (geocodingService == null) {
+            updateStopSuggestionAdapter(adapter, view, new ArrayList<>());
+            return;
+        }
+        geocodingService.searchAddressSuggestions(
+            encodedQuery,
+            true,
+            AUTOCOMPLETE_LIMIT,
+            "address,place,poi",
+            BuildConfig.MAPBOX_ACCESS_TOKEN
+        ).enqueue(new Callback<MapboxGeocodingResponse>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<MapboxGeocodingResponse> call,
+                @NonNull Response<MapboxGeocodingResponse> response
+            ) {
+                if (!isLatestStopAutocompleteToken(token)) return;
+                List<String> suggestions = new ArrayList<>();
+                if (response.isSuccessful() && response.body() != null && response.body().features != null) {
+                    for (MapboxGeocodingResponse.Feature feature : response.body().features) {
+                        if (feature == null || feature.place_name == null
+                            || feature.place_name.trim().isEmpty()) continue;
+                        suggestions.add(feature.place_name);
+                    }
+                }
+                updateStopSuggestionAdapter(adapter, view, suggestions);
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<MapboxGeocodingResponse> call, @NonNull Throwable t) {
+                if (!isLatestStopAutocompleteToken(token)) return;
+                updateStopSuggestionAdapter(adapter, view, new ArrayList<>());
+            }
+        });
+    }
+
     private void setupPanelSwipeToClose() {
         View.OnTouchListener dragListener = (v, event) -> {
             if (binding == null || !estimatePanelOpen) {
@@ -458,10 +697,26 @@ public class LandingFragment extends Fragment {
             return;
         }
         estimatePanelOpen = false;
+        currentOrderStep = 1;
+        nextStopId = 0;
+        nextPassengerId = 0;
+        for (Runnable r : stopAutocompleteRunnables.values()) {
+            autocompleteHandler.removeCallbacks(r);
+        }
+        stopAutocompleteRunnables.clear();
+        stopRows.clear();
+        passengerRows.clear();
+        lastGeocodedWaypoints = new ArrayList<>();
+        lastEstimateResponse = null;
         binding.estimatePanel.setVisibility(View.GONE);
         binding.btnEstimateLauncher.setVisibility(View.VISIBLE);
         binding.estimatePanel.setAlpha(1f);
         binding.estimatePanel.setTranslationY(0f);
+        binding.stopsContainer.removeAllViews();
+        binding.passengersContainer.removeAllViews();
+        binding.scheduleLaterFields.setVisibility(View.GONE);
+        binding.scheduleNow.setChecked(true);
+        updateStepVisibility();
     }
 
     private void openEstimatePanel() {
@@ -693,7 +948,12 @@ public class LandingFragment extends Fragment {
                 EstimateResponse estimateResponse = response.body();
                 estimatedStartLocation = startLocation;
                 estimatedDestinationLocation = destinationLocation;
-                showEstimateResult(estimateResponse);
+                lastGeocodedWaypoints = new ArrayList<>();
+                lastGeocodedWaypoints.add(startLocation);
+                lastGeocodedWaypoints.add(destinationLocation);
+                lastEstimateResponse = estimateResponse;
+                currentOrderStep = 2;
+                updateStepVisibility();
                 requestStreetRoute(
                     startLocation,
                     destinationLocation,
@@ -862,26 +1122,493 @@ public class LandingFragment extends Fragment {
             });
     }
 
-    private void showEstimateResult(EstimateResponse response) {
-        if (binding == null || response == null) {
+    private void updateStepVisibility() {
+        if (binding == null) {
             return;
         }
+        binding.step1Content.setVisibility(currentOrderStep == 1 ? View.VISIBLE : View.GONE);
+        binding.step2Content.setVisibility(currentOrderStep == 2 ? View.VISIBLE : View.GONE);
+        binding.step3Content.setVisibility(currentOrderStep == 3 ? View.VISIBLE : View.GONE);
+        binding.btnBack.setVisibility(currentOrderStep > 1 ? View.VISIBLE : View.GONE);
+        if (currentOrderStep == 3) {
+            binding.btnContinueOrRequest.setText(isPassengerLoggedIn() ? R.string.order_request_ride : R.string.landing_signup_cta);
+            fillConfirmStep();
+            boolean canRequest = isPassengerLoggedIn()
+                ? binding.termsCheckbox.isChecked()
+                : true;
+            binding.btnContinueOrRequest.setEnabled(canRequest);
+            binding.termsCheckbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                if (binding != null) {
+                    binding.btnContinueOrRequest.setEnabled(isPassengerLoggedIn() ? isChecked : true);
+                }
+            });
+        } else {
+            binding.btnContinueOrRequest.setText(R.string.order_continue);
+            binding.btnContinueOrRequest.setEnabled(true);
+            binding.termsCheckbox.setOnCheckedChangeListener(null);
+        }
+    }
 
-        int durationMinutes = response.durationInMinutes == null ? 0 : response.durationInMinutes;
-        double estimatedPrice = response.estimatedPrice == null ? 0.0 : response.estimatedPrice;
-        double distance = response.distanceInKm == null ? 0.0 : response.distanceInKm;
+    private void fillConfirmStep() {
+        if (binding == null || lastEstimateResponse == null || lastGeocodedWaypoints == null) {
+            return;
+        }
+        StringBuilder route = new StringBuilder();
+        for (int i = 0; i < lastGeocodedWaypoints.size(); i++) {
+            LocationDto wp = lastGeocodedWaypoints.get(i);
+            String addr = wp.address != null ? wp.address : "";
+            if (i == 0) {
+                route.append(getString(R.string.order_pickup)).append(": ").append(addr);
+            } else if (i == lastGeocodedWaypoints.size() - 1) {
+                route.append("\n").append(getString(R.string.order_dropoff)).append(": ").append(addr);
+            } else {
+                route.append("\n").append(getString(R.string.order_stop)).append(": ").append(addr);
+            }
+        }
+        binding.confirmRouteSummary.setText(route.toString());
+        int duration = lastEstimateResponse.durationInMinutes == null ? 0 : lastEstimateResponse.durationInMinutes;
+        double distance = lastEstimateResponse.distanceInKm == null ? 0.0 : lastEstimateResponse.distanceInKm;
+        String scheduled = getOrderScheduledNow() ? getString(R.string.order_scheduled_now) : getOrderScheduledTimeString();
+        binding.confirmDetails.setText(getString(R.string.order_vehicle_type) + ": " + getSelectedVehicleType()
+            + "\n" + getString(R.string.order_distance) + ": " + String.format("%.1f km", distance)
+            + "\n" + getString(R.string.order_duration) + ": ~" + duration + " min"
+            + "\n" + getString(R.string.order_scheduled) + ": " + scheduled);
+        double price = lastEstimateResponse.estimatedPrice == null ? 0.0 : lastEstimateResponse.estimatedPrice;
+        binding.confirmPrice.setText(getString(R.string.order_estimated_fare) + ": " + String.format("%.0f RSD", price));
+    }
 
-        binding.resultEtaValue.setText(getString(R.string.landing_estimate_eta_value_format, durationMinutes));
-        binding.resultPriceValue.setText(getString(R.string.landing_estimate_price_value_format, estimatedPrice));
-        binding.resultDistanceValue.setText(getString(R.string.landing_estimate_distance_value_format, distance));
-        binding.estimateResults.setVisibility(View.VISIBLE);
+    private void addStopRow() {
+        if (binding == null) {
+            return;
+        }
+        LinearLayout row = new LinearLayout(requireContext());
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setLayoutParams(new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT));
+        ((LinearLayout.LayoutParams) row.getLayoutParams()).topMargin = getResources().getDimensionPixelSize(R.dimen.spacing_xs);
+        AutoCompleteTextView input = new AutoCompleteTextView(requireContext());
+        input.setHint(R.string.order_stop_hint);
+        input.setInputType(android.text.InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS);
+        LinearLayout.LayoutParams inputLp = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+        input.setLayoutParams(inputLp);
+        ArrayAdapter<String> stopAdapter = new ArrayAdapter<>(
+            requireContext(),
+            android.R.layout.simple_dropdown_item_1line,
+            new ArrayList<>()
+        );
+        input.setAdapter(stopAdapter);
+        input.setOnItemClickListener((parent, view1, position, id) -> {
+            if (stopAdapter != null && position >= 0 && position < stopAdapter.getCount()) {
+                String item = stopAdapter.getItem(position);
+                if (item != null) input.setText(item);
+            }
+            input.dismissDropDown();
+        });
+        input.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {}
+            @Override
+            public void afterTextChanged(Editable s) {
+                Runnable previous = stopAutocompleteRunnables.remove(input);
+                if (previous != null) {
+                    autocompleteHandler.removeCallbacks(previous);
+                }
+                Runnable runnable = () -> {
+                    stopAutocompleteRunnables.remove(input);
+                    String query = input.getText() == null ? "" : input.getText().toString().trim();
+                    fetchAddressSuggestions(query, stopAdapter, input);
+                };
+                stopAutocompleteRunnables.put(input, runnable);
+                autocompleteHandler.postDelayed(runnable, AUTOCOMPLETE_DEBOUNCE_MS);
+            }
+        });
+        android.widget.ImageButton removeBtn = new android.widget.ImageButton(requireContext());
+        removeBtn.setImageResource(android.R.drawable.ic_menu_close_clear_cancel);
+        removeBtn.setBackground(null);
+        removeBtn.setOnClickListener(v -> {
+            stopAutocompleteRunnables.remove(input);
+            if (binding != null) binding.stopsContainer.removeView(row);
+            stopRows.remove(row);
+        });
+        row.addView(input);
+        row.addView(removeBtn);
+        binding.stopsContainer.addView(row);
+        stopRows.add(row);
+    }
+
+    private void addPassengerRow() {
+        if (binding == null) {
+            return;
+        }
+        if (getPassengerCount() >= getVehicleCapacity()) {
+            return;
+        }
+        LinearLayout row = new LinearLayout(requireContext());
+        row.setOrientation(LinearLayout.HORIZONTAL);
+        row.setLayoutParams(new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT));
+        ((LinearLayout.LayoutParams) row.getLayoutParams()).topMargin = getResources().getDimensionPixelSize(R.dimen.spacing_xs);
+        EditText input = new EditText(requireContext());
+        input.setHint(R.string.order_passenger_email_hint);
+        input.setInputType(android.text.InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        LinearLayout.LayoutParams inputLp = new LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f);
+        input.setLayoutParams(inputLp);
+        android.widget.ImageButton removeBtn = new android.widget.ImageButton(requireContext());
+        removeBtn.setImageResource(android.R.drawable.ic_menu_close_clear_cancel);
+        removeBtn.setBackground(null);
+        removeBtn.setOnClickListener(v -> {
+            binding.passengersContainer.removeView(row);
+            passengerRows.remove(row);
+        });
+        row.addView(input);
+        row.addView(removeBtn);
+        binding.passengersContainer.addView(row);
+        passengerRows.add(row);
+    }
+
+    private int getPassengerCount() {
+        return passengerRows.size();
+    }
+
+    private int getVehicleCapacity() {
+        String vt = getSelectedVehicleType();
+        if ("VAN".equalsIgnoreCase(vt)) {
+            return 6;
+        }
+        return 3;
+    }
+
+    private void onOrderBack() {
+        if (currentOrderStep > 1) {
+            currentOrderStep--;
+            updateStepVisibility();
+        }
+    }
+
+    private void onContinueOrRequest() {
+        if (binding == null) {
+            return;
+        }
+        if (currentOrderStep == 1) {
+            runStep1Continue();
+        } else if (currentOrderStep == 2) {
+            if (!isStep2Valid()) {
+                showEstimateError(R.string.landing_estimate_failed);
+                return;
+            }
+            currentOrderStep = 3;
+            updateStepVisibility();
+        } else if (currentOrderStep == 3) {
+            if (!binding.termsCheckbox.isChecked()) {
+                showEstimateError(R.string.landing_estimate_failed);
+                return;
+            }
+            if (isPassengerLoggedIn()) {
+                createRideFromEstimate();
+            } else {
+                navigateTo(R.id.registrationFragment);
+            }
+        }
+    }
+
+    private boolean isStep2Valid() {
+        if (binding == null) {
+            return true;
+        }
+        if (binding.scheduleNow.isChecked()) {
+            return true;
+        }
+        int hours = 0;
+        int minutes = 0;
+        try {
+            if (binding.scheduleHoursInput.getText() != null && binding.scheduleHoursInput.getText().length() > 0) {
+                hours = Integer.parseInt(binding.scheduleHoursInput.getText().toString());
+            }
+            if (binding.scheduleMinutesInput.getText() != null && binding.scheduleMinutesInput.getText().length() > 0) {
+                minutes = Integer.parseInt(binding.scheduleMinutesInput.getText().toString());
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        int totalMinutes = hours * 60 + minutes;
+        return totalMinutes > 0 && totalMinutes <= 300;
+    }
+
+    private void runStep1Continue() {
+        if (binding == null) {
+            return;
+        }
+        String pickup = binding.pickupInput.getText() == null ? "" : binding.pickupInput.getText().toString().trim();
+        String destination = binding.destinationInput.getText() == null ? "" : binding.destinationInput.getText().toString().trim();
+        if (pickup.isEmpty() || destination.isEmpty()) {
+            showEstimateError(R.string.landing_locations_required);
+            return;
+        }
+        List<String> stopAddresses = new ArrayList<>();
+        for (View row : stopRows) {
+            if (row instanceof LinearLayout) {
+                for (int i = 0; i < ((LinearLayout) row).getChildCount(); i++) {
+                    View child = ((LinearLayout) row).getChildAt(i);
+                    if (child instanceof EditText) {
+                        String t = ((EditText) child).getText() == null ? "" : ((EditText) child).getText().toString().trim();
+                        if (!t.isEmpty()) {
+                            stopAddresses.add(t);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        setEstimateLoading(true);
+        geocodeAllWaypoints(pickup, stopAddresses, destination, 0, new ArrayList<>(), new GeocodeAllCallback() {
+            @Override
+            public void onSuccess(List<LocationDto> waypoints) {
+                lastGeocodedWaypoints = waypoints;
+                requestEstimateWithWaypoints(waypoints);
+            }
+
+            @Override
+            public void onFailure() {
+                setEstimateLoading(false);
+                showEstimateError(R.string.landing_geocode_failed);
+            }
+        });
+    }
+
+    private interface GeocodeAllCallback {
+        void onSuccess(List<LocationDto> waypoints);
+        void onFailure();
+    }
+
+    private void geocodeAllWaypoints(String pickup, List<String> stopAddresses, String destination,
+                                     int index, List<LocationDto> accumulated, GeocodeAllCallback callback) {
+        String address = index == 0 ? pickup : (index <= stopAddresses.size() ? stopAddresses.get(index - 1) : destination);
+        geocodeAddress(address, new GeocodeCallback() {
+            @Override
+            public void onSuccess(LocationDto location) {
+                accumulated.add(location);
+                int next = index + 1;
+                if (next > stopAddresses.size() + 1) {
+                    callback.onSuccess(accumulated);
+                } else {
+                    geocodeAllWaypoints(pickup, stopAddresses, destination, next, accumulated, callback);
+                }
+            }
+
+            @Override
+            public void onFailure() {
+                callback.onFailure();
+            }
+        });
+    }
+
+    private void requestEstimateWithWaypoints(List<LocationDto> waypoints) {
+        if (waypoints.size() < 2 || rideApiService == null) {
+            setEstimateLoading(false);
+            showEstimateError(R.string.landing_estimate_failed);
+            return;
+        }
+        LocationDto start = waypoints.get(0);
+        LocationDto end = waypoints.get(waypoints.size() - 1);
+        List<LocationDto> middle = waypoints.size() > 2
+            ? new ArrayList<>(waypoints.subList(1, waypoints.size() - 1))
+            : new ArrayList<>();
+        EstimateRequest request = new EstimateRequest(start, end, middle, getSelectedVehicleType());
+        rideApiService.estimateRide(request).enqueue(new Callback<EstimateResponse>() {
+            @Override
+            public void onResponse(@NonNull Call<EstimateResponse> call, @NonNull Response<EstimateResponse> response) {
+                setEstimateLoading(false);
+                if (binding == null || !response.isSuccessful() || response.body() == null) {
+                    showEstimateError(R.string.landing_estimate_failed);
+                    return;
+                }
+                lastEstimateResponse = response.body();
+                currentOrderStep = 2;
+                updateStepVisibility();
+                requestStreetRouteFromWaypoints(waypoints, lastEstimateResponse.routeCoordinates);
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<EstimateResponse> call, @NonNull Throwable t) {
+                setEstimateLoading(false);
+                showEstimateError(R.string.landing_estimate_failed);
+            }
+        });
+    }
+
+    private void requestStreetRouteFromWaypoints(List<LocationDto> waypoints,
+                                                 List<List<Double>> fallbackCoordinates) {
+        if (waypoints.size() < 2) {
+            applyRouteCoordinates(fallbackCoordinates == null ? Collections.emptyList() : fallbackCoordinates, ++routeRequestToken);
+            return;
+        }
+        StringBuilder coords = new StringBuilder();
+        for (int i = 0; i < waypoints.size(); i++) {
+            LocationDto wp = waypoints.get(i);
+            if (wp != null && wp.longitude != null && wp.latitude != null) {
+                if (coords.length() > 0) coords.append(";");
+                coords.append(wp.longitude).append(",").append(wp.latitude);
+            }
+        }
+        if (coords.length() == 0) {
+            applyRouteCoordinates(fallbackCoordinates == null ? Collections.emptyList() : fallbackCoordinates, ++routeRequestToken);
+            return;
+        }
+        int requestToken = ++routeRequestToken;
+        fetchDirectionsWithProfile(
+            "driving-traffic",
+            coords.toString(),
+            fallbackCoordinates == null ? Collections.emptyList() : fallbackCoordinates,
+            requestToken,
+            true
+        );
+    }
+
+    private boolean getOrderScheduledNow() {
+        return binding != null && binding.scheduleNow.isChecked();
+    }
+
+    private String getOrderScheduledTimeString() {
+        if (binding == null) return getString(R.string.order_scheduled_now);
+        int h = 0;
+        int m = 0;
+        try {
+            if (binding.scheduleHoursInput.getText() != null && binding.scheduleHoursInput.getText().length() > 0) {
+                h = Integer.parseInt(binding.scheduleHoursInput.getText().toString());
+            }
+            if (binding.scheduleMinutesInput.getText() != null && binding.scheduleMinutesInput.getText().length() > 0) {
+                m = Integer.parseInt(binding.scheduleMinutesInput.getText().toString());
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        return h + "h " + m + "m from now";
+    }
+
+    private boolean isPassengerLoggedIn() {
+        if (sessionManager == null || !sessionManager.isAuthenticated()) {
+            return false;
+        }
+        String role = sessionManager.getRole();
+        if (role == null || role.trim().isEmpty()) {
+            return false;
+        }
+        return "PASSENGER".equals(role.trim().toUpperCase());
+    }
+
+    private void createRideFromEstimate() {
+        if (binding == null || rideApiService == null || sessionManager == null) {
+            return;
+        }
+        if (lastGeocodedWaypoints == null || lastGeocodedWaypoints.size() < 2) {
+            showEstimateError(R.string.landing_locations_required);
+            return;
+        }
+        List<RideCreateRequest.WaypointRequest> waypoints = new ArrayList<>();
+        for (int i = 0; i < lastGeocodedWaypoints.size(); i++) {
+            LocationDto wp = lastGeocodedWaypoints.get(i);
+            if (wp == null || wp.latitude == null || wp.longitude == null) continue;
+            waypoints.add(new RideCreateRequest.WaypointRequest(
+                wp.address != null ? wp.address : "",
+                wp.latitude,
+                wp.longitude,
+                i + 1
+            ));
+        }
+        if (waypoints.isEmpty()) {
+            showEstimateError(R.string.landing_estimate_failed);
+            return;
+        }
+        RideCreateRequest request = new RideCreateRequest();
+        request.waypoints = waypoints;
+        request.vehicleType = getSelectedVehicleType();
+        request.babyTransport = binding.babyTransportCheckbox.isChecked();
+        request.petTransport = binding.petTransportCheckbox.isChecked();
+        request.linkedPassengerEmails = getLinkedPassengerEmails();
+        request.scheduledFor = getOrderScheduledNow() ? null : computeScheduledForIso();
+
+        binding.btnContinueOrRequest.setEnabled(false);
+        rideApiService.createRide(request).enqueue(new Callback<RideResponse>() {
+            @Override
+            public void onResponse(
+                @NonNull Call<RideResponse> call,
+                @NonNull Response<RideResponse> response
+            ) {
+                if (binding == null) {
+                    return;
+                }
+                binding.btnContinueOrRequest.setEnabled(true);
+                if (!response.isSuccessful() || response.body() == null) {
+                    showEstimateError(R.string.landing_estimate_failed);
+                    return;
+                }
+                RideResponse ride = response.body();
+                if (ride.id == null) {
+                    showEstimateError(R.string.landing_estimate_failed);
+                    return;
+                }
+                NavController navController = NavHostFragment.findNavController(LandingFragment.this);
+                Bundle args = new Bundle();
+                args.putLong("rideId", ride.id);
+                navController.navigate(R.id.rideTrackingFragment, args);
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<RideResponse> call, @NonNull Throwable t) {
+                if (binding != null) {
+                    binding.btnContinueOrRequest.setEnabled(true);
+                }
+                showEstimateError(R.string.landing_estimate_failed);
+            }
+        });
+    }
+
+    private List<String> getLinkedPassengerEmails() {
+        List<String> list = new ArrayList<>();
+        for (View row : passengerRows) {
+            if (row instanceof LinearLayout) {
+                for (int i = 0; i < ((LinearLayout) row).getChildCount(); i++) {
+                    View child = ((LinearLayout) row).getChildAt(i);
+                    if (child instanceof EditText) {
+                        String email = ((EditText) child).getText() == null ? "" : ((EditText) child).getText().toString().trim();
+                        if (!email.isEmpty()) {
+                            list.add(email);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return list.isEmpty() ? null : list;
+    }
+
+    private String computeScheduledForIso() {
+        if (binding == null) return null;
+        int h = 0;
+        int m = 0;
+        try {
+            if (binding.scheduleHoursInput.getText() != null && binding.scheduleHoursInput.getText().length() > 0) {
+                h = Integer.parseInt(binding.scheduleHoursInput.getText().toString());
+            }
+            if (binding.scheduleMinutesInput.getText() != null && binding.scheduleMinutesInput.getText().length() > 0) {
+                m = Integer.parseInt(binding.scheduleMinutesInput.getText().toString());
+            }
+        } catch (NumberFormatException ignored) {
+        }
+        long millis = System.currentTimeMillis() + (h * 3600L + m * 60L) * 1000L;
+        return new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US) {
+            { setTimeZone(java.util.TimeZone.getTimeZone("UTC")); }
+        }.format(new java.util.Date(millis));
     }
 
     private void setEstimateLoading(boolean loading) {
         if (binding == null) {
             return;
         }
-        binding.btnEstimate.setEnabled(!loading);
+        binding.btnContinueOrRequest.setEnabled(!loading);
         binding.estimateProgress.setVisibility(loading ? View.VISIBLE : View.GONE);
     }
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideInconsistencyBottomSheet.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideInconsistencyBottomSheet.java
@@ -1,0 +1,157 @@
+package com.drumigo.mobile.ui.ride;
+
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.api.RideApiService;
+import com.drumigo.mobile.data.model.ride.RideInconsistencyCreateRequest;
+import com.drumigo.mobile.data.model.ride.RideInconsistencyResponse;
+import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputEditText;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+final class RideInconsistencyBottomSheet {
+
+    private static final int MIN_NOTE_LENGTH = 10;
+
+    interface CallbackHandler {
+        void onReportSubmitted();
+    }
+
+    private final Context context;
+    private final RideApiService rideApiService;
+    private final long rideId;
+    private final CallbackHandler callbackHandler;
+
+    private BottomSheetDialog dialog;
+    private TextInputEditText noteInput;
+    private TextView errorText;
+    private MaterialButton submitButton;
+    private boolean submitting;
+
+    private RideInconsistencyBottomSheet(
+        @NonNull Context context,
+        @NonNull RideApiService rideApiService,
+        long rideId,
+        @NonNull CallbackHandler callbackHandler
+    ) {
+        this.context = context;
+        this.rideApiService = rideApiService;
+        this.rideId = rideId;
+        this.callbackHandler = callbackHandler;
+    }
+
+    static void show(
+        @NonNull Context context,
+        @NonNull RideApiService rideApiService,
+        long rideId,
+        @NonNull CallbackHandler callbackHandler
+    ) {
+        new RideInconsistencyBottomSheet(context, rideApiService, rideId, callbackHandler).showInternal();
+    }
+
+    private void showInternal() {
+        dialog = new BottomSheetDialog(context);
+        dialog.setContentView(R.layout.bottom_sheet_ride_inconsistency);
+        dialog.setDismissWithAnimation(true);
+
+        noteInput = dialog.findViewById(R.id.inconsistencyNoteInput);
+        errorText = dialog.findViewById(R.id.inconsistencyErrorText);
+        submitButton = dialog.findViewById(R.id.inconsistencySubmitButton);
+        View closeButton = dialog.findViewById(R.id.inconsistencyCloseButton);
+
+        if (closeButton != null) {
+            closeButton.setOnClickListener(v -> dismiss());
+        }
+        if (submitButton != null) {
+            submitButton.setOnClickListener(v -> onSubmit());
+        }
+
+        dialog.setOnShowListener(ignored -> {
+            if (dialog != null) {
+                View bottomSheet = dialog.findViewById(com.google.android.material.R.id.design_bottom_sheet);
+                if (bottomSheet != null) {
+                    BottomSheetBehavior.from(bottomSheet).setState(BottomSheetBehavior.STATE_EXPANDED);
+                }
+            }
+        });
+        dialog.show();
+    }
+
+    private void onSubmit() {
+        if (submitting || noteInput == null || submitButton == null || errorText == null) {
+            return;
+        }
+        String note = noteInput.getText() != null ? noteInput.getText().toString().trim() : "";
+        if (note.length() < MIN_NOTE_LENGTH) {
+            errorText.setText(context.getString(R.string.ride_tracking_inconsistency_note_too_short, MIN_NOTE_LENGTH));
+            errorText.setVisibility(View.VISIBLE);
+            return;
+        }
+        errorText.setVisibility(View.GONE);
+        submitting = true;
+        submitButton.setEnabled(false);
+        submitButton.setText(R.string.ride_tracking_inconsistency_submitting);
+
+        rideApiService.reportInconsistency(rideId, new RideInconsistencyCreateRequest(note))
+            .enqueue(new Callback<RideInconsistencyResponse>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<RideInconsistencyResponse> call,
+                    @NonNull Response<RideInconsistencyResponse> response
+                ) {
+                    if (dialog == null) {
+                        return;
+                    }
+                    submitting = false;
+                    if (submitButton != null) {
+                        submitButton.setEnabled(true);
+                        submitButton.setText(R.string.ride_tracking_inconsistency_submit);
+                    }
+                    if (response.isSuccessful()) {
+                        if (callbackHandler != null) {
+                            callbackHandler.onReportSubmitted();
+                        }
+                        dismiss();
+                    } else {
+                        if (errorText != null) {
+                            errorText.setText(R.string.ride_tracking_inconsistency_failed);
+                            errorText.setVisibility(View.VISIBLE);
+                        }
+                    }
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<RideInconsistencyResponse> call, @NonNull Throwable t) {
+                    if (dialog == null) {
+                        return;
+                    }
+                    submitting = false;
+                    if (submitButton != null) {
+                        submitButton.setEnabled(true);
+                        submitButton.setText(R.string.ride_tracking_inconsistency_submit);
+                    }
+                    if (errorText != null) {
+                        errorText.setText(R.string.ride_tracking_inconsistency_failed);
+                        errorText.setVisibility(View.VISIBLE);
+                    }
+                }
+            });
+    }
+
+    private void dismiss() {
+        if (dialog != null) {
+            dialog.dismiss();
+            dialog = null;
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
@@ -1,5 +1,6 @@
 package com.drumigo.mobile.ui.ride;
 
+import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
@@ -11,12 +12,15 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
 
 import com.drumigo.mobile.BuildConfig;
 import com.drumigo.mobile.R;
@@ -36,6 +40,7 @@ import com.drumigo.mobile.data.model.ride.LocationUpdate;
 import com.drumigo.mobile.data.model.ride.RideResponse;
 import com.drumigo.mobile.data.model.ride.RideTrackingResponse;
 import com.drumigo.mobile.data.model.ride.RoutePoint;
+import com.drumigo.mobile.ui.history.RideHistoryActivity;
 import com.drumigo.mobile.session.SessionManager;
 import com.drumigo.mobile.databinding.FragmentRideTrackingBinding;
 import com.google.android.material.snackbar.Snackbar;
@@ -80,6 +85,10 @@ public class RideTrackingFragment extends Fragment {
     private static final int MAPBOX_MAX_ROUTE_POINTS = 25;
     private static final double COORD_TOLERANCE = 1e-8;
     private static final double EARTH_RADIUS_METERS = 6_371_000.0;
+    private static final double MIN_FORWARD_MOVE_METERS = 8.0;
+    private static final double MAX_FORWARD_MOVE_METERS = 90.0;
+    private static final double DEFAULT_FORWARD_MOVE_METERS = 20.0;
+    private static final double MAX_PROJECTION_CATCHUP_METERS = 60.0;
     private static final long PANEL_SHOW_ANIMATION_MS = 240L;
     private static final long PANEL_HIDE_ANIMATION_MS = 200L;
 
@@ -101,6 +110,9 @@ public class RideTrackingFragment extends Fragment {
 
     private ActiveRide activeRide;
     private List<RoutePoint> renderedRoute = new ArrayList<>();
+    private double[] routeCumulativeDistancesMeters = new double[0];
+    private double routeProgressMeters = 0.0;
+    private RoutePoint lastBackendLocation = null;
     private String currentRoleNormalized = "";
     private long rideId;
     private boolean pendingActiveRideLookup = false;
@@ -112,6 +124,10 @@ public class RideTrackingFragment extends Fragment {
     private float panelDragStartY = 0f;
     private long lastRouteRequestAt = 0L;
     private int routeRequestToken = 0;
+    private Long nextScheduledRideId = null;
+    private String nextRideOrigin = "";
+    private String nextRideDestination = "";
+    private String nextRideScheduledFor = null;
     private final Handler pollingHandler = new Handler(Looper.getMainLooper());
     private final Runnable backendPollingRunnable = new Runnable() {
         @Override
@@ -224,11 +240,20 @@ public class RideTrackingFragment extends Fragment {
     }
 
     private void setupActions() {
-        View.OnClickListener notImplementedListener = v -> showNotImplemented();
+        binding.btnStartRide.setOnClickListener(v -> onStartRide());
         binding.btnCancelRide.setOnClickListener(v -> openCancelRideSheet());
         binding.btnStopRide.setOnClickListener(v -> openStopRideSheet());
+        binding.btnEndRide.setOnClickListener(v -> onEndRide());
         binding.btnPanic.setOnClickListener(v -> openPanicSheet());
-        binding.btnReportIssue.setOnClickListener(notImplementedListener);
+        binding.btnReportIssue.setOnClickListener(v -> openInconsistencySheet());
+        if (binding.nextRideCard != null) {
+            if (binding.btnOpenNextRide != null) {
+                binding.btnOpenNextRide.setOnClickListener(v -> navigateToNextRide());
+            }
+            if (binding.btnViewUpcoming != null) {
+                binding.btnViewUpcoming.setOnClickListener(v -> openRideHistory());
+            }
+        }
         applyActionVisibility();
     }
 
@@ -380,6 +405,45 @@ public class RideTrackingFragment extends Fragment {
                 applyRide(updated);
                 requestRouteIfNeeded(true);
                 Snackbar.make(binding.getRoot(), R.string.ride_tracking_stop_success, Snackbar.LENGTH_SHORT).show();
+                if (isDriverRole()) {
+                    openRideHistory();
+                }
+            }
+        );
+    }
+
+    private void openInconsistencySheet() {
+        if (binding == null || getContext() == null || rideApiService == null) {
+            return;
+        }
+        if (!isPassengerRole()) {
+            return;
+        }
+        if (pendingActiveRideLookup || rideId == 0L) {
+            resolveActiveRideAndStartTracking();
+            Snackbar.make(binding.getRoot(), R.string.ride_tracking_loading_active_ride, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+        if (activeRide == null) {
+            Snackbar.make(binding.getRoot(), R.string.ride_tracking_load_failed, Snackbar.LENGTH_SHORT).show();
+            return;
+        }
+        if (!isRideActiveStatus(getRideStatusLabel())) {
+            Snackbar.make(
+                binding.getRoot(),
+                getString(R.string.ride_tracking_inconsistency_failed),
+                Snackbar.LENGTH_SHORT
+            ).show();
+            return;
+        }
+        RideInconsistencyBottomSheet.show(
+            requireContext(),
+            rideApiService,
+            rideId,
+            () -> {
+                if (binding != null) {
+                    Snackbar.make(binding.getRoot(), R.string.ride_tracking_inconsistency_success, Snackbar.LENGTH_SHORT).show();
+                }
             }
         );
     }
@@ -415,6 +479,204 @@ public class RideTrackingFragment extends Fragment {
                 Snackbar.make(binding.getRoot(), R.string.ride_tracking_cancel_success, Snackbar.LENGTH_SHORT).show();
             }
         );
+    }
+
+    private void onStartRide() {
+        if (binding == null || rideApiService == null || rideId == 0L) {
+            return;
+        }
+        if (!isDriverRole()) {
+            return;
+        }
+        String status = getRideStatusLabel();
+        if (!"ACCEPTED".equals(normalizeRideStatus(status))) {
+            Snackbar.make(
+                binding.getRoot(),
+                getString(R.string.ride_tracking_start_accepted_only, status),
+                Snackbar.LENGTH_SHORT
+            ).show();
+            return;
+        }
+        binding.btnStartRide.setEnabled(false);
+        binding.btnStartRide.setText(R.string.ride_tracking_start_ride_loading);
+        rideApiService.startRide(rideId).enqueue(new Callback<RideResponse>() {
+            @Override
+            public void onResponse(@NonNull Call<RideResponse> call, @NonNull Response<RideResponse> response) {
+                if (binding == null) {
+                    return;
+                }
+                binding.btnStartRide.setEnabled(true);
+                binding.btnStartRide.setText(R.string.ride_tracking_start_ride);
+                if (response.isSuccessful()) {
+                    Snackbar.make(binding.getRoot(), R.string.ride_tracking_start_success, Snackbar.LENGTH_SHORT).show();
+                    fetchRideTracking();
+                } else {
+                    Snackbar.make(binding.getRoot(), R.string.ride_tracking_start_failed, Snackbar.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<RideResponse> call, @NonNull Throwable t) {
+                if (binding == null) {
+                    return;
+                }
+                binding.btnStartRide.setEnabled(true);
+                binding.btnStartRide.setText(R.string.ride_tracking_start_ride);
+                Snackbar.make(binding.getRoot(), R.string.ride_tracking_start_failed, Snackbar.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void onEndRide() {
+        if (binding == null || rideApiService == null || rideId == 0L) {
+            return;
+        }
+        if (!isDriverRole()) {
+            return;
+        }
+        String status = getRideStatusLabel();
+        if (!isRideActiveStatus(status)) {
+            Snackbar.make(
+                binding.getRoot(),
+                getString(R.string.ride_tracking_end_active_only, status),
+                Snackbar.LENGTH_SHORT
+            ).show();
+            return;
+        }
+        binding.btnEndRide.setEnabled(false);
+        binding.btnEndRide.setText(R.string.ride_tracking_end_ride_loading);
+        rideApiService.endRide(rideId).enqueue(new Callback<RideResponse>() {
+            @Override
+            public void onResponse(@NonNull Call<RideResponse> call, @NonNull Response<RideResponse> response) {
+                if (binding == null) {
+                    return;
+                }
+                binding.btnEndRide.setEnabled(true);
+                binding.btnEndRide.setText(R.string.ride_tracking_end_ride);
+                if (response.isSuccessful()) {
+                    stopTracking();
+                    if (activeRide != null) {
+                        activeRide.status = "FINISHED";
+                        applyRide(activeRide);
+                    }
+                    clearRouteAndMapForFinishedRide();
+                    updateCompletionState();
+                    loadUpcomingRidesForDriver();
+                    Snackbar.make(binding.getRoot(), R.string.ride_tracking_end_success, Snackbar.LENGTH_SHORT).show();
+                } else {
+                    Snackbar.make(binding.getRoot(), R.string.ride_tracking_end_failed, Snackbar.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<RideResponse> call, @NonNull Throwable t) {
+                if (binding == null) {
+                    return;
+                }
+                binding.btnEndRide.setEnabled(true);
+                binding.btnEndRide.setText(R.string.ride_tracking_end_ride);
+                Snackbar.make(binding.getRoot(), R.string.ride_tracking_end_failed, Snackbar.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void loadUpcomingRidesForDriver() {
+        if (!isDriverRole() || sessionManager == null || driverApiService == null) {
+            return;
+        }
+        long driverId = sessionManager.getUserId();
+        if (driverId <= 0L) {
+            return;
+        }
+        driverApiService.getUpcomingDriverRides(driverId, null, 0, 5, "scheduledFor,asc")
+            .enqueue(new Callback<PageResponse<RideResponse>>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<PageResponse<RideResponse>> call,
+                    @NonNull Response<PageResponse<RideResponse>> response
+                ) {
+                    if (!response.isSuccessful() || response.body() == null || response.body().content == null) {
+                        return;
+                    }
+                    List<RideResponse> content = response.body().content;
+                    if (content.isEmpty()) {
+                        return;
+                    }
+                    RideResponse nextRide = content.get(0);
+                    if (nextRide == null || nextRide.id == null) {
+                        return;
+                    }
+                    nextScheduledRideId = nextRide.id;
+                    nextRideOrigin = waypointAddress(nextRide, 0);
+                    nextRideDestination = waypointAddress(nextRide, -1);
+                    nextRideScheduledFor = nextRide.scheduledFor;
+                    showNextRideCard();
+                }
+
+                @Override
+                public void onFailure(@NonNull Call<PageResponse<RideResponse>> call, @NonNull Throwable t) {
+                    // ignore
+                }
+            });
+    }
+
+    private String waypointAddress(RideResponse ride, int index) {
+        if (ride == null || ride.waypoints == null || ride.waypoints.isEmpty()) {
+            return "";
+        }
+        int i = index < 0 ? ride.waypoints.size() + index : index;
+        if (i < 0 || i >= ride.waypoints.size()) {
+            return "";
+        }
+        RideResponse.WaypointInfo wp = ride.waypoints.get(i);
+        return wp != null && wp.address != null ? wp.address : "";
+    }
+
+    private void showNextRideCard() {
+        if (binding == null || binding.nextRideCard == null) {
+            return;
+        }
+        if (nextScheduledRideId == null) {
+            binding.nextRideCard.setVisibility(View.GONE);
+            return;
+        }
+        if (binding.nextRideOrigin != null) {
+            binding.nextRideOrigin.setText(nextRideOrigin != null ? nextRideOrigin : "");
+        }
+        if (binding.nextRideDestination != null) {
+            binding.nextRideDestination.setText(nextRideDestination != null ? nextRideDestination : "");
+        }
+        if (binding.nextRideScheduled != null) {
+            binding.nextRideScheduled.setText(formatScheduledTime(nextRideScheduledFor));
+        }
+        binding.nextRideCard.setVisibility(View.VISIBLE);
+    }
+
+    private String formatScheduledTime(String iso8601) {
+        if (iso8601 == null || iso8601.trim().isEmpty()) {
+            return getString(R.string.ride_tracking_no_upcoming);
+        }
+        try {
+            java.time.Instant instant = java.time.Instant.parse(iso8601);
+            java.time.ZonedDateTime zdt = instant.atZone(java.time.ZoneId.systemDefault());
+            return java.time.format.DateTimeFormatter.ofPattern("MMM d, h:mm a").format(zdt);
+        } catch (Exception e) {
+            return iso8601;
+        }
+    }
+
+    private void navigateToNextRide() {
+        if (nextScheduledRideId == null) {
+            return;
+        }
+        NavController nav = Navigation.findNavController(requireView());
+        Bundle args = new Bundle();
+        args.putLong(ARG_RIDE_ID, nextScheduledRideId);
+        nav.navigate(R.id.rideTrackingFragment, args);
+    }
+
+    private void openRideHistory() {
+        startActivity(new Intent(requireContext(), RideHistoryActivity.class));
     }
 
     private boolean isRideStatusLoaded() {
@@ -496,20 +758,28 @@ public class RideTrackingFragment extends Fragment {
         return ROLE_PASSENGER.equals(currentRoleNormalized);
     }
 
+    /**
+     * Align with frontend: Passenger = Panic + Report inconsistency only.
+     * Driver = Start Ride, Stop Ride, End Ride, Panic. No Cancel in tracking panel.
+     */
     private void applyActionVisibility() {
         if (binding == null) {
             return;
         }
         boolean showDriverControls = isDriverRole();
         boolean showPassengerControls = isPassengerRole();
-        boolean rideActive = isRideActiveStatus(getRideStatusLabel());
+        String statusLabel = getRideStatusLabel();
+        boolean rideActive = isRideActiveStatus(statusLabel);
+        boolean rideAccepted = "ACCEPTED".equals(normalizeRideStatus(statusLabel));
 
-        binding.btnCancelRide.setVisibility((showDriverControls || showPassengerControls) ? View.VISIBLE : View.GONE);
+        binding.btnStartRide.setVisibility(showDriverControls ? View.VISIBLE : View.GONE);
+        binding.btnStartRide.setEnabled(showDriverControls && rideAccepted);
+        binding.btnCancelRide.setVisibility(View.GONE);
         binding.btnStopRide.setVisibility(showDriverControls ? View.VISIBLE : View.GONE);
+        binding.btnEndRide.setVisibility(View.GONE);
         binding.btnReportIssue.setVisibility(showPassengerControls ? View.VISIBLE : View.GONE);
         binding.btnPanic.setVisibility((showDriverControls || showPassengerControls) ? View.VISIBLE : View.GONE);
 
-        binding.btnCancelRide.setEnabled(showDriverControls || showPassengerControls);
         if (showDriverControls) {
             binding.btnStopRide.setEnabled(rideActive);
         }
@@ -517,6 +787,77 @@ public class RideTrackingFragment extends Fragment {
             binding.btnReportIssue.setEnabled(rideActive);
         }
         binding.btnPanic.setEnabled(rideActive || !isRideStatusLoaded());
+    }
+
+    private void updateRideNotStartedMessage() {
+        if (binding == null || !isPassengerRole() || activeRide == null) {
+            if (binding != null && binding.rideNotStartedMessage != null) {
+                binding.rideNotStartedMessage.setVisibility(View.GONE);
+            }
+            return;
+        }
+        String status = normalizeRideStatus(activeRide.status);
+        if ("ACTIVE".equals(status) || "IN_PROGRESS".equals(status)) {
+            binding.rideNotStartedMessage.setVisibility(View.GONE);
+            return;
+        }
+        binding.rideNotStartedMessage.setVisibility(View.VISIBLE);
+        if ("ACCEPTED".equals(status)) {
+            binding.rideNotStartedMessage.setText(R.string.ride_tracking_not_started_accepted);
+        } else {
+            binding.rideNotStartedMessage.setText(R.string.ride_tracking_not_started_pending);
+        }
+    }
+
+    private void updateCheckpoints() {
+        if (binding == null || binding.checkpointsContainer == null || binding.checkpointsTitle == null) {
+            return;
+        }
+        if (activeRide == null || activeRide.route == null || activeRide.route.size() < 2) {
+            binding.checkpointsTitle.setVisibility(View.GONE);
+            binding.checkpointsContainer.setVisibility(View.GONE);
+            return;
+        }
+        List<RoutePoint> sorted = new ArrayList<>(activeRide.route);
+        Collections.sort(sorted, Comparator.comparingInt(wp -> wp.order));
+        binding.checkpointsTitle.setVisibility(View.VISIBLE);
+        binding.checkpointsContainer.setVisibility(View.VISIBLE);
+        binding.checkpointsContainer.removeAllViews();
+        RoutePoint current = activeRide.currentLocation;
+        boolean destinationReached = isRideTerminalStatus(activeRide.status)
+            || (current != null && sorted.size() >= 2
+                && distanceMeters(current, sorted.get(sorted.size() - 1)) <= 40.0);
+        for (int i = 0; i < sorted.size(); i++) {
+            RoutePoint wp = sorted.get(i);
+            boolean isStart = i == 0;
+            boolean isDest = i == sorted.size() - 1;
+            boolean passed = isDest ? destinationReached : (wp.order <= lastPassedWaypointOrder);
+            String title = isStart ? getString(R.string.ride_tracking_checkpoint_pickup)
+                : isDest ? getString(R.string.ride_tracking_checkpoint_destination)
+                : getString(R.string.ride_tracking_checkpoint_label, i);
+            String address = isStart ? (activeRide.startAddress != null ? activeRide.startAddress : (wp.address != null ? wp.address : ""))
+                : isDest ? (activeRide.destinationAddress != null ? activeRide.destinationAddress : (wp.address != null ? wp.address : ""))
+                : (wp.address != null && !wp.address.isEmpty() ? wp.address : getString(R.string.ride_tracking_checkpoint_waypoint_fallback, i));
+            addCheckpointRow(binding.checkpointsContainer, title, address, passed);
+        }
+    }
+
+    private void addCheckpointRow(android.view.ViewGroup container, String title, String address, boolean passed) {
+        android.view.LayoutInflater inflater = android.view.LayoutInflater.from(requireContext());
+        View row = inflater.inflate(android.R.layout.simple_list_item_2, container, false);
+        TextView text1 = row.findViewById(android.R.id.text1);
+        TextView text2 = row.findViewById(android.R.id.text2);
+        if (text1 != null) {
+            text1.setText(title);
+            text1.setAlpha(passed ? 0.6f : 1f);
+            text1.setPaintFlags(passed ? text1.getPaintFlags() | android.graphics.Paint.STRIKE_THRU_TEXT_FLAG : text1.getPaintFlags() & ~android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+        }
+        if (text2 != null) {
+            text2.setText(address);
+            text2.setAlpha(passed ? 0.6f : 1f);
+            text2.setPaintFlags(passed ? text2.getPaintFlags() | android.graphics.Paint.STRIKE_THRU_TEXT_FLAG : text2.getPaintFlags() & ~android.graphics.Paint.STRIKE_THRU_TEXT_FLAG);
+        }
+        container.addView(row);
     }
 
     private void openTrackingPanel() {
@@ -824,19 +1165,39 @@ public class RideTrackingFragment extends Fragment {
         if (response == null || activeRide == null) {
             return;
         }
-        Double lat = response.vehicleCurrentLat;
-        Double lng = response.vehicleCurrentLng;
-        if (lat == null || lng == null) {
-            return;
+        String status = normalizeRideStatus(activeRide.status);
+        // Only apply vehicle location updates when ride is ACTIVE (driver has clicked Start).
+        // Before that, keep the car at pickup so it doesn't move until the driver starts.
+        if ("ACTIVE".equals(status)) {
+            Double lat = response.vehicleCurrentLat;
+            Double lng = response.vehicleCurrentLng;
+            if (lat != null && lng != null) {
+                RoutePoint current = new RoutePoint(lat, lng, 0);
+                int eta = response.estimatedDurationSec != null ? response.estimatedDurationSec : 0;
+                float bearing = 0f;
+                if (previousLocation != null) {
+                    bearing = (float) calculateBearing(previousLocation, current);
+                }
+                previousLocation = current;
+                applyLocationUpdate(new LocationUpdate(lat, lng, System.currentTimeMillis(), eta, bearing));
+            }
+        } else {
+            // ACCEPTED or PENDING: pin car at pickup (first waypoint) until driver starts
+            if (activeRide.route != null && !activeRide.route.isEmpty()) {
+                List<RoutePoint> sorted = new ArrayList<>(activeRide.route);
+                Collections.sort(sorted, Comparator.comparingInt(wp -> wp.order));
+                RoutePoint start = sorted.get(0);
+                activeRide.currentLocation = new RoutePoint(start.lat, start.lng, 0);
+            }
+            if (response.estimatedDurationSec != null) {
+                activeRide.estimatedArrivalTimeSec = response.estimatedDurationSec;
+            }
+            if (binding != null) {
+                binding.etaValue.setText(formatEta(activeRide.estimatedArrivalTimeSec));
+            }
+            updateMapContent();
+            updateCheckpoints();
         }
-        RoutePoint current = new RoutePoint(lat, lng, 0);
-        int eta = response.estimatedDurationSec != null ? response.estimatedDurationSec : 0;
-        float bearing = 0f;
-        if (previousLocation != null) {
-            bearing = (float) calculateBearing(previousLocation, current);
-        }
-        previousLocation = current;
-        applyLocationUpdate(new LocationUpdate(lat, lng, System.currentTimeMillis(), eta, bearing));
     }
 
     private void applyRide(ActiveRide ride) {
@@ -844,6 +1205,9 @@ public class RideTrackingFragment extends Fragment {
         activeRide = ride;
         if (destinationChanged) {
             renderedRoute.clear();
+            routeCumulativeDistancesMeters = new double[0];
+            routeProgressMeters = 0.0;
+            lastBackendLocation = null;
             lastPassedWaypointOrder = Integer.MIN_VALUE;
             routeRequestToken++;
         }
@@ -858,6 +1222,8 @@ public class RideTrackingFragment extends Fragment {
         binding.toAddress.setText(ride.destinationAddress == null ? "" : ride.destinationAddress);
         binding.etaValue.setText(formatEta(ride.estimatedArrivalTimeSec));
         applyActionVisibility();
+        updateRideNotStartedMessage();
+        updateCheckpoints();
         updateMapContent();
         updateCompletionState();
     }
@@ -866,14 +1232,86 @@ public class RideTrackingFragment extends Fragment {
         if (activeRide == null || update == null) {
             return;
         }
-        activeRide.currentLocation = new RoutePoint(update.lat, update.lng, 0);
+        // Only move the car when ride is ACTIVE (driver has started the ride)
+        if (!"ACTIVE".equals(normalizeRideStatus(activeRide.status))) {
+            return;
+        }
+        RoutePoint backendLocation = new RoutePoint(update.lat, update.lng, 0);
+        RoutePoint displayLocation;
+        if (renderedRoute == null || renderedRoute.size() < 2) {
+            displayLocation = backendLocation;
+        } else {
+            displayLocation = computeNextLocationOnRoute(backendLocation);
+        }
+        activeRide.currentLocation = displayLocation;
+        lastBackendLocation = backendLocation;
         activeRide.estimatedArrivalTimeSec = update.estimatedArrivalTimeSec;
         currentBearing = update.bearing;
+        // Update which waypoints we've passed: use progress along route when available, else 70m distance (frontend heuristic)
+        if (renderedRoute != null && renderedRoute.size() >= 2 && routeCumulativeDistancesMeters.length >= 2) {
+            updateLastPassedWaypointOrderFromRouteProgress();
+        } else {
+            updateLastPassedWaypointOrderFromLocation(displayLocation);
+        }
         if (binding != null) {
             binding.etaValue.setText(formatEta(update.estimatedArrivalTimeSec));
+            updateCheckpoints();
         }
         updateMapContent();
         requestRouteIfNeeded(false);
+    }
+
+    /**
+     * Update lastPassedWaypointOrder from route progress (same idea as frontend but using path):
+     * a waypoint is passed when the car's progress along the route has passed that waypoint's
+     * position on the route. This avoids the car "jumping" and ensures checkpoints cross out
+     * as the car follows the path (frontend uses 70m distance; we use progress for reliability).
+     */
+    private static final double WAYPOINT_PASSED_BUFFER_METERS = 50.0;
+
+    private void updateLastPassedWaypointOrderFromRouteProgress() {
+        if (activeRide == null || activeRide.route == null || renderedRoute == null || renderedRoute.size() < 2
+            || routeCumulativeDistancesMeters.length < 2) {
+            return;
+        }
+        List<RoutePoint> sorted = new ArrayList<>(activeRide.route);
+        Collections.sort(sorted, Comparator.comparingInt(wp -> wp.order));
+        if (sorted.size() < 2) {
+            return;
+        }
+        int maxReachedOrder = Integer.MIN_VALUE;
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            RoutePoint wp = sorted.get(i);
+            double waypointDistanceAlongRoute = closestDistanceAlongRoute(wp, renderedRoute, routeCumulativeDistancesMeters);
+            if (routeProgressMeters >= waypointDistanceAlongRoute - WAYPOINT_PASSED_BUFFER_METERS) {
+                maxReachedOrder = Math.max(maxReachedOrder, wp.order);
+            }
+        }
+        if (maxReachedOrder != Integer.MIN_VALUE) {
+            lastPassedWaypointOrder = Math.max(lastPassedWaypointOrder, maxReachedOrder);
+        }
+    }
+
+    /** Fallback when route polyline not yet available: use 70m distance like frontend. */
+    private void updateLastPassedWaypointOrderFromLocation(RoutePoint location) {
+        if (activeRide == null || activeRide.route == null || location == null) {
+            return;
+        }
+        List<RoutePoint> sorted = new ArrayList<>(activeRide.route);
+        Collections.sort(sorted, Comparator.comparingInt(wp -> wp.order));
+        if (sorted.size() < 2) {
+            return;
+        }
+        int maxReachedOrder = Integer.MIN_VALUE;
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            RoutePoint wp = sorted.get(i);
+            if (distanceMeters(location, wp) <= WAYPOINT_REACHED_RADIUS_METERS) {
+                maxReachedOrder = Math.max(maxReachedOrder, wp.order);
+            }
+        }
+        if (maxReachedOrder != Integer.MIN_VALUE) {
+            lastPassedWaypointOrder = Math.max(lastPassedWaypointOrder, maxReachedOrder);
+        }
     }
 
     private void updateCompletionState() {
@@ -883,7 +1321,13 @@ public class RideTrackingFragment extends Fragment {
         boolean isCompleted = isRideTerminalStatus(activeRide.status);
         binding.rideCompletedMessage.setVisibility(isCompleted ? View.VISIBLE : View.GONE);
         if (isCompleted) {
+            binding.rideCompletedMessage.setText(
+                getString(R.string.ride_tracking_completed) + "\n" + getString(R.string.ride_tracking_no_active_ride));
+            clearRouteAndMapForFinishedRide();
             stopTracking();
+            if (isDriverRole()) {
+                loadUpcomingRidesForDriver();
+            }
         }
     }
 
@@ -892,13 +1336,35 @@ public class RideTrackingFragment extends Fragment {
             return;
         }
         ensureAnnotationManagers();
+        if (isRideTerminalStatus(activeRide.status)) {
+            clearRouteAndMapForFinishedRide();
+            return;
+        }
         updateRouteLine();
         updateMarkers();
         updateMapCamera();
     }
 
+    /** When ride is finished: clear route and markers so the map shows no route and says no active ride. */
+    private void clearRouteAndMapForFinishedRide() {
+        renderedRoute = new ArrayList<>();
+        routeCumulativeDistancesMeters = new double[0];
+        routeProgressMeters = 0.0;
+        lastBackendLocation = null;
+        if (polylineAnnotationManager != null) {
+            polylineAnnotationManager.deleteAll();
+        }
+        if (pointAnnotationManager != null) {
+            pointAnnotationManager.deleteAll();
+        }
+    }
+
     private void updateMarkers() {
         if (pointAnnotationManager == null || activeRide == null) {
+            return;
+        }
+        if (isRideTerminalStatus(activeRide.status)) {
+            pointAnnotationManager.deleteAll();
             return;
         }
         pointAnnotationManager.deleteAll();
@@ -928,6 +1394,10 @@ public class RideTrackingFragment extends Fragment {
 
     private void updateRouteLine() {
         if (polylineAnnotationManager == null || activeRide == null) {
+            return;
+        }
+        if (isRideTerminalStatus(activeRide.status)) {
+            polylineAnnotationManager.deleteAll();
             return;
         }
         List<RoutePoint> source = null;
@@ -968,13 +1438,15 @@ public class RideTrackingFragment extends Fragment {
             return;
         }
         long now = System.currentTimeMillis();
-        if (!force && now - lastRouteRequestAt < ROUTE_REFRESH_INTERVAL_MS) {
+        int previousLastPassed = lastPassedWaypointOrder;
+        List<RoutePoint> requestPoints = deduplicateConsecutivePoints(
+            buildRouteRequestPoints(activeRide.currentLocation)
+        );
+        boolean waypointTransitioned = lastPassedWaypointOrder > previousLastPassed;
+        if (!force && !waypointTransitioned && now - lastRouteRequestAt < ROUTE_REFRESH_INTERVAL_MS) {
             return;
         }
         lastRouteRequestAt = now;
-        List<RoutePoint> requestPoints = deduplicateConsecutivePoints(
-            buildFallbackCurrentToDestination(activeRide.currentLocation)
-        );
         if (requestPoints.size() < 2) {
             return;
         }
@@ -1180,6 +1652,16 @@ public class RideTrackingFragment extends Fragment {
         }
         if (!route.isEmpty()) {
             renderedRoute = route;
+            routeCumulativeDistancesMeters = buildRouteCumulativeDistances(renderedRoute);
+            if (routeCumulativeDistancesMeters.length >= 2 && activeRide.currentLocation != null) {
+                routeProgressMeters = closestDistanceAlongRoute(
+                    activeRide.currentLocation,
+                    renderedRoute,
+                    routeCumulativeDistancesMeters
+                );
+            } else {
+                routeProgressMeters = 0.0;
+            }
             updateMapContent();
         }
     }
@@ -1192,6 +1674,144 @@ public class RideTrackingFragment extends Fragment {
             renderedRoute = new ArrayList<>(activeRide.route);
         }
         updateMapContent();
+    }
+
+    /**
+     * Compute display position on the route from backend location (same logic as frontend):
+     * project backend onto route, advance progress with min/max forward step and catchup.
+     */
+    private RoutePoint computeNextLocationOnRoute(RoutePoint backendLocation) {
+        List<RoutePoint> route = renderedRoute;
+        if (route == null || route.size() < 2 || routeCumulativeDistancesMeters.length < 2) {
+            return backendLocation;
+        }
+        if (routeCumulativeDistancesMeters.length != route.size()) {
+            routeCumulativeDistancesMeters = buildRouteCumulativeDistances(route);
+        }
+        double backendProjectedDistance = closestDistanceAlongRoute(
+            backendLocation,
+            route,
+            routeCumulativeDistancesMeters
+        );
+        routeProgressMeters = Math.max(routeProgressMeters, backendProjectedDistance);
+
+        double forwardMoveMeters = DEFAULT_FORWARD_MOVE_METERS;
+        if (lastBackendLocation != null) {
+            forwardMoveMeters = distanceMeters(lastBackendLocation, backendLocation);
+        }
+        forwardMoveMeters = Math.max(MIN_FORWARD_MOVE_METERS,
+            Math.min(MAX_FORWARD_MOVE_METERS, forwardMoveMeters));
+
+        double totalRouteDistance = routeCumulativeDistancesMeters[routeCumulativeDistancesMeters.length - 1];
+        double projectedAheadDistance = backendProjectedDistance - routeProgressMeters;
+        boolean canCatchUpToProjection = projectedAheadDistance > 0
+            && projectedAheadDistance <= MAX_PROJECTION_CATCHUP_METERS;
+        double projectedTarget = canCatchUpToProjection ? backendProjectedDistance : routeProgressMeters;
+        double stepTarget = routeProgressMeters + forwardMoveMeters;
+        routeProgressMeters = Math.min(totalRouteDistance, Math.max(stepTarget, projectedTarget));
+
+        return pointAlongRouteAtDistance(route, routeCumulativeDistancesMeters, routeProgressMeters);
+    }
+
+    private double[] buildRouteCumulativeDistances(List<RoutePoint> route) {
+        if (route == null || route.size() < 2) {
+            return new double[0];
+        }
+        double[] cumulative = new double[route.size()];
+        cumulative[0] = 0.0;
+        for (int i = 1; i < route.size(); i++) {
+            RoutePoint prev = route.get(i - 1);
+            RoutePoint curr = route.get(i);
+            cumulative[i] = cumulative[i - 1] + distanceMeters(prev, curr);
+        }
+        return cumulative;
+    }
+
+    private double closestDistanceAlongRoute(
+        RoutePoint point,
+        List<RoutePoint> route,
+        double[] cumulativeDistances
+    ) {
+        if (route.size() < 2 || cumulativeDistances.length < 2) {
+            return 0.0;
+        }
+        double refLatRad = Math.toRadians(point.lat);
+        double cosLat = Math.cos(refLatRad);
+        if (Math.abs(cosLat) < 1e-9) cosLat = 1e-9;
+
+        double px = Math.toRadians(point.lng) * EARTH_RADIUS_METERS * cosLat;
+        double py = Math.toRadians(point.lat) * EARTH_RADIUS_METERS;
+
+        double minDistSq = Double.POSITIVE_INFINITY;
+        double closestDistanceAlongRoute = 0.0;
+
+        for (int i = 0; i < route.size() - 1; i++) {
+            RoutePoint a = route.get(i);
+            RoutePoint b = route.get(i + 1);
+            double ax = Math.toRadians(a.lng) * EARTH_RADIUS_METERS * cosLat;
+            double ay = Math.toRadians(a.lat) * EARTH_RADIUS_METERS;
+            double bx = Math.toRadians(b.lng) * EARTH_RADIUS_METERS * cosLat;
+            double by = Math.toRadians(b.lat) * EARTH_RADIUS_METERS;
+            double abx = bx - ax;
+            double aby = by - ay;
+            double apx = px - ax;
+            double apy = py - ay;
+            double abLenSq = abx * abx + aby * aby;
+            double t = abLenSq <= 0 ? 0 : (apx * abx + apy * aby) / abLenSq;
+            double clampedT = Math.max(0.0, Math.min(1.0, t));
+            double projX = ax + abx * clampedT;
+            double projY = ay + aby * clampedT;
+            double dx = px - projX;
+            double dy = py - projY;
+            double distSq = dx * dx + dy * dy;
+
+            if (distSq < minDistSq) {
+                minDistSq = distSq;
+                double segmentStart = cumulativeDistances[i];
+                double segmentEnd = cumulativeDistances[i + 1];
+                closestDistanceAlongRoute = segmentStart + (segmentEnd - segmentStart) * clampedT;
+            }
+        }
+        return closestDistanceAlongRoute;
+    }
+
+    private RoutePoint pointAlongRouteAtDistance(
+        List<RoutePoint> route,
+        double[] cumulativeDistances,
+        double distanceMeters
+    ) {
+        if (route == null || route.isEmpty()) {
+            return new RoutePoint(0, 0, 0);
+        }
+        if (route.size() == 1 || cumulativeDistances.length < 2) {
+            RoutePoint p = route.get(0);
+            return new RoutePoint(p.lat, p.lng, 0);
+        }
+        if (distanceMeters <= 0) {
+            RoutePoint p = route.get(0);
+            return new RoutePoint(p.lat, p.lng, 0);
+        }
+        double totalDistance = cumulativeDistances[cumulativeDistances.length - 1];
+        if (distanceMeters >= totalDistance) {
+            RoutePoint p = route.get(route.size() - 1);
+            return new RoutePoint(p.lat, p.lng, 0);
+        }
+        for (int i = 1; i < cumulativeDistances.length; i++) {
+            double segmentEndDistance = cumulativeDistances[i];
+            if (distanceMeters > segmentEndDistance) {
+                continue;
+            }
+            double segmentStartDistance = cumulativeDistances[i - 1];
+            double segmentLength = segmentEndDistance - segmentStartDistance;
+            double ratio = segmentLength <= 0 ? 0 : (distanceMeters - segmentStartDistance) / segmentLength;
+            RoutePoint start = route.get(i - 1);
+            RoutePoint end = route.get(i);
+            double lat = start.lat + (end.lat - start.lat) * ratio;
+            double lng = start.lng + (end.lng - start.lng) * ratio;
+            return new RoutePoint(lat, lng, 0);
+        }
+        RoutePoint last = route.get(route.size() - 1);
+        return new RoutePoint(last.lat, last.lng, 0);
     }
 
     private boolean didDestinationChange(ActiveRide previous, ActiveRide current) {
@@ -1294,7 +1914,8 @@ public class RideTrackingFragment extends Fragment {
                     continue;
                 }
                 int order = waypoint.order == null ? 0 : waypoint.order;
-                route.add(new RoutePoint(waypoint.lat, waypoint.lng, order));
+                String addr = waypoint.address != null ? waypoint.address : "";
+                route.add(new RoutePoint(waypoint.lat, waypoint.lng, order, addr));
             }
             ride.route = route;
         }
@@ -1329,7 +1950,8 @@ public class RideTrackingFragment extends Fragment {
                 continue;
             }
             int order = waypoint.order == null ? 0 : waypoint.order;
-            route.add(new RoutePoint(waypoint.lat, waypoint.lng, order));
+            String addr = waypoint.address != null ? waypoint.address : "";
+            route.add(new RoutePoint(waypoint.lat, waypoint.lng, order, addr));
         }
         ride.route = route;
 

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
@@ -79,7 +79,12 @@ public class RideTrackingFragment extends Fragment {
     private static final double DEFAULT_LAT = 45.2500;
     private static final double DEFAULT_ZOOM = 13.5;
     private static final String MAPBOX_STYLE_URI = "mapbox://styles/mapbox/streets-v12";
-    private static final long LOCATION_POLLING_INTERVAL_MS = 2500L;
+    /**
+     * Match backend simulation tick (RideTrackingSimulationService.TICK_INTERVAL_MS = 3000) and frontend
+     * (POLL_INTERVAL_MS = 3000). Polling faster or out of sync can see multiple ticks in one response
+     * (e.g. 400m) when the app was briefly backgrounded or the main thread was busy.
+     */
+    private static final long LOCATION_POLLING_INTERVAL_MS = 3000L;
     private static final long ROUTE_REFRESH_INTERVAL_MS = 20_000L;
     private static final double WAYPOINT_REACHED_RADIUS_METERS = 70.0;
     private static final int MAPBOX_MAX_ROUTE_POINTS = 25;
@@ -88,7 +93,9 @@ public class RideTrackingFragment extends Fragment {
     private static final double MIN_FORWARD_MOVE_METERS = 8.0;
     private static final double MAX_FORWARD_MOVE_METERS = 90.0;
     private static final double DEFAULT_FORWARD_MOVE_METERS = 20.0;
-    private static final double MAX_PROJECTION_CATCHUP_METERS = 60.0;
+    private static final double MAX_PROJECTION_CATCHUP_METERS = 120.0;
+    /** Hard cap: progress along route never advances more than this in one update (prevents visible jumps). */
+    private static final double MAX_PROGRESS_ADVANCE_PER_UPDATE_METERS = 40.0;
     private static final long PANEL_SHOW_ANIMATION_MS = 240L;
     private static final long PANEL_HIDE_ANIMATION_MS = 200L;
 
@@ -100,6 +107,7 @@ public class RideTrackingFragment extends Fragment {
     private Bitmap carIcon;
     private Bitmap startIcon;
     private Bitmap destinationIcon;
+    private Bitmap waypointIcon;
 
     private RideApiService rideApiService;
     private DriverApiService driverApiService;
@@ -1247,6 +1255,7 @@ public class RideTrackingFragment extends Fragment {
         lastBackendLocation = backendLocation;
         activeRide.estimatedArrivalTimeSec = update.estimatedArrivalTimeSec;
         currentBearing = update.bearing;
+        syncDisplayPositionToBackend(displayLocation);
         // Update which waypoints we've passed: use progress along route when available, else 70m distance (frontend heuristic)
         if (renderedRoute != null && renderedRoute.size() >= 2 && routeCumulativeDistancesMeters.length >= 2) {
             updateLastPassedWaypointOrderFromRouteProgress();
@@ -1259,6 +1268,24 @@ public class RideTrackingFragment extends Fragment {
         }
         updateMapContent();
         requestRouteIfNeeded(false);
+    }
+
+    /** Sends the displayed (capped) position to the backend so it stays in sync with what we show. */
+    private void syncDisplayPositionToBackend(RoutePoint displayLocation) {
+        if (rideId == 0L || displayLocation == null || rideApiService == null) {
+            return;
+        }
+        rideApiService.updateTrackingPosition(rideId, new com.drumigo.mobile.data.model.ride.RideTrackingPositionRequest(displayLocation.lat, displayLocation.lng))
+            .enqueue(new Callback<Void>() {
+                @Override
+                public void onResponse(@NonNull Call<Void> call, @NonNull Response<Void> response) {
+                    // Ignore success – backend is now in sync
+                }
+                @Override
+                public void onFailure(@NonNull Call<Void> call, @NonNull Throwable t) {
+                    // Ignore – next poll will still work
+                }
+            });
     }
 
     /**
@@ -1381,6 +1408,18 @@ public class RideTrackingFragment extends Fragment {
                 .withPoint(Point.fromLngLat(activeRide.destinationLocation.lng, activeRide.destinationLocation.lat))
                 .withIconImage(getDestinationIcon())
                 .withIconAnchor(IconAnchor.CENTER));
+        }
+
+        if (activeRide.route != null && activeRide.route.size() > 2) {
+            List<RoutePoint> sortedWaypoints = new ArrayList<>(activeRide.route);
+            Collections.sort(sortedWaypoints, Comparator.comparingInt(wp -> wp.order));
+            for (int i = 1; i < sortedWaypoints.size() - 1; i++) {
+                RoutePoint wp = sortedWaypoints.get(i);
+                pointAnnotationManager.create(new PointAnnotationOptions()
+                    .withPoint(Point.fromLngLat(wp.lng, wp.lat))
+                    .withIconImage(getWaypointIcon())
+                    .withIconAnchor(IconAnchor.CENTER));
+            }
         }
 
         if (activeRide.currentLocation != null) {
@@ -1653,12 +1692,16 @@ public class RideTrackingFragment extends Fragment {
         if (!route.isEmpty()) {
             renderedRoute = route;
             routeCumulativeDistancesMeters = buildRouteCumulativeDistances(renderedRoute);
+            double totalRouteDistance = routeCumulativeDistancesMeters.length >= 2
+                ? routeCumulativeDistancesMeters[routeCumulativeDistancesMeters.length - 1]
+                : 0.0;
             if (routeCumulativeDistancesMeters.length >= 2 && activeRide.currentLocation != null) {
-                routeProgressMeters = closestDistanceAlongRoute(
+                double projectedOnNewRoute = closestDistanceAlongRoute(
                     activeRide.currentLocation,
                     renderedRoute,
                     routeCumulativeDistancesMeters
                 );
+                routeProgressMeters = Math.min(totalRouteDistance, Math.max(routeProgressMeters, projectedOnNewRoute));
             } else {
                 routeProgressMeters = 0.0;
             }
@@ -1672,6 +1715,18 @@ public class RideTrackingFragment extends Fragment {
         }
         if (renderedRoute == null || renderedRoute.isEmpty()) {
             renderedRoute = new ArrayList<>(activeRide.route);
+        }
+        routeCumulativeDistancesMeters = buildRouteCumulativeDistances(renderedRoute);
+        double totalRouteDistance = routeCumulativeDistancesMeters.length >= 2
+            ? routeCumulativeDistancesMeters[routeCumulativeDistancesMeters.length - 1]
+            : 0.0;
+        if (routeCumulativeDistancesMeters.length >= 2 && activeRide.currentLocation != null) {
+            double projectedOnNewRoute = closestDistanceAlongRoute(
+                activeRide.currentLocation,
+                renderedRoute,
+                routeCumulativeDistancesMeters
+            );
+            routeProgressMeters = Math.min(totalRouteDistance, Math.max(routeProgressMeters, projectedOnNewRoute));
         }
         updateMapContent();
     }
@@ -1688,12 +1743,15 @@ public class RideTrackingFragment extends Fragment {
         if (routeCumulativeDistancesMeters.length != route.size()) {
             routeCumulativeDistancesMeters = buildRouteCumulativeDistances(route);
         }
+        double previousProgress = routeProgressMeters;
         double backendProjectedDistance = closestDistanceAlongRoute(
             backendLocation,
             route,
             routeCumulativeDistancesMeters
         );
-        routeProgressMeters = Math.max(routeProgressMeters, backendProjectedDistance);
+        double maxProgressFromBackend = routeProgressMeters + MAX_PROJECTION_CATCHUP_METERS;
+        double cappedBackendProjected = Math.min(backendProjectedDistance, maxProgressFromBackend);
+        routeProgressMeters = Math.max(routeProgressMeters, cappedBackendProjected);
 
         double forwardMoveMeters = DEFAULT_FORWARD_MOVE_METERS;
         if (lastBackendLocation != null) {
@@ -1709,6 +1767,7 @@ public class RideTrackingFragment extends Fragment {
         double projectedTarget = canCatchUpToProjection ? backendProjectedDistance : routeProgressMeters;
         double stepTarget = routeProgressMeters + forwardMoveMeters;
         routeProgressMeters = Math.min(totalRouteDistance, Math.max(stepTarget, projectedTarget));
+        routeProgressMeters = Math.min(routeProgressMeters, previousProgress + MAX_PROGRESS_ADVANCE_PER_UPDATE_METERS);
 
         return pointAlongRouteAtDistance(route, routeCumulativeDistancesMeters, routeProgressMeters);
     }
@@ -1856,6 +1915,13 @@ public class RideTrackingFragment extends Fragment {
             destinationIcon = createTintedMarker(R.drawable.ic_circle, R.color.success);
         }
         return destinationIcon;
+    }
+
+    private Bitmap getWaypointIcon() {
+        if (waypointIcon == null) {
+            waypointIcon = createTintedMarker(R.drawable.ic_circle, R.color.accent);
+        }
+        return waypointIcon;
     }
 
     private Bitmap createTintedMarker(int drawableResId, int colorResId) {

--- a/mobile/app/src/main/res/drawable/ic_star.xml
+++ b/mobile/app/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Use white so code can tint with SRC_IN to get star_filled color -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27z"/>
+</vector>

--- a/mobile/app/src/main/res/drawable/ic_star_outline.xml
+++ b/mobile/app/src/main/res/drawable/ic_star_outline.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Use white so code can tint with SRC_IN -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+</vector>

--- a/mobile/app/src/main/res/layout/bottom_sheet_ride_inconsistency.xml
+++ b/mobile/app/src/main/res/layout/bottom_sheet_ride_inconsistency.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_ride_history_details_sheet"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/spacing_md"
+    android:paddingTop="@dimen/spacing_sm"
+    android:paddingEnd="@dimen/spacing_md"
+    android:paddingBottom="@dimen/spacing_md">
+
+    <View
+        android:layout_width="44dp"
+        android:layout_height="4dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="@dimen/spacing_sm"
+        android:background="@drawable/bg_ride_history_sheet_handle" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            style="@style/TextStyle.Title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/ride_tracking_inconsistency_sheet_title"
+            android:textSize="@dimen/text_lg" />
+
+        <ImageView
+            android:id="@+id/inconsistencyCloseButton"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:background="@drawable/bg_ride_history_sheet_close"
+            android:contentDescription="@string/ride_tracking_inconsistency_sheet_close"
+            android:padding="7dp"
+            android:src="@drawable/ic_close_simple"
+            app:tint="@color/text_medium" />
+    </LinearLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/inconsistencyNoteLayout"
+        style="@style/Widget.Drumigo.TextInputLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_md"
+        android:hint="@string/ride_tracking_inconsistency_hint">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/inconsistencyNoteInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top|start"
+            android:inputType="textMultiLine|textCapSentences"
+            android:minLines="3"
+            android:maxLength="1000" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/inconsistencyErrorText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_sm"
+        android:textColor="@color/error"
+        android:textSize="@dimen/text_sm"
+        android:visibility="gone" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/inconsistencySubmitButton"
+        style="@style/Widget.Drumigo.Button.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_md"
+        android:text="@string/ride_tracking_inconsistency_submit" />
+</LinearLayout>

--- a/mobile/app/src/main/res/layout/fragment_landing.xml
+++ b/mobile/app/src/main/res/layout/fragment_landing.xml
@@ -150,10 +150,42 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
+
+                        <LinearLayout
+                            android:id="@+id/favoriteRoutesSection"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:visibility="gone">
+                            <TextView
+                                style="@style/TextStyle.Subtitle"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/order_quick_pick_favorites" />
+                            <com.google.android.material.textfield.TextInputLayout
+                                style="@style/Widget.Drumigo.TextInputLayout"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="@dimen/spacing_sm"
+                                android:hint="@string/order_favorite_route_hint"
+                                app:endIconMode="dropdown_menu">
+
+                                <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                                    android:id="@+id/favoriteRouteDropdown"
+                                    style="@style/Widget.Drumigo.TextInputEditText"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:inputType="none"
+                                    android:textColor="@color/text_dark"
+                                    android:textSize="@dimen/text_md" />
+                            </com.google.android.material.textfield.TextInputLayout>
+                        </LinearLayout>
+
                         <TextView
                             style="@style/TextStyle.Subtitle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
                             android:text="@string/order_where_going" />
                         <TextView
                             android:id="@+id/activeVehiclesCount"

--- a/mobile/app/src/main/res/layout/fragment_landing.xml
+++ b/mobile/app/src/main/res/layout/fragment_landing.xml
@@ -82,6 +82,53 @@
                     app:tint="@color/text_medium" />
             </LinearLayout>
 
+            <!-- Step indicator -->
+            <LinearLayout
+                android:id="@+id/stepIndicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center"
+                android:paddingStart="@dimen/spacing_md"
+                android:paddingEnd="@dimen/spacing_md"
+                android:paddingTop="@dimen/spacing_xs"
+                android:paddingBottom="@dimen/spacing_sm">
+                <TextView
+                    android:id="@+id/step1Label"
+                    style="@style/TextStyle.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="@string/order_step_route" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_weight="0.5"
+                    android:background="@color/border" />
+                <TextView
+                    android:id="@+id/step2Label"
+                    style="@style/TextStyle.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="@string/order_step_options" />
+                <View
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:layout_weight="0.5"
+                    android:background="@color/border" />
+                <TextView
+                    android:id="@+id/step3Label"
+                    style="@style/TextStyle.Caption"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    android:text="@string/order_step_confirm" />
+            </LinearLayout>
+
             <androidx.core.widget.NestedScrollView
                 android:id="@+id/estimateScroll"
                 android:layout_width="match_parent"
@@ -97,71 +144,251 @@
                     android:paddingEnd="@dimen/spacing_md"
                     android:paddingBottom="@dimen/spacing_md">
 
-                    <TextView
-                        android:id="@+id/activeVehiclesCount"
-                        style="@style/TextStyle.Caption"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/landing_active_vehicles_count_placeholder" />
-
-                    <com.google.android.material.textfield.TextInputLayout
-                        style="@style/Widget.Drumigo.TextInputLayout"
+                    <!-- Step 1: Route -->
+                    <LinearLayout
+                        android:id="@+id/step1Content"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md">
+                        android:orientation="vertical">
+                        <TextView
+                            style="@style/TextStyle.Subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/order_where_going" />
+                        <TextView
+                            android:id="@+id/activeVehiclesCount"
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs"
+                            android:text="@string/landing_active_vehicles_count_placeholder" />
 
-                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
-                            android:id="@+id/pickupInput"
-                            style="@style/Widget.Drumigo.TextInputEditText"
+                        <com.google.android.material.textfield.TextInputLayout
+                            style="@style/Widget.Drumigo.TextInputLayout"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="@string/landing_pickup_hint"
-                            android:inputType="textPostalAddress"
-                            android:maxLines="1" />
-                    </com.google.android.material.textfield.TextInputLayout>
+                            android:layout_marginTop="@dimen/spacing_md">
 
-                    <com.google.android.material.textfield.TextInputLayout
-                        style="@style/Widget.Drumigo.TextInputLayout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_sm">
+                            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                                android:id="@+id/pickupInput"
+                                style="@style/Widget.Drumigo.TextInputEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/landing_pickup_hint"
+                                android:inputType="textPostalAddress"
+                                android:maxLines="1" />
+                        </com.google.android.material.textfield.TextInputLayout>
 
-                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
-                            android:id="@+id/destinationInput"
-                            style="@style/Widget.Drumigo.TextInputEditText"
+                        <com.google.android.material.textfield.TextInputLayout
+                            style="@style/Widget.Drumigo.TextInputLayout"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="@string/landing_destination_hint"
-                            android:inputType="textPostalAddress"
-                            android:maxLines="1" />
-                    </com.google.android.material.textfield.TextInputLayout>
+                            android:layout_marginTop="@dimen/spacing_sm">
 
-                    <com.google.android.material.textfield.TextInputLayout
-                        style="@style/Widget.Drumigo.TextInputLayout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_sm"
-                        app:endIconMode="dropdown_menu"
-                        android:hint="@string/landing_vehicle_type_hint">
+                            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                                android:id="@+id/destinationInput"
+                                style="@style/Widget.Drumigo.TextInputEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/landing_destination_hint"
+                                android:inputType="textPostalAddress"
+                                android:maxLines="1" />
+                        </com.google.android.material.textfield.TextInputLayout>
 
-                        <com.google.android.material.textfield.MaterialAutoCompleteTextView
-                            android:id="@+id/vehicleTypeDropdown"
-                            style="@style/Widget.Drumigo.TextInputEditText"
+                        <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:inputType="none"
-                            android:textColor="@color/text_dark"
-                            android:textSize="@dimen/text_md" />
-                    </com.google.android.material.textfield.TextInputLayout>
+                            android:orientation="horizontal"
+                            android:gravity="center_vertical"
+                            android:layout_marginTop="@dimen/spacing_sm">
+                            <TextView
+                                style="@style/TextStyle.Caption"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="@string/order_add_stop" />
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btnAddStop"
+                                style="@style/Widget.Drumigo.Button.Secondary"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/order_add_stop"
+                                android:textAllCaps="false" />
+                        </LinearLayout>
+                        <LinearLayout
+                            android:id="@+id/stopsContainer"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical" />
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnEstimate"
-                        style="@style/Widget.Drumigo.Button.Primary"
+                        <com.google.android.material.textfield.TextInputLayout
+                            style="@style/Widget.Drumigo.TextInputLayout"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            app:endIconMode="dropdown_menu"
+                            android:hint="@string/landing_vehicle_type_hint">
+
+                            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                                android:id="@+id/vehicleTypeDropdown"
+                                style="@style/Widget.Drumigo.TextInputEditText"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:inputType="none"
+                                android:textColor="@color/text_dark"
+                                android:textSize="@dimen/text_md" />
+                        </com.google.android.material.textfield.TextInputLayout>
+                    </LinearLayout>
+
+                    <!-- Step 2: Options -->
+                    <LinearLayout
+                        android:id="@+id/step2Content"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:text="@string/landing_calculate_estimate"
-                        android:textAllCaps="false" />
+                        android:orientation="vertical"
+                        android:visibility="gone">
+                        <TextView
+                            style="@style/TextStyle.Subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/order_ride_options" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            android:text="@string/order_schedule_ride"
+                            android:textSize="@dimen/text_sm"
+                            android:textStyle="bold" />
+                        <RadioGroup
+                            android:id="@+id/scheduleGroup"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:layout_marginTop="@dimen/spacing_xs">
+                            <RadioButton
+                                android:id="@+id/scheduleNow"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/order_schedule_now"
+                                android:checked="true" />
+                            <RadioButton
+                                android:id="@+id/scheduleLater"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginStart="@dimen/spacing_md"
+                                android:text="@string/order_schedule_later" />
+                        </RadioGroup>
+                        <LinearLayout
+                            android:id="@+id/scheduleLaterFields"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:visibility="gone"
+                            android:layout_marginTop="@dimen/spacing_sm">
+                            <com.google.android.material.textfield.TextInputLayout
+                                style="@style/Widget.Drumigo.TextInputLayout"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginEnd="@dimen/spacing_xs"
+                                android:hint="@string/order_schedule_hours">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/scheduleHoursInput"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:inputType="number"
+                                    android:maxLength="1" />
+                            </com.google.android.material.textfield.TextInputLayout>
+                            <com.google.android.material.textfield.TextInputLayout
+                                style="@style/Widget.Drumigo.TextInputLayout"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_marginStart="@dimen/spacing_xs"
+                                android:hint="@string/order_schedule_minutes">
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/scheduleMinutesInput"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:inputType="number" />
+                            </com.google.android.material.textfield.TextInputLayout>
+                        </LinearLayout>
+                        <TextView
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs"
+                            android:text="@string/order_schedule_max_hint" />
+                        <com.google.android.material.checkbox.MaterialCheckBox
+                            android:id="@+id/babyTransportCheckbox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
+                            android:text="@string/order_baby_seat" />
+                        <com.google.android.material.checkbox.MaterialCheckBox
+                            android:id="@+id/petTransportCheckbox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/order_pet_transport" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
+                            android:text="@string/order_additional_passengers"
+                            android:textSize="@dimen/text_sm"
+                            android:textStyle="bold" />
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddPassenger"
+                            style="@style/Widget.Drumigo.Button.Secondary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs"
+                            android:text="@string/order_add_passenger"
+                            android:textAllCaps="false" />
+                        <LinearLayout
+                            android:id="@+id/passengersContainer"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical" />
+                    </LinearLayout>
+
+                    <!-- Step 3: Confirm -->
+                    <LinearLayout
+                        android:id="@+id/step3Content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:visibility="gone">
+                        <TextView
+                            style="@style/TextStyle.Subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/order_confirm_title" />
+                        <TextView
+                            android:id="@+id/confirmRouteSummary"
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm" />
+                        <TextView
+                            android:id="@+id/confirmDetails"
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_xs" />
+                        <TextView
+                            android:id="@+id/confirmPrice"
+                            style="@style/TextStyle.Title"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm" />
+                        <com.google.android.material.checkbox.MaterialCheckBox
+                            android:id="@+id/termsCheckbox"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
+                            android:text="@string/order_terms_accept" />
+                    </LinearLayout>
 
                     <ProgressBar
                         android:id="@+id/estimateProgress"
@@ -172,160 +399,28 @@
                         android:visibility="gone" />
 
                     <LinearLayout
-                        android:id="@+id/estimateResults"
+                        android:id="@+id/formActions"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:background="@drawable/bg_estimate_results"
-                        android:orientation="vertical"
-                        android:padding="@dimen/spacing_md"
-                        android:visibility="gone">
-
-                        <LinearLayout
+                        android:orientation="horizontal"
+                        android:gravity="end"
+                        android:layout_marginTop="@dimen/spacing_md">
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnBack"
+                            style="@style/Widget.Drumigo.Button.Secondary"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal">
-
-                            <ImageView
-                                android:layout_width="18dp"
-                                android:layout_height="18dp"
-                                android:src="@drawable/ic_check" />
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="@dimen/spacing_xs"
-                                android:text="@string/landing_estimate_summary"
-                                android:textColor="@color/success"
-                                android:textSize="@dimen/text_sm"
-                                android:textStyle="bold" />
-                        </LinearLayout>
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_sm"
-                            android:orientation="horizontal">
-
-                            <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_marginEnd="6dp"
-                                android:layout_weight="1"
-                                android:background="@drawable/bg_estimate_metric_card"
-                                android:gravity="center"
-                                android:orientation="vertical"
-                                android:padding="@dimen/spacing_sm">
-
-                                <TextView
-                                    android:id="@+id/resultEtaValue"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:textColor="@color/text_dark"
-                                    android:textSize="@dimen/text_xl"
-                                    android:textStyle="bold" />
-
-                                <TextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="2dp"
-                                    android:text="@string/landing_estimate_time_label"
-                                    android:textColor="@color/text_light"
-                                    android:textSize="@dimen/text_xs" />
-                            </LinearLayout>
-
-                            <LinearLayout
-                                android:layout_width="0dp"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="6dp"
-                                android:layout_weight="1"
-                                android:background="@drawable/bg_estimate_metric_card"
-                                android:gravity="center"
-                                android:orientation="vertical"
-                                android:padding="@dimen/spacing_sm">
-
-                                <TextView
-                                    android:id="@+id/resultPriceValue"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:textColor="@color/text_dark"
-                                    android:textSize="@dimen/text_xl"
-                                    android:textStyle="bold" />
-
-                                <TextView
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginTop="2dp"
-                                    android:text="@string/landing_estimate_price_label"
-                                    android:textColor="@color/text_light"
-                                    android:textSize="@dimen/text_xs" />
-                            </LinearLayout>
-                        </LinearLayout>
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="10dp"
-                            android:background="@drawable/bg_estimate_metric_card"
-                            android:gravity="center"
-                            android:orientation="horizontal"
-                            android:padding="@dimen/spacing_sm">
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/landing_estimate_distance_label"
-                                android:textColor="@color/primary"
-                                android:textSize="@dimen/text_sm"
-                                android:textStyle="bold" />
-
-                            <TextView
-                                android:id="@+id/resultDistanceValue"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="@dimen/spacing_xs"
-                                android:textColor="@color/text_medium"
-                                android:textSize="@dimen/text_sm" />
-                        </LinearLayout>
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing_md"
-                        android:background="@drawable/bg_estimate_cta"
-                        android:orientation="vertical"
-                        android:padding="@dimen/spacing_md">
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center"
-                            android:text="@string/landing_cta_title"
-                            android:textColor="@color/text_dark"
-                            android:textSize="@dimen/text_md"
-                            android:textStyle="bold" />
-
-                        <TextView
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_xs"
-                            android:gravity="center"
-                            android:lineSpacingExtra="2dp"
-                            android:text="@string/landing_cta_description"
-                            android:textColor="@color/text_light"
-                            android:textSize="@dimen/text_sm" />
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnBookRide"
-                            style="@style/Widget.Drumigo.Button.Primary"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/spacing_sm"
-                            android:text="@string/landing_signup_cta"
+                            android:layout_marginEnd="@dimen/spacing_sm"
+                            android:text="@string/order_back"
                             android:textAllCaps="false"
-                            app:backgroundTint="@color/accent" />
+                            android:visibility="gone" />
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnContinueOrRequest"
+                            style="@style/Widget.Drumigo.Button.Primary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/order_continue"
+                            android:textAllCaps="false" />
                     </LinearLayout>
 
                     <LinearLayout

--- a/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
+++ b/mobile/app/src/main/res/layout/fragment_ride_tracking.xml
@@ -282,6 +282,33 @@
                         </LinearLayout>
                     </com.google.android.material.card.MaterialCardView>
 
+                    <TextView
+                        android:id="@+id/rideNotStartedMessage"
+                        style="@style/TextStyle.Body"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:background="@drawable/bg_estimate_note"
+                        android:padding="@dimen/spacing_md"
+                        android:visibility="gone" />
+
+                    <TextView
+                        android:id="@+id/checkpointsTitle"
+                        style="@style/TextStyle.Caption"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:text="@string/ride_tracking_checkpoints_title"
+                        android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/checkpointsContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_xs"
+                        android:orientation="vertical"
+                        android:visibility="gone" />
+
                     <LinearLayout
                         android:id="@+id/actionButtons"
                         android:layout_width="match_parent"
@@ -290,11 +317,29 @@
                         android:orientation="vertical">
 
                         <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnStartRide"
+                            style="@style/Widget.Drumigo.Button.Primary"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/ride_tracking_start_ride"
+                            android:visibility="gone" />
+
+                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnStopRide"
                             style="@style/Widget.Drumigo.Button.Primary"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
                             android:text="@string/ride_tracking_stop_ride" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnEndRide"
+                            style="@style/Widget.Drumigo.Button.Primary"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            android:text="@string/ride_tracking_end_ride"
+                            android:visibility="gone" />
 
                         <com.google.android.material.button.MaterialButton
                             android:id="@+id/btnCancelRide"
@@ -331,6 +376,71 @@
                         android:padding="@dimen/spacing_md"
                         android:text="@string/ride_tracking_completed"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/nextRideCard"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_md"
+                        android:background="@drawable/bg_estimate_results"
+                        android:orientation="vertical"
+                        android:padding="@dimen/spacing_md"
+                        android:visibility="gone">
+
+                        <TextView
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/ride_tracking_next_ride_pickup" />
+                        <TextView
+                            android:id="@+id/nextRideOrigin"
+                            style="@style/TextStyle.Body"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/text_dark" />
+
+                        <TextView
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            android:text="@string/ride_tracking_next_ride_destination" />
+                        <TextView
+                            android:id="@+id/nextRideDestination"
+                            style="@style/TextStyle.Body"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/text_dark" />
+
+                        <TextView
+                            style="@style/TextStyle.Caption"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            android:text="@string/ride_tracking_next_ride_scheduled" />
+                        <TextView
+                            android:id="@+id/nextRideScheduled"
+                            style="@style/TextStyle.Body"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/text_dark" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnOpenNextRide"
+                            style="@style/Widget.Drumigo.Button.Primary"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_md"
+                            android:text="@string/ride_tracking_open_next_ride" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnViewUpcoming"
+                            style="@style/Widget.Drumigo.Button.Secondary"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/spacing_sm"
+                            android:text="@string/ride_tracking_view_upcoming" />
+                    </LinearLayout>
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
         </LinearLayout>

--- a/mobile/app/src/main/res/layout/item_ride_history.xml
+++ b/mobile/app/src/main/res/layout/item_ride_history.xml
@@ -51,6 +51,15 @@
                     android:textSize="13sp" />
             </LinearLayout>
 
+            <ImageButton
+                android:id="@+id/favoriteStar"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/ride_history_favorite_toggle"
+                android:src="@drawable/ic_star_outline"
+                android:visibility="gone" />
+
             <LinearLayout
                 android:id="@+id/statusBadge"
                 android:layout_width="wrap_content"

--- a/mobile/app/src/main/res/menu/drawer_menu.xml
+++ b/mobile/app/src/main/res/menu/drawer_menu.xml
@@ -33,11 +33,6 @@
             android:title="@string/nav_ride_history" />
 
         <item
-            android:id="@+id/nav_favorite_routes"
-            android:icon="@drawable/ic_person"
-            android:title="@string/nav_favorite_routes" />
-
-        <item
             android:id="@+id/nav_dashboard"
             android:icon="@drawable/ic_menu_dark"
             android:title="@string/nav_dashboard" />

--- a/mobile/app/src/main/res/values/colors.xml
+++ b/mobile/app/src/main/res/values/colors.xml
@@ -31,6 +31,8 @@
     <color name="marker_busy">#F97316</color>
     <!-- danger is an alias used across code; keep for compatibility -->
     <color name="danger">#EF4444</color>
+    <!-- Favorite star (filled) - distinct yellow so it's clearly "favorited" -->
+    <color name="star_filled">#EAB308</color>
 
     <!-- Transparency variants -->
     <color name="primary_10">#1A5B4CDB</color>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -321,6 +321,9 @@
     <string name="order_step_options">Options</string>
     <string name="order_step_confirm">Confirm</string>
     <string name="order_where_going">Where are you going?</string>
+    <string name="order_quick_pick_favorites">Quick pick from favorites</string>
+    <string name="order_favorite_route_hint">Choose favorite route</string>
+    <string name="order_enter_address_manually">Enter address manually</string>
     <string name="order_add_stop">Add stop</string>
     <string name="order_stop_hint">Stop address</string>
     <string name="order_continue">Continue</string>
@@ -357,6 +360,10 @@
     <string name="ride_history_amount_label">Amount:</string>
     <string name="ride_history_cancellation_label">Cancellation:</string>
     <string name="ride_history_none">--</string>
+    <string name="ride_history_favorite_toggle">Add or remove from favorites</string>
+    <string name="favorite_added">Added to favorites</string>
+    <string name="favorite_removed">Removed from favorites</string>
+    <string name="favorite_error">Failed to update favorite</string>
     <string name="ride_history_not_cancelled">No cancellation</string>
     <string name="ride_history_panic_active">Panic triggered</string>
     <string name="ride_history_panic_inactive">No panic event</string>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -131,6 +131,16 @@
     <string name="ride_tracking_to">To</string>
     <string name="ride_tracking_from_placeholder">Start address</string>
     <string name="ride_tracking_to_placeholder">Destination address</string>
+    <string name="ride_tracking_start_ride">Start Ride</string>
+    <string name="ride_tracking_start_ride_loading">Starting…</string>
+    <string name="ride_tracking_start_success">Ride started successfully.</string>
+    <string name="ride_tracking_start_failed">Failed to start ride. Please try again.</string>
+    <string name="ride_tracking_start_accepted_only">Ride can be started only when ACCEPTED. Current status: %1$s.</string>
+    <string name="ride_tracking_end_ride">End Ride</string>
+    <string name="ride_tracking_end_ride_loading">Ending…</string>
+    <string name="ride_tracking_end_success">Ride completed.</string>
+    <string name="ride_tracking_end_failed">Failed to end ride. Please try again.</string>
+    <string name="ride_tracking_end_active_only">Ride can be ended only when ACTIVE. Current status: %1$s.</string>
     <string name="ride_tracking_stop_ride">Stop Ride</string>
     <string name="ride_tracking_cancel_ride">Cancel Ride</string>
     <string name="ride_tracking_cancel_sheet_title_driver">Cancel this ride?</string>
@@ -198,7 +208,21 @@
     <string name="ride_tracking_stop_failed_with_code">Failed to stop ride (%1$d).</string>
     <string name="ride_tracking_panic">Emergency / Panic</string>
     <string name="ride_tracking_report_issue">Report route issue</string>
+    <string name="ride_tracking_inconsistency_sheet_title">Report route issue</string>
+    <string name="ride_tracking_inconsistency_sheet_close">Close</string>
+    <string name="ride_tracking_inconsistency_hint">Describe the issue (minimum 10 characters)</string>
+    <string name="ride_tracking_inconsistency_submit">Submit report</string>
+    <string name="ride_tracking_inconsistency_submitting">Submitting…</string>
+    <string name="ride_tracking_inconsistency_success">Report submitted.</string>
+    <string name="ride_tracking_inconsistency_failed">Failed to submit report. Please try again.</string>
+    <string name="ride_tracking_inconsistency_note_too_short">Please enter at least %1$d characters.</string>
     <string name="ride_tracking_completed">Ride completed</string>
+    <string name="ride_tracking_next_ride_pickup">Next pickup</string>
+    <string name="ride_tracking_next_ride_destination">Destination</string>
+    <string name="ride_tracking_next_ride_scheduled">Scheduled</string>
+    <string name="ride_tracking_open_next_ride">Open next ride</string>
+    <string name="ride_tracking_view_upcoming">View upcoming</string>
+    <string name="ride_tracking_no_upcoming">No upcoming scheduled rides.</string>
     <string name="ride_tracking_load_failed">Unable to load ride tracking</string>
     <string name="ride_tracking_not_implemented">This action is not implemented yet</string>
     <string name="ride_tracking_open_panel">Ride details</string>
@@ -235,6 +259,13 @@
     <string name="ride_tracking_panic_already_sent">Panic alert already sent for this ride.</string>
     <string name="ride_tracking_loading_active_ride">Loading active ride...</string>
     <string name="ride_tracking_no_active_ride">No active ride found.</string>
+    <string name="ride_tracking_not_started_pending">Your ride request is pending driver assignment.</string>
+    <string name="ride_tracking_not_started_accepted">Your ride has been accepted. Waiting for the driver to start the ride.</string>
+    <string name="ride_tracking_checkpoints_title">Checkpoints</string>
+    <string name="ride_tracking_checkpoint_pickup">Pickup</string>
+    <string name="ride_tracking_checkpoint_destination">Destination</string>
+    <string name="ride_tracking_checkpoint_label">Checkpoint %1$d</string>
+    <string name="ride_tracking_checkpoint_waypoint_fallback">Waypoint %1$d</string>
 
     <!-- Registration Messages -->
     <string name="register_success">Registration successful. Please check your email.</string>
@@ -250,7 +281,7 @@
     <string name="login_error_invalid_credentials">Invalid email or password</string>
 
     <!-- Landing -->
-    <string name="landing_title">Estimate your ride</string>
+    <string name="landing_title">Order a ride</string>
     <string name="landing_pickup_hint">Pickup location</string>
     <string name="landing_destination_hint">Destination</string>
     <string name="landing_calculate_estimate">Calculate estimate</string>
@@ -263,6 +294,8 @@
     <string name="landing_vehicle_type_hint">Vehicle type</string>
     <string name="landing_estimate_summary">Route calculated</string>
     <string name="landing_signup_cta">Sign up to book</string>
+    <string name="landing_order_ride_cta">Order ride</string>
+    <string name="landing_order_ride_launcher">Order a ride</string>
     <string name="landing_cta_title">Ready to book this ride?</string>
     <string name="landing_cta_description">Create a free account to book rides, track your driver in real-time, and enjoy seamless travel.</string>
     <string name="landing_estimate_note">This is an estimate only. Actual price may vary based on traffic, route changes, and selected vehicle type.</string>
@@ -282,6 +315,41 @@
     <string name="landing_estimate_eta_format">Estimated time: ~%1$d min</string>
     <string name="landing_estimate_price_format">Estimated price: ~%.0f RSD</string>
     <string name="landing_estimate_distance_format">Distance: %.1f km</string>
+
+    <!-- Order ride 3-step flow -->
+    <string name="order_step_route">Route</string>
+    <string name="order_step_options">Options</string>
+    <string name="order_step_confirm">Confirm</string>
+    <string name="order_where_going">Where are you going?</string>
+    <string name="order_add_stop">Add stop</string>
+    <string name="order_stop_hint">Stop address</string>
+    <string name="order_continue">Continue</string>
+    <string name="order_ride_options">Ride options</string>
+    <string name="order_schedule_ride">Schedule ride</string>
+    <string name="order_schedule_now">For now</string>
+    <string name="order_schedule_later">For later</string>
+    <string name="order_schedule_hours">Hours</string>
+    <string name="order_schedule_minutes">Minutes</string>
+    <string name="order_schedule_max_hint">Max 5 hours from now</string>
+    <string name="order_baby_seat">Baby seat required</string>
+    <string name="order_pet_transport">Pet transport</string>
+    <string name="order_additional_passengers">Additional passengers</string>
+    <string name="order_add_passenger">Add passenger</string>
+    <string name="order_passenger_email_hint">Passenger email</string>
+    <string name="order_confirm_title">Confirm your ride</string>
+    <string name="order_route_summary">Route summary</string>
+    <string name="order_pickup">Pickup</string>
+    <string name="order_stop">Stop</string>
+    <string name="order_dropoff">Dropoff</string>
+    <string name="order_vehicle_type">Vehicle type</string>
+    <string name="order_distance">Distance</string>
+    <string name="order_duration">Duration</string>
+    <string name="order_scheduled">Scheduled</string>
+    <string name="order_scheduled_now">Now</string>
+    <string name="order_estimated_fare">Estimated fare</string>
+    <string name="order_terms_accept">I agree to the terms and conditions</string>
+    <string name="order_request_ride">Request ride</string>
+    <string name="order_back">Back</string>
 
     <!-- Ride History -->
     <string name="ride_history_subtitle">View all your completed and cancelled rides</string>


### PR DESCRIPTION
This pull request introduces several backend and mobile app improvements focused on ride tracking synchronization, favorite routes handling, driver assignment logic, and some UI and API enhancements. The most significant changes include adding new endpoints and logic to keep the backend vehicle position in sync with the client's displayed position, improving favorite route retrieval to avoid duplicates, refining driver assignment rejection logic, and enhancing the ride tracking simulation to better match client-side behavior.

**Ride Tracking Synchronization:**

* Added a new endpoint `PUT /{id}/tracking-position` in `RideController` allowing drivers or passengers to sync the displayed vehicle position with the backend, ensuring consistent tracking between client and server. (`RideController.java`, `RideService.java`, `VehicleService.java`) [[1]](diffhunk://#diff-00cd089c5e27a5f47f4cfbbf345903e13765566ca2c837db4be7e503097b762cR148-R161) [[2]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R172-R204) [[3]](diffhunk://#diff-114b014dbe668f249ef057d63a3544d571faedd3a5955ed36611a69e996ae560R142-R151)
* The ride tracking simulation now caps backend vehicle movement per tick to 40 meters and advances simulation based on the latest backend or client-updated position, keeping the simulation and client display closely aligned. (`RideTrackingSimulationService.java`) [[1]](diffhunk://#diff-af9e1dcd31ceb86e460639db26f32a6fb8b33360961e30a98395891cd4b01914L34-R35) [[2]](diffhunk://#diff-af9e1dcd31ceb86e460639db26f32a6fb8b33360961e30a98395891cd4b01914R119-R132) [[3]](diffhunk://#diff-af9e1dcd31ceb86e460639db26f32a6fb8b33360961e30a98395891cd4b01914R146-R185)

**Favorite Routes Handling:**

* Updated favorite routes retrieval to return at most one route per source ride (keeping the latest), preventing duplicates in the passenger's favorite routes list. (`FavoriteRouteService.java`)

**Driver Assignment Logic:**

* Improved driver assignment logic for immediate rides: now, only drivers not currently on a ride are considered, and if none are available, a clear "No drivers available" message is returned instead of fallback assignment attempts. (`RideService.java`) [[1]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50L60-R61) [[2]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50L538-R574) [[3]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50R624-R627) [[4]](diffhunk://#diff-737f7d1a345e5d0cdf04e85c4138f73e1373c6c4f4f2caaa633cc91b83814e50L605-R645)

**Mobile App and API Enhancements:**

* Added a new `MapboxSearchBoxService` for address autocomplete and exposed it through the API client. (`MapboxSearchBoxService.java`, `MapboxApiClient.java`) [[1]](diffhunk://#diff-98b83de6ffbfffd3958e45ba7cab2df1daad85c104d339f3aec57127e5f75771R1-R23) [[2]](diffhunk://#diff-2f1febb78e3e753fa5b5bf5e25055d6651ec267ffa2e07a81fa4bd149758e93fR22-R25)
* Set `android:usesCleartextTraffic="true"` in the manifest to allow HTTP traffic during development. (`AndroidManifest.xml`)
* Updated build configuration to enable deprecation warnings for Java code. (`build.gradle.kts`)

**UI and Navigation Adjustments:**

* Adjusted navigation in `MainActivity` to route "Order Ride" to the landing fragment and made minor changes to drawer menu item visibility. (`MainActivity.java`) [[1]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L323) [[2]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L355) [[3]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L476-R474)