### PR TITLE
[MOB 32] Admin ride tracking

### DIFF
--- a/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/MainActivity.java
@@ -85,6 +85,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private static final long MY_NOTIFICATION_POLLING_INTERVAL_MS = 6_000L;
     private static final int MY_NOTIFICATION_PAGE_SIZE = 20;
 
+    /** Intent extra: ride ID when opening ride tracking from admin ride history (view-only). */
+    public static final String EXTRA_ADMIN_TRACK_RIDE_ID = "admin_track_ride_id";
+    /** Intent extra: true when opening ride tracking in admin view-only mode. */
+    public static final String EXTRA_ADMIN_VIEW_ONLY = "admin_view_only";
+
     private ActivityMainBinding binding;
     private NavController navController;
     private DrawerLayout drawerLayout;
@@ -200,6 +205,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         startAdminPanicNotificationPollingIfNeeded();
         startMyNotificationPollingIfNeeded();
         openNotificationsIfRequested();
+        openAdminTrackRideIfRequested();
     }
 
     private void openNotificationsIfRequested() {
@@ -209,6 +215,19 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         NavDestination current = navController.getCurrentDestination();
         if (current != null && current.getId() == R.id.notificationsFragment) return;
         navController.navigate(R.id.notificationsFragment);
+    }
+
+    private void openAdminTrackRideIfRequested() {
+        if (navController == null || getIntent() == null) return;
+        if (!getIntent().hasExtra(EXTRA_ADMIN_TRACK_RIDE_ID) || !getIntent().getBooleanExtra(EXTRA_ADMIN_VIEW_ONLY, false)) return;
+        long rideId = getIntent().getLongExtra(EXTRA_ADMIN_TRACK_RIDE_ID, 0L);
+        getIntent().removeExtra(EXTRA_ADMIN_TRACK_RIDE_ID);
+        getIntent().removeExtra(EXTRA_ADMIN_VIEW_ONLY);
+        if (rideId <= 0L) return;
+        Bundle args = new Bundle();
+        args.putLong("rideId", rideId);
+        args.putBoolean("adminViewOnly", true);
+        navController.navigate(R.id.rideTrackingFragment, args);
     }
 
     @Override
