### PR TITLE
[MOB 31] Panic notif

### DIFF
--- a/mobile/app/src/main/AndroidManifest.xml
+++ b/mobile/app/src/main/AndroidManifest.xml
@@ -87,6 +87,11 @@
             android:exported="false"
             android:label="@string/admin_notifications_title" />
 
+        <activity
+            android:name="com.drumigo.mobile.ui.admin.AdminPanicNotificationsActivity"
+            android:exported="false"
+            android:label="@string/nav_panic_notifications" />
+
     </application>
 
 </manifest>

--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -373,7 +373,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             setDrawerItemState(menu, R.id.nav_dashboard, true, false);
             setDrawerItemState(menu, R.id.nav_active_rides_admin, true, false);
             setDrawerItemState(menu, R.id.nav_ride_history, true, true);
-            setDrawerItemState(menu, R.id.nav_panic_notifications, true, false);
+            setDrawerItemState(menu, R.id.nav_panic_notifications, true, true);
             setDrawerItemState(menu, R.id.nav_live_support, true, true);
             setDrawerItemState(menu, R.id.nav_register_driver, true, false);
             setDrawerItemState(menu, R.id.nav_drivers, false, false);
@@ -606,6 +606,10 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         } else if (itemId == R.id.nav_all_notifications) {
             if (isUserAuthenticated() && ROLE_ADMIN.equals(getCurrentRoleNormalized())) {
                 startActivity(new Intent(this, com.drumigo.mobile.ui.admin.AdminNotificationsActivity.class));
+            }
+        } else if (itemId == R.id.nav_panic_notifications) {
+            if (isUserAuthenticated() && ROLE_ADMIN.equals(getCurrentRoleNormalized())) {
+                startActivity(new Intent(this, com.drumigo.mobile.ui.admin.AdminPanicNotificationsActivity.class));
             }
         } else {
             android.widget.Toast.makeText(

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/ApiClient.java
@@ -52,6 +52,10 @@ public class ApiClient {
         return getRetrofit().create(NotificationApiService.class);
     }
 
+    public static PanicApiService getPanicApiService() {
+        return getRetrofit().create(PanicApiService.class);
+    }
+
     public static UserApiService getUserApiService() {
         return getRetrofit().create(UserApiService.class);
     }

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/api/PanicApiService.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/api/PanicApiService.java
@@ -1,0 +1,21 @@
+package com.drumigo.mobile.data.api;
+
+import com.drumigo.mobile.data.model.history.PageResponse;
+import com.drumigo.mobile.data.model.panic.PanicEventResponse;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+/**
+ * Panic events API for admin. GET /api/panic-events (admin only).
+ */
+public interface PanicApiService {
+
+    @GET("panic-events")
+    Call<PageResponse<PanicEventResponse>> getPanicEvents(
+        @Query("page") int page,
+        @Query("size") int size,
+        @Query("sort") String sort
+    );
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/data/model/panic/PanicEventResponse.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/data/model/panic/PanicEventResponse.java
@@ -1,0 +1,13 @@
+package com.drumigo.mobile.data.model.panic;
+
+/**
+ * Matches backend PanicEventResponse. createdAt is ISO-8601 string.
+ */
+public class PanicEventResponse {
+    public Long id;
+    public Long rideId;
+    public Long userId;
+    public String userEmail;
+    public String reason;
+    public String createdAt;
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/admin/AdminPanicEventAdapter.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/admin/AdminPanicEventAdapter.java
@@ -1,0 +1,103 @@
+package com.drumigo.mobile.ui.admin;
+
+import android.content.Context;
+import android.content.Intent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.model.panic.PanicEventResponse;
+import com.drumigo.mobile.ui.history.RideHistoryActivity;
+
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+
+public class AdminPanicEventAdapter extends RecyclerView.Adapter<AdminPanicEventAdapter.ViewHolder> {
+
+    private final List<PanicEventResponse> items = new ArrayList<>();
+
+    public void setItems(List<PanicEventResponse> list) {
+        items.clear();
+        if (list != null) {
+            items.addAll(list);
+        }
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+            .inflate(R.layout.item_admin_panic_event, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        if (position < 0 || position >= items.size()) return;
+        PanicEventResponse e = items.get(position);
+        holder.time.setText(formatDate(e.createdAt));
+        holder.rideId.setText("Ride #" + (e.rideId != null ? e.rideId : ""));
+        holder.userEmail.setText(e.userEmail != null ? e.userEmail : "");
+        if (e.reason != null && !e.reason.trim().isEmpty()) {
+            holder.reason.setVisibility(View.VISIBLE);
+            holder.reason.setText(e.reason);
+        } else {
+            holder.reason.setVisibility(View.GONE);
+        }
+        holder.viewRide.setOnClickListener(v -> {
+            Context ctx = v.getContext();
+            ctx.startActivity(new Intent(ctx, RideHistoryActivity.class));
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    private static String formatDate(String iso) {
+        if (iso == null || iso.isEmpty()) return "—";
+        try {
+            SimpleDateFormat in = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US);
+            in.setLenient(true);
+            Date date = in.parse(iso, new ParsePosition(0));
+            if (date == null) {
+                SimpleDateFormat alt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+                date = alt.parse(iso, new ParsePosition(0));
+            }
+            if (date == null) return iso;
+            SimpleDateFormat out = new SimpleDateFormat("dd/MM/yyyy, HH:mm", Locale.getDefault());
+            return out.format(date);
+        } catch (Exception ex) {
+            return iso;
+        }
+    }
+
+    static final class ViewHolder extends RecyclerView.ViewHolder {
+        final TextView time;
+        final TextView rideId;
+        final TextView userEmail;
+        final TextView reason;
+        final Button viewRide;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+            time = itemView.findViewById(R.id.panicItemTime);
+            rideId = itemView.findViewById(R.id.panicItemRideId);
+            userEmail = itemView.findViewById(R.id.panicItemUserEmail);
+            reason = itemView.findViewById(R.id.panicItemReason);
+            viewRide = itemView.findViewById(R.id.panicItemViewRide);
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/admin/AdminPanicNotificationsActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/admin/AdminPanicNotificationsActivity.java
@@ -1,0 +1,175 @@
+package com.drumigo.mobile.ui.admin;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.drumigo.mobile.R;
+import com.drumigo.mobile.data.api.ApiClient;
+import com.drumigo.mobile.data.api.PanicApiService;
+import com.drumigo.mobile.data.model.history.PageResponse;
+import com.drumigo.mobile.data.model.panic.PanicEventResponse;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class AdminPanicNotificationsActivity extends AppCompatActivity {
+
+    private static final int PAGE_SIZE = 10;
+    private static final String SORT = "createdAt,desc";
+
+    private PanicApiService panicApiService;
+    private RecyclerView recyclerView;
+    private ProgressBar loadingView;
+    private TextView emptyText;
+    private TextView errorText;
+    private View paginationRow;
+    private Button prevButton;
+    private TextView pageText;
+    private Button nextButton;
+
+    private AdminPanicEventAdapter adapter;
+    private int currentPage = 0;
+    private int totalPages = 0;
+    private int totalElements = 0;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_admin_panic_notifications);
+
+        panicApiService = ApiClient.getPanicApiService();
+
+        setupToolbar();
+        bindViews();
+        setupList();
+        setupPagination();
+        loadPage(0);
+    }
+
+    private void setupToolbar() {
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setTitle(R.string.nav_panic_notifications);
+        }
+    }
+
+    private void bindViews() {
+        recyclerView = findViewById(R.id.adminPanicRecyclerView);
+        loadingView = findViewById(R.id.adminPanicLoading);
+        emptyText = findViewById(R.id.adminPanicEmptyText);
+        errorText = findViewById(R.id.adminPanicErrorText);
+        paginationRow = findViewById(R.id.adminPanicPagination);
+        prevButton = findViewById(R.id.adminPanicPrevButton);
+        pageText = findViewById(R.id.adminPanicPageText);
+        nextButton = findViewById(R.id.adminPanicNextButton);
+    }
+
+    private void setupList() {
+        adapter = new AdminPanicEventAdapter();
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setAdapter(adapter);
+    }
+
+    private void setupPagination() {
+        if (prevButton != null) {
+            prevButton.setOnClickListener(v -> {
+                if (currentPage > 0) {
+                    loadPage(currentPage - 1);
+                }
+            });
+        }
+        if (nextButton != null) {
+            nextButton.setOnClickListener(v -> {
+                if (currentPage < totalPages - 1) {
+                    loadPage(currentPage + 1);
+                }
+            });
+        }
+    }
+
+    private void loadPage(int page) {
+        currentPage = page;
+        recyclerView.setVisibility(View.GONE);
+        emptyText.setVisibility(View.GONE);
+        errorText.setVisibility(View.GONE);
+        loadingView.setVisibility(View.VISIBLE);
+        paginationRow.setVisibility(View.GONE);
+
+        panicApiService.getPanicEvents(currentPage, PAGE_SIZE, SORT)
+            .enqueue(new Callback<PageResponse<PanicEventResponse>>() {
+                @Override
+                public void onResponse(
+                    @NonNull Call<PageResponse<PanicEventResponse>> call,
+                    @NonNull Response<PageResponse<PanicEventResponse>> response
+                ) {
+                    loadingView.setVisibility(View.GONE);
+                    if (!response.isSuccessful() || response.body() == null) {
+                        errorText.setVisibility(View.VISIBLE);
+                        errorText.setText(R.string.admin_panic_error);
+                        return;
+                    }
+                    PageResponse<PanicEventResponse> body = response.body();
+                    List<PanicEventResponse> content = body.content;
+                    totalPages = body.totalPages;
+                    totalElements = body.totalElements;
+
+                    if (content == null || content.isEmpty()) {
+                        emptyText.setVisibility(View.VISIBLE);
+                    } else {
+                        adapter.setItems(content);
+                        recyclerView.setVisibility(View.VISIBLE);
+                    }
+                    updatePaginationUi();
+                }
+
+                @Override
+                public void onFailure(
+                    @NonNull Call<PageResponse<PanicEventResponse>> call,
+                    @NonNull Throwable t
+                ) {
+                    loadingView.setVisibility(View.GONE);
+                    errorText.setVisibility(View.VISIBLE);
+                    errorText.setText(R.string.admin_panic_error);
+                    updatePaginationUi();
+                }
+            });
+    }
+
+    private void updatePaginationUi() {
+        if (totalElements == 0 && (adapter == null || adapter.getItemCount() == 0)) {
+            paginationRow.setVisibility(View.GONE);
+            return;
+        }
+        paginationRow.setVisibility(View.VISIBLE);
+        int shownPages = Math.max(totalPages, 1);
+        if (pageText != null) {
+            pageText.setText(getString(R.string.admin_notifications_page_info, currentPage + 1, shownPages, totalElements));
+        }
+        if (prevButton != null) prevButton.setEnabled(currentPage > 0);
+        if (nextButton != null) nextButton.setEnabled(currentPage < totalPages - 1);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/mobile/app/src/main/res/layout/activity_admin_panic_notifications.xml
+++ b/mobile/app/src/main/res/layout/activity_admin_panic_notifications.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/bg_cream"
+    tools:context=".ui.admin.AdminPanicNotificationsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        app:elevation="0dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/white"
+            app:title="@string/nav_panic_notifications"
+            app:titleTextColor="@color/text_dark"
+            app:navigationIcon="@drawable/ic_arrow_back" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/admin_panic_subtitle"
+            android:textColor="@color/text_light"
+            android:textSize="14sp" />
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="12dp"
+            android:layout_weight="1"
+            android:minHeight="120dp">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/adminPanicRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingBottom="8dp"
+                android:visibility="gone"
+                tools:listitem="@layout/item_admin_panic_event"
+                tools:visibility="visible" />
+
+            <ProgressBar
+                android:id="@+id/adminPanicLoading"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/adminPanicEmptyText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:padding="24dp"
+                android:text="@string/admin_panic_empty"
+                android:textColor="@color/text_light"
+                android:textAlignment="center"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <TextView
+                android:id="@+id/adminPanicErrorText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:padding="24dp"
+                android:textColor="@color/error"
+                android:visibility="gone"
+                tools:text="Failed to load"
+                tools:visibility="visible" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:id="@+id/adminPanicPagination"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <Button
+                android:id="@+id/adminPanicPrevButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/admin_notifications_previous" />
+
+            <TextView
+                android:id="@+id/adminPanicPageText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:textColor="@color/text_medium"
+                tools:text="Page 1 of 1 (0 total)" />
+
+            <Button
+                android:id="@+id/adminPanicNextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/admin_notifications_next" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/mobile/app/src/main/res/layout/item_admin_panic_event.xml
+++ b/mobile/app/src/main/res/layout/item_admin_panic_event.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/spacing_sm"
+    app:cardBackgroundColor="@color/white"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/panicItemTime"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textColor="@color/text_dark"
+                android:textSize="14sp"
+                tools:text="22/02/2025, 14:30" />
+
+            <TextView
+                android:id="@+id/panicItemRideId"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/text_medium"
+                android:textSize="13sp"
+                tools:text="Ride #42" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/panicItemUserEmail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textColor="@color/text_dark"
+            android:textSize="13sp"
+            tools:text="user@example.com" />
+
+        <TextView
+            android:id="@+id/panicItemReason"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:textColor="@color/text_light"
+            android:textSize="12sp"
+            android:visibility="gone"
+            tools:text="Reason text"
+            tools:visibility="visible" />
+
+        <Button
+            android:id="@+id/panicItemViewRide"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/admin_panic_view_ride" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -179,6 +179,10 @@
     <string name="admin_panic_notification_channel_description">Emergency panic alerts from active rides</string>
     <string name="admin_panic_notification_title">PANIC alert</string>
     <string name="admin_panic_notification_fallback">A panic event has been triggered.</string>
+    <string name="admin_panic_subtitle">Review emergency alerts from passengers and drivers during rides. Use ride history to follow up as needed.</string>
+    <string name="admin_panic_empty">No panic notifications. Alerts will appear here when triggered during active rides.</string>
+    <string name="admin_panic_error">Failed to load panic notifications.</string>
+    <string name="admin_panic_view_ride">View ride</string>
     <string name="user_notification_channel_name">Notifications</string>
     <string name="user_notification_channel_description">Ride and app notifications</string>
     <string name="nav_active_vehicles">Active Vehicles</string>


### PR DESCRIPTION
This pull request introduces a new admin feature for viewing panic (emergency) notifications in the mobile app. It adds a dedicated screen for admins to review panic events triggered by users during rides, including pagination, error handling, and integration with backend APIs. The navigation drawer is updated to allow access to this new screen for admin users.

**New admin panic notifications feature:**

* Added a new screen, `AdminPanicNotificationsActivity`, for admins to view and paginate through panic events, with error and empty states, and the ability to navigate to ride history. [[1]](diffhunk://#diff-55e558301865b3a40c9995750c57f0e04ad9cd6ef4fd9677185a034b3885f09aR1-R175) [[2]](diffhunk://#diff-d45e9f82d87fdbe0d497ac3ad70d06648779d11c19c88d5025738e71fdbba9d0R1-R123) [[3]](diffhunk://#diff-f2ad77cb4e0be2fd0a99704e4a1daa4ea4e8891fa9e66db88af32cf60c38ec13R1-R71) [[4]](diffhunk://#diff-dbc286255b6d5bba5c9bdab6a0e8d656f4b3cff6df010b6f38bdd97faa946c3aR182-R185)
* Created a new RecyclerView adapter, `AdminPanicEventAdapter`, to display panic event details in a card layout, including event time, user email, reason, and a button to view the related ride. [[1]](diffhunk://#diff-2e1960c0387f7ae549225c61ca216485487bea121c07fa5c589f5057b5487a03R1-R103) [[2]](diffhunk://#diff-f2ad77cb4e0be2fd0a99704e4a1daa4ea4e8891fa9e66db88af32cf60c38ec13R1-R71)
* Introduced a new API interface, `PanicApiService`, and corresponding model `PanicEventResponse`, to fetch panic events from the backend. [[1]](diffhunk://#diff-099e9a29e80ad40e06a4d92a8038a760246b2bf2063a33fdc46407d0331db4c7R1-R21) [[2]](diffhunk://#diff-d2c44d70fda2a36622a1471b892250e2a4cfaa57dd665a3bfa30528eacd64c1cR1-R13)
* Updated `ApiClient` to provide access to the new `PanicApiService`.

**Navigation and access control:**

* Registered the new activity in the manifest and updated the navigation drawer logic to show the "Panic Notifications" item for admins, launching the new activity when selected. [[1]](diffhunk://#diff-bce0c3202d674f0041e23230c200feb777301569b8d8d0ed586dff00021b3c84R90-R94) [[2]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48L376-R376) [[3]](diffhunk://#diff-520e7d21379e902127f48b9b30c0acdc31f9d40857dd1089b891d4fd11d21a48R610-R613)