@@ -369,9 +388,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         if (ROLE_ADMIN.equals(role)) {
-            // Mirrors web admin navbar placeholders.
-            setDrawerItemState(menu, R.id.nav_dashboard, true, false);
-            setDrawerItemState(menu, R.id.nav_active_rides_admin, true, false);
             setDrawerItemState(menu, R.id.nav_ride_history, true, true);
             setDrawerItemState(menu, R.id.nav_panic_notifications, true, true);
             setDrawerItemState(menu, R.id.nav_live_support, true, true);
@@ -423,8 +439,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             R.id.nav_ride_tracking,
             R.id.nav_ride_history,
             R.id.nav_notifications,
-            R.id.nav_dashboard,
-            R.id.nav_active_rides_admin,
             R.id.nav_panic_notifications,
             R.id.nav_live_support,
             R.id.nav_register_driver,

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryActivity.java
@@ -1,5 +1,6 @@
 package com.drumigo.mobile.ui.history;
 
+import android.content.Intent;
 import android.app.DatePickerDialog;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
@@ -24,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.tabs.TabLayout;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
+import com.drumigo.mobile.MainActivity;
 import com.drumigo.mobile.R;
 import com.drumigo.mobile.data.api.AdminApiService;
 import com.drumigo.mobile.data.api.ApiClient;
@@ -56,7 +58,8 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class RideHistoryActivity extends AppCompatActivity
-    implements RideHistoryAdapter.OnRideClickListener, RideHistoryAdapter.OnFavoriteToggleListener {
+    implements RideHistoryAdapter.OnRideClickListener, RideHistoryAdapter.OnFavoriteToggleListener,
+    RideHistoryAdapter.OnTrackRideClickListener {
 
     private static final String TAG = "RideHistoryActivity";
     private static final String ROLE_DRIVER = "DRIVER";
@@ -279,12 +282,15 @@ public class RideHistoryActivity extends AppCompatActivity
 
     private void setupRecyclerView() {
         boolean showFavorite = ROLE_PASSENGER.equals(currentRole);
+        boolean showTrackButton = ROLE_ADMIN.equals(currentRole);
         adapter = new RideHistoryAdapter(
             new ArrayList<>(),
             this,
             this,
             showFavorite,
-            showFavorite ? this : null
+            showFavorite ? this : null,
+            showTrackButton,
+            showTrackButton ? this : null
         );
         if (recyclerView != null) {
             recyclerView.setLayoutManager(new LinearLayoutManager(this));
@@ -709,6 +715,18 @@ public class RideHistoryActivity extends AppCompatActivity
         boolean showRating = ROLE_PASSENGER.equals(currentRole);
         RideApiService rideApiService = showRating ? ApiClient.getRideApiService() : null;
         RideHistoryDetailsBottomSheet.show(this, ride, showRating, rideApiService);
+    }
+
+    @Override
+    public void onTrackRideClicked(Ride ride) {
+        if (ride == null || ride.getId() == null) {
+            return;
+        }
+        Intent intent = new Intent(this, MainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(MainActivity.EXTRA_ADMIN_TRACK_RIDE_ID, ride.getId().longValue());
+        intent.putExtra(MainActivity.EXTRA_ADMIN_VIEW_ONLY, true);
+        startActivity(intent);
     }
 
     @Override

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/history/RideHistoryAdapter.java
@@ -10,6 +10,8 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.google.android.material.button.MaterialButton;
+
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
@@ -32,20 +34,30 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         void onFavoriteToggled(Ride ride);
     }
 
+    public interface OnTrackRideClickListener {
+        void onTrackRideClicked(Ride ride);
+    }
+
     private List<Ride> rides;
     private final Context context;
     private final OnRideClickListener onRideClickListener;
     /** True only for Passenger tab; Driver and Admin do not show favorite button. */
     private final boolean showFavoriteButton;
     private final OnFavoriteToggleListener onFavoriteToggleListener;
+    /** True only for Admin tab; show "Track ride" for in-progress rides. */
+    private final boolean showTrackButton;
+    private final OnTrackRideClickListener onTrackRideClickListener;
 
     public RideHistoryAdapter(List<Ride> rides, Context context, OnRideClickListener onRideClickListener,
-                              boolean showFavoriteButton, OnFavoriteToggleListener onFavoriteToggleListener) {
+                              boolean showFavoriteButton, OnFavoriteToggleListener onFavoriteToggleListener,
+                              boolean showTrackButton, OnTrackRideClickListener onTrackRideClickListener) {
         this.rides = rides == null ? Collections.emptyList() : rides;
         this.context = context;
         this.onRideClickListener = onRideClickListener;
         this.showFavoriteButton = showFavoriteButton;
         this.onFavoriteToggleListener = onFavoriteToggleListener;
+        this.showTrackButton = showTrackButton;
+        this.onTrackRideClickListener = onTrackRideClickListener;
     }
 
     @NonNull
@@ -73,6 +85,7 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         bindStatusSection(holder, ride);
         bindBottomSummary(holder, ride);
         bindFavoriteStar(holder, ride);
+        bindTrackButton(holder, ride);
 
         holder.itemView.setOnClickListener(v -> {
             if (onRideClickListener != null) {
@@ -98,6 +111,29 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
             }
             v.setClickable(true);
         });
+    }
+
+    private void bindTrackButton(RideViewHolder holder, Ride ride) {
+        boolean show = showTrackButton && isInProgress(ride) && onTrackRideClickListener != null;
+        holder.btnTrackRide.setVisibility(show ? View.VISIBLE : View.GONE);
+        if (!show) {
+            return;
+        }
+        holder.btnTrackRide.setOnClickListener(v -> {
+            v.setClickable(false);
+            if (onTrackRideClickListener != null) {
+                onTrackRideClickListener.onTrackRideClicked(ride);
+            }
+            v.setClickable(true);
+        });
+    }
+
+    private static boolean isInProgress(Ride ride) {
+        if (ride == null || ride.getStatus() == null) {
+            return false;
+        }
+        String normalized = ride.getStatus().trim().toUpperCase().replace(" ", "_");
+        return "ACTIVE".equals(normalized) || "IN_PROGRESS".equals(normalized);
     }
 
     private void bindRouteAndTime(RideViewHolder holder, Ride ride) {
@@ -178,6 +214,7 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
         TextView priceText;
         View panicIndicator;
         ImageView panicIcon;
+        MaterialButton btnTrackRide;
 
         RideViewHolder(@NonNull View itemView) {
             super(itemView);
@@ -194,6 +231,7 @@ public class RideHistoryAdapter extends RecyclerView.Adapter<RideHistoryAdapter.
             priceText = itemView.findViewById(R.id.priceText);
             panicIndicator = itemView.findViewById(R.id.panicIndicator);
             panicIcon = itemView.findViewById(R.id.panicIcon);
+            btnTrackRide = itemView.findViewById(R.id.btnTrackRide);
         }
     }
 }

--- a/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
+++ b/mobile/app/src/main/java/com/drumigo/mobile/ui/ride/RideTrackingFragment.java
@@ -73,6 +73,7 @@ import retrofit2.Response;
 public class RideTrackingFragment extends Fragment {
 
     private static final String ARG_RIDE_ID = "rideId";
+    private static final String ARG_ADMIN_VIEW_ONLY = "adminViewOnly";
     private static final String ROLE_DRIVER = "DRIVER";
     private static final String ROLE_PASSENGER = "PASSENGER";
     private static final double DEFAULT_LNG = 19.8200;
@@ -123,6 +124,7 @@ public class RideTrackingFragment extends Fragment {
     private RoutePoint lastBackendLocation = null;
     private String currentRoleNormalized = "";
     private long rideId;
+    private boolean adminViewOnly = false;
     private boolean pendingActiveRideLookup = false;
     private RoutePoint previousLocation;
     private int lastPassedWaypointOrder = Integer.MIN_VALUE;
@@ -160,7 +162,8 @@ public class RideTrackingFragment extends Fragment {
         sessionManager = SessionManager.getInstance(requireContext());
         currentRoleNormalized = getCurrentRoleNormalized();
         rideId = getArguments() != null ? getArguments().getLong(ARG_RIDE_ID, 0L) : 0L;
-        if (rideId == 0L) {
+        adminViewOnly = getArguments() != null && getArguments().getBoolean(ARG_ADMIN_VIEW_ONLY, false);
+        if (rideId == 0L && !adminViewOnly) {
             if (RideTrackingConfig.USE_MOCK_UPDATES) {
                 rideId = RideTrackingConfig.MOCK_RIDE_ID;
             } else {
@@ -186,6 +189,14 @@ public class RideTrackingFragment extends Fragment {
         mapView = binding.mapView;
         setupMap();
         setupActions();
+        if (adminViewOnly) {
+            if (binding.actionButtons != null) {
+                binding.actionButtons.setVisibility(View.GONE);
+            }
+            if (binding.nextRideCard != null) {
+                binding.nextRideCard.setVisibility(View.GONE);
+            }
+        }
         setupTrackingPanel();
     }
 
@@ -964,6 +975,16 @@ public class RideTrackingFragment extends Fragment {
     }
 
     private void startTracking() {
+        if (adminViewOnly) {
+            if (rideId <= 0L) {
+                showNoActiveRideError();
+                return;
+            }
+            fetchRideTracking();
+            pollingHandler.removeCallbacks(backendPollingRunnable);
+            pollingHandler.postDelayed(backendPollingRunnable, LOCATION_POLLING_INTERVAL_MS);
+            return;
+        }
         if (pendingActiveRideLookup || rideId == 0L) {
             resolveActiveRideAndStartTracking();
             return;
@@ -1272,7 +1293,7 @@ public class RideTrackingFragment extends Fragment {
 
     /** Sends the displayed (capped) position to the backend so it stays in sync with what we show. */
     private void syncDisplayPositionToBackend(RoutePoint displayLocation) {
-        if (rideId == 0L || displayLocation == null || rideApiService == null) {
+        if (adminViewOnly || rideId == 0L || displayLocation == null || rideApiService == null) {
             return;
         }
         rideApiService.updateTrackingPosition(rideId, new com.drumigo.mobile.data.model.ride.RideTrackingPositionRequest(displayLocation.lat, displayLocation.lng))

--- a/mobile/app/src/main/res/layout/item_ride_history.xml
+++ b/mobile/app/src/main/res/layout/item_ride_history.xml
@@ -243,6 +243,15 @@
             </FrameLayout>
         </LinearLayout>
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnTrackRide"
+            style="@style/Widget.Drumigo.Button.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/ride_history_track_ride"
+            android:visibility="gone" />
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/mobile/app/src/main/res/menu/drawer_menu.xml
+++ b/mobile/app/src/main/res/menu/drawer_menu.xml
@@ -38,16 +38,6 @@
             android:title="@string/nav_notifications" />
 
         <item
-            android:id="@+id/nav_dashboard"
-            android:icon="@drawable/ic_menu_dark"
-            android:title="@string/nav_dashboard" />
-
-        <item
-            android:id="@+id/nav_active_rides_admin"
-            android:icon="@drawable/ic_car"
-            android:title="@string/nav_active_rides_admin" />
-
-        <item
             android:id="@+id/nav_panic_notifications"
             android:icon="@drawable/ic_warning"
             android:title="@string/nav_panic_notifications" />

--- a/mobile/app/src/main/res/navigation/nav_graph.xml
+++ b/mobile/app/src/main/res/navigation/nav_graph.xml
@@ -27,6 +27,10 @@
             android:name="rideId"
             app:argType="long"
             android:defaultValue="0L" />
+        <argument
+            android:name="adminViewOnly"
+            app:argType="boolean"
+            android:defaultValue="false" />
     </fragment>
 
     <fragment

--- a/mobile/app/src/main/res/values/strings.xml
+++ b/mobile/app/src/main/res/values/strings.xml
@@ -103,8 +103,6 @@
     <string name="nav_ride_history">Ride History</string>
     <string name="nav_favorite_routes">Favorite Routes</string>
     <string name="nav_support">Support</string>
-    <string name="nav_dashboard">Dashboard</string>
-    <string name="nav_active_rides_admin">Active Rides</string>
     <string name="nav_panic_notifications">Panic Notifications</string>
     <string name="nav_live_support">Live Support / Chat</string>
     <string name="nav_register_driver">Register Driver</string>
@@ -466,6 +464,7 @@
     <string name="ride_history_route_map_loading">Loading route map...</string>
     <string name="ride_history_route_map_error">Unable to load route on map</string>
     <string name="ride_history_route_map_missing_addresses">Missing pickup or destination address</string>
+    <string name="ride_history_track_ride">Track ride</string>
 
     <!-- Ride rating (passenger) -->
     <string name="ride_rating_title">Rate your ride</string>


### PR DESCRIPTION
This pull request introduces a new "Track ride" feature for admins in the ride history screen, allowing them to view a ride's tracking screen in a read-only mode. It also cleans up the admin navigation drawer by removing unused dashboard and active rides menu items. The most important changes are grouped below.

### Admin "Track ride" feature

* Added a "Track ride" button to each in-progress ride in the admin ride history tab, which launches the ride tracking screen in a view-only mode. (`RideHistoryAdapter`, `RideHistoryActivity`, `item_ride_history.xml`, `strings.xml`) (Fa806e4aR85, F880a534R282, F3e91f5cR243, Fd4bed03R464)
* Introduced intent extras (`EXTRA_ADMIN_TRACK_RIDE_ID`, `EXTRA_ADMIN_VIEW_ONLY`) and navigation argument (`adminViewOnly`) to support launching ride tracking in admin view-only mode. (`MainActivity`, `nav_graph.xml`) (F02f7347R85, F8df687cR27)
* Updated `RideTrackingFragment` to hide action buttons and disable backend position syncing when in admin view-only mode. (`RideTrackingFragment.java`) (F8b02b3fR124, F8b02b3fR189, F8b02b3fR975, F8b02b3fR1293)

### Admin navigation drawer cleanup

* Removed the dashboard and active rides menu items from the admin drawer and related logic. (`drawer_menu.xml`, `MainActivity.java`, `strings.xml`) (F8d5acbaR37, F02f7347R388, F02f7347R439, Fd4bed03R103)

### Adapter and UI enhancements

* Refactored `RideHistoryAdapter` to support the new track ride button and callback, including logic to show the button only for in-progress rides and admins. (`RideHistoryAdapter.java`) (Fa806e4aR34, Fa806e4aR113, Fa806e4aR214, Fa806e4aR231)

These changes collectively improve admin usability for monitoring rides and streamline the navigation experience